### PR TITLE
Add Handlers to refresh recording list when notifications are received

### DIFF
--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -55,6 +55,7 @@ export interface ActiveRecordingsListProps {
 }
 
 export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListProps> = (props) => {
+  const notifications = React.useContext(NotificationsContext);
   const context = React.useContext(ServiceContext);
   const routerHistory = useHistory();
 
@@ -65,6 +66,11 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   const [isLoading, setIsLoading] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState('');
   const { url } = useRouteMatch();
+
+  const RECORDING_CREATED = "RecordingCreated";
+  const RECORDING_DELETED = "RecordingDeleted";
+  const RECORDING_SAVED = "RecordingSaved";
+  const RECORDING_ARCHIVED = "RecordingArchived";
 
   const tableColumns: string[] = [
     'Name',
@@ -120,6 +126,34 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
     addSubscription(
       context.target.target().subscribe(refreshRecordingList)
     );
+  }, []);
+
+  React.useEffect(() => {
+    const created_sub = context.notificationChannel.messages(RECORDING_CREATED)
+      .subscribe(v => {
+        const recordingName = Object.values(v.message)[0];
+        const targetId = Object.values(v.message)[1];
+        notifications.info('WebSocket Client Activity', `Recording ${recordingName} created in target: ${targetId}`);
+        refreshRecordingList();
+      });
+      const archived_sub = context.notificationChannel.messages(RECORDING_ARCHIVED)
+      .subscribe(v => {
+         const recordingName = Object.values(v.message)[0];
+         notifications.info('WebSocket Client Activity', `Recording ${recordingName} archived`);
+         refreshRecordingList();
+      });
+      const deleted_sub = context.notificationChannel.messages(RECORDING_DELETED)
+      .subscribe(v => {
+         const recording = Object.values(v.message)[0];
+         notifications.info('WebSocket Client Activity', `Recording ${recording} deleted`);
+         refreshRecordingList();
+      });
+      const saved_sub = context.notificationChannel.messages(RECORDING_SAVED)
+      .subscribe(v => {
+         const recordingName = Object.values(v.message)[0];
+         notifications.info('WebSocket Client Activity', `Recording ${recordingName} archived`);
+         refreshRecordingList();
+      });
   }, []);
 
   React.useEffect(() => {

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -142,7 +142,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
         notifications.info('Recording Created', `${event.recording} created in target: ${event.target}`);
         refreshRecordingList();
       }));
-  }, []);
+  }, [context.notificationChannel, notifications, refreshRecordingList]);
 
   React.useEffect(() => {
     addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingSaved)
@@ -151,7 +151,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
          notifications.info('Recording Archived', `${event.recording} was archived`);
          refreshRecordingList();
       }));
-  }, []);
+  }, [context.notificationChannel, notifications, refreshRecordingList]);
 
   React.useEffect(() => {
     addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingArchived)
@@ -160,7 +160,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
          notifications.info('Recording Archived', `${event.recording} was archived`);
          refreshRecordingList();
       }));
-  }, []);
+  }, [context.notificationChannel, notifications, refreshRecordingList]);
 
   React.useEffect(() => {
     addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingDeleted)
@@ -169,7 +169,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
          notifications.info('Recording Deleted', `${event.recording} was deleted`);
          refreshRecordingList();
       }));
-  }, []);
+  }, [context.notificationChannel, notifications, refreshRecordingList]);
 
   React.useEffect(() => {
     const sub = context.target.authFailure().subscribe(() => {

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -54,6 +54,18 @@ export interface ActiveRecordingsListProps {
   onArchive?: Function;
 }
 
+interface RecordingNotificationEvent {
+  recording : string;
+  target : string;
+}
+
+enum NotificationCategory {
+  RecordingCreated = 'RecordingCreated',
+  RecordingDeleted = 'RecordingDeleted',
+  RecordingSaved = 'RecordingSaved',
+  RecordingArchived = 'RecordingArchived'
+};
+
 export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListProps> = (props) => {
   const notifications = React.useContext(NotificationsContext);
   const context = React.useContext(ServiceContext);
@@ -73,13 +85,6 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
     'Duration',
     'State',
   ];
-
-  enum NotificationCategory {
-    RecordingCreated = 'RecordingCreated',
-    RecordingDeleted = 'RecordingDeleted',
-    RecordingSaved = 'RecordingSaved',
-    RecordingArchived = 'RecordingArchived'
-  };
 
   const addSubscription = useSubscriptions();
 
@@ -165,11 +170,6 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
          refreshRecordingList();
       }));
   }, []);
-
-interface RecordingNotificationEvent {
-  recording : string;
-  target : string;
-}
 
   React.useEffect(() => {
     const sub = context.target.authFailure().subscribe(() => {


### PR DESCRIPTION
Hi,

This PR addresses https://github.com/cryostatio/cryostat-web/issues/165 , adding notification handlers for each of the new notifications emitted by the backend on the Notifications channel. Whenever the web client receives one of these it will trigger a refresh of the recordings list to reflect new recordings being created/deleted/archived in the backend.