### PR TITLE
Download templates as .jfc, not .xml

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -394,7 +394,7 @@ export class ApiService {
     }))
     .subscribe(resp => {
       this.downloadFile(
-        `${template.name}.xml`,
+        `${template.name}.jfc`,
         resp,
         'application/jfc+xml')
     });


### PR DESCRIPTION
`.jfc` is used as the file extension for flight recorder event templates by the JDK as well as by JMC, so it makes sense to use the same extension when we download and save templates.