### PR TITLE
Add a badge to README for Google Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cryostat-Web
 
 ![Build Status](https://github.com/cryostatio/cryostat-web/actions/workflows/ci.yaml/badge.svg)
+[![Google Group : Cryostat Development](https://img.shields.io/badge/Google%20Group-Cryostat%20Development-blue.svg)](https://groups.google.com/g/cryostat-development)
 
 Web front-end for [Cryostat](https://github.com/cryostatio/cryostat), providing a graphical user interface for managing JFR on remote JVMs.
 


### PR DESCRIPTION
This PR follows cryostatio/cryostat#491 and adds a badge to the web client README linking to our Google Group.