### PR TITLE
Remove event specifier string text area

### DIFF
--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright The Cryostat Authors
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -57,6 +57,7 @@ export interface EventTemplate {
   name: string;
   description: string;
   provider: string;
+  type: "TARGET" | "CUSTOM";
 }
 
 const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, CreateRecordingProps>> = (props) => {

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -57,8 +57,10 @@ export interface EventTemplate {
   name: string;
   description: string;
   provider: string;
-  type: "TARGET" | "CUSTOM";
+  type: TemplateType;
 }
+
+export type TemplateType = "TARGET" | "CUSTOM";
 
 const Comp: React.FunctionComponent< RouteComponentProps<{}, StaticContext, CreateRecordingProps>> = (props) => {
   const context = React.useContext(ServiceContext);

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright The Cryostat Authors
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -51,8 +51,6 @@ export interface CustomRecordingFormProps {
 }
 
 export const RecordingNamePattern = /^[\w_]+$/;
-export const TemplatePattern = /^template=([\w]+)(?:,type=([\w]+))?$/;
-export const EventSpecifierPattern = /([\w\\.$]+):([\w]+)=([\w\d\\.]+)/;
 
 export const CustomRecordingForm = (props) => {
   const context = React.useContext(ServiceContext);
@@ -66,9 +64,7 @@ export const CustomRecordingForm = (props) => {
   const [durationUnit, setDurationUnit] = React.useState(1000);
   const [templates, setTemplates] = React.useState([] as EventTemplate[]);
   const [template, setTemplate] = React.useState(props.template || props?.location?.state?.template ||  '');
-  const [templateType] = React.useState(props.templateType || props?.location?.state?.templateType || '');
-  const [eventSpecifiers, setEventSpecifiers] = React.useState(props?.eventSpecifiers?.join(' ') || '');
-  const [eventsValid, setEventsValid] = React.useState((!!props.template || !!props?.location?.state?.template) ? ValidatedOptions.success : ValidatedOptions.default);
+  const [templateType, setTemplateType] = React.useState(props.templateType || props?.location?.state?.templateType || null as "TARGET" | "CUSTOM" | null);
   const [maxAge, setMaxAge] = React.useState(0);
   const [maxAgeUnits, setMaxAgeUnits] = React.useState(1);
   const [maxSize, setMaxSize] = React.useState(0);
@@ -87,21 +83,23 @@ export const CustomRecordingForm = (props) => {
     setDurationUnit(Number(evt));
   };
 
-  const handleTemplateChange = (name) => {
-    setEventsValid(name ? ValidatedOptions.success : ValidatedOptions.error);
-    setEventSpecifiers('');
-    setTemplate(name);
+  const handleTemplateChange = (template) => {
+    const parts: string[] = template.split(',');
+    setTemplate(parts[0]);
+    setTemplateType(parts[1]);
   };
 
-  const handleEventSpecifiersChange = (evt) => {
-    setEventsValid((TemplatePattern.test(evt) || EventSpecifierPattern.test(evt)) ? ValidatedOptions.success : ValidatedOptions.error);
-    setTemplate('');
-    setEventSpecifiers(evt);
+  const getEventString = () => {
+    var str = '';
+    if (!!template) {
+      str += `template=${template}`;
+    }
+    if (!!templateType) {
+      str += `,type=${templateType}`;
+    }
+    console.log({ str });
+    return str;
   };
-
-  const getEventSpecifiers = () => template ? templateType ? `template=${template},type=${templateType}` : `template=${template}` : eventSpecifiers;
-
-  const getEventString = () => template ? templateType ? `template=${template},type=${templateType}` : `template=${template}` : eventSpecifiers.split(/\s+/).filter(Boolean).join(',');
 
   const handleRecordingNameChange = (name) => {
     setNameValid(RecordingNamePattern.test(name) ? ValidatedOptions.success : ValidatedOptions.error);
@@ -141,9 +139,6 @@ export const CustomRecordingForm = (props) => {
     if (nameValid !== ValidatedOptions.success) {
       notificationMessages.push(`Recording name ${recordingName} is invalid`);
     }
-    if (eventsValid !== ValidatedOptions.success) {
-      notificationMessages.push(`Event specifiers are invalid`);
-    }
     if (notificationMessages.length > 0) {
       const message = notificationMessages.join('. ').trim() + '.';
       notifications.warning('Invalid form data', message);
@@ -174,19 +169,6 @@ export const CustomRecordingForm = (props) => {
       .subscribe(options => setRecordingOptions(options));
     return () => sub.unsubscribe();
   }, []);
-
-  React.useEffect(() => {
-    if (TemplatePattern.test(eventSpecifiers)) {
-      const regexMatches = TemplatePattern.exec(eventSpecifiers);
-      if (!regexMatches || !regexMatches[1]) {
-        return;
-      }
-      const template = regexMatches[1];
-      if (templates.find(t => t.name === template)) {
-        handleTemplateChange(template);
-      }
-    }
-  }, [eventSpecifiers, templates]);
 
   return (<>
     <Text component={TextVariants.small}>
@@ -228,49 +210,30 @@ export const CustomRecordingForm = (props) => {
         <DurationPicker enabled={!continuous} period={duration} onPeriodChange={handleDurationChange} unitScalar={durationUnit} onUnitScalarChange={handleDurationUnitChange} />
       </FormGroup>
       <FormGroup
-        label="Events"
+        label="Template"
         isRequired
-        fieldId="recording-events"
-        validated={eventsValid}
-        helperText="Select a template from the dropdown, or enter a template name or event specifier string in the text area"
+        fieldId="recording-template"
+        validated={!!template ? "success" : "error"}
       >
-        <Split hasGutter={true}>
-          <SplitItem>
-            <FormSelect
-              value={template}
-              onChange={handleTemplateChange}
-              aria-label="Event Template Input"
-            >
-              <FormSelectOption key="0" value="" label="Custom Event Definition" />
-              <FormSelectOptionGroup key="1" label="Remote Templates">
-                {
-                  templates.map((t: EventTemplate, idx: number) => (<FormSelectOption key={idx+2} value={t.name} label={t.name} />))
-                }
-              </FormSelectOptionGroup>
-            </FormSelect>
-          </SplitItem>
-          <SplitItem>
-            <Tooltip
-              isContentLeftAligned
-              position={TooltipPosition.auto}
-              content={
-                <Text component={TextVariants.p}>
-                  Templates are selected with the syntax <i>template=Foo</i>.<br /><br />
-
-                  Event names and options are specified with the syntax <i>ns.Event:option=Value</i>
-                  &mdash; ex. <i>jdk.SocketRead:enabled=true</i>.<br /><br />
-
-                Multiple event option specifiers should be separated by whitespace.
-                </Text>
-              }
-            >
-              <OutlinedQuestionCircleIcon />
-            </Tooltip>
-          </SplitItem>
-          <SplitItem isFilled>
-            <TextArea value={getEventSpecifiers()} onChange={handleEventSpecifiersChange} aria-label="Custom Event Specifiers Area" validated={eventsValid} />
-          </SplitItem>
-        </Split>
+        <FormSelect
+          value={`${template},${templateType}`}
+          onChange={handleTemplateChange}
+          aria-label="Event Template Input"
+        >
+          <FormSelectOption key="0" value="" label="Select a Template" />
+          <FormSelectOptionGroup key="1" label="Target Templates">
+            {
+              // FIXME idx offset hardcoding is fragile and will break if the number of TARGET templates != 3. These should be computed and memoized in advance in
+              // a separate function and then referenced here.
+              templates.filter(t => t.type === "TARGET").map((t: EventTemplate, idx: number) => (<FormSelectOption key={idx+2} value={`${t.name},${t.type}`} label={t.name} />))
+            }
+          </FormSelectOptionGroup>
+          <FormSelectOptionGroup key="2" label="Custom Templates">
+            {
+              templates.filter(t => t.type === "CUSTOM").map((t: EventTemplate, idx: number) => (<FormSelectOption key={idx+5} value={`${t.name},${t.type}`} label={t.name} />))
+            }
+          </FormSelectOptionGroup>
+        </FormSelect>
       </FormGroup>
       <ExpandableSection toggleTextExpanded="Hide advanced options" toggleTextCollapsed="Show advanced options">
         <Form>


### PR DESCRIPTION
See cryostatio/cryostat#486

This removes the text area on the Custom Recording creation form, corresponding to the backend change that has removed support for the old event specifier string syntax, which has been superceded by custom templates.

This also enhances the template selection dropdown on the form to organize the templates into TARGET/CUSTOM sections. Previously, all template names were listed together in one group. The indication of TARGET/CUSTOM type was included in the text area when a template was selected.

![Screenshot from 2021-06-16 14-45-20](https://user-images.githubusercontent.com/3787464/122275863-b54bd800-ced3-11eb-9671-37ea44ca11d8.png)

For testing convenience, this PR includes a commit reverting #214, due to #216. This change is not actually part of this PR. Once this change has been looked over and provisionally approved I will rebase and remove that first commit before merging.