### PR TITLE
Tab hangs when visiting Recordings

### DIFF
--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -144,7 +144,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
           refreshRecordingList();
         }, [refreshRecordingList]);
       }));
-  }, [context.notificationChannel, notifications, refreshRecordingList]); 
+  }, [context.notificationChannel, notifications]); 
 
   React.useEffect(() => {
     addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingSaved)

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -140,36 +140,44 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
       .subscribe(v => {
         const event: RecordingNotificationEvent = v.message;
         notifications.info('Recording Created', `${event.recording} created in target: ${event.target}`);
-        refreshRecordingList();
+        React.useCallback(() => {
+          refreshRecordingList();
+        }, [refreshRecordingList]);
       }));
-  }, [context.notificationChannel, notifications, refreshRecordingList]);
+  }, [context.notificationChannel, notifications, refreshRecordingList]); 
 
   React.useEffect(() => {
     addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingSaved)
       .subscribe(v => {
          const event: RecordingNotificationEvent = v.message;
          notifications.info('Recording Archived', `${event.recording} was archived`);
-         refreshRecordingList();
+         React.useCallback(() => {
+          refreshRecordingList();
+        }, [refreshRecordingList]);
       }));
-  }, [context.notificationChannel, notifications, refreshRecordingList]);
+  }, [context.notificationChannel, notifications]);
 
   React.useEffect(() => {
     addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingArchived)
       .subscribe(v => {
          const event: RecordingNotificationEvent = v.message;
          notifications.info('Recording Archived', `${event.recording} was archived`);
-         refreshRecordingList();
+         React.useCallback(() => {
+          refreshRecordingList();
+        }, [refreshRecordingList]);
       }));
-  }, [context.notificationChannel, notifications, refreshRecordingList]);
+  }, [context.notificationChannel, notifications]);
 
   React.useEffect(() => {
     addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingDeleted)
       .subscribe(v => {
          const event: RecordingNotificationEvent = v.message;
          notifications.info('Recording Deleted', `${event.recording} was deleted`);
-         refreshRecordingList();
+         React.useCallback(() => {
+          refreshRecordingList();
+        }, [refreshRecordingList]);
       }));
-  }, [context.notificationChannel, notifications, refreshRecordingList]);
+  }, [context.notificationChannel, notifications]);
 
   React.useEffect(() => {
     const sub = context.target.authFailure().subscribe(() => {


### PR DESCRIPTION
This PR resolves https://github.com/cryostatio/cryostat-web/issues/216 . The hang was caused by including the refreshRecordingsList function in the dependency array for the notifcation handlers. Since React does shallow comparison when determining if the dependencies have changed, this will cause problems as the function object will have a different reference on each render despite essentially being the same. 

This patch changes the way the function dependency is handled, wrapping it inside of a React.useCallback hook so that the notification handlers will be called when the dependencies of refreshRecordingList change (effectively what we want from including it in the dependency array), resolving the hang.