### PR TITLE
fix(targets): hold targets state in new service

### DIFF
--- a/src/app/Shared/Services/Services.tsx
+++ b/src/app/Shared/Services/Services.tsx
@@ -57,7 +57,7 @@ const api = new ApiService(TargetInstance, NotificationsInstance);
 const notificationChannel = new NotificationChannel(api, NotificationsInstance);
 const reports = new ReportService(api, NotificationsInstance);
 const settings = new SettingsService();
-const targets = new TargetsService(api, notificationChannel, NotificationsInstance);
+const targets = new TargetsService(api, NotificationsInstance, notificationChannel);
 
 const defaultServices: Services = { target: TargetInstance, targets, api, notificationChannel, reports, settings };
 

--- a/src/app/Shared/Services/Services.tsx
+++ b/src/app/Shared/Services/Services.tsx
@@ -57,7 +57,7 @@ const api = new ApiService(TargetInstance, NotificationsInstance);
 const notificationChannel = new NotificationChannel(api, NotificationsInstance);
 const reports = new ReportService(api, NotificationsInstance);
 const settings = new SettingsService();
-const targets = new TargetsService(api, notificationChannel);
+const targets = new TargetsService(api, notificationChannel, NotificationsInstance);
 
 const defaultServices: Services = { target: TargetInstance, targets, api, notificationChannel, reports, settings };
 

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -72,14 +72,9 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   const refreshTargetList = React.useCallback(() => {
     setLoading(true);
     addSubscription(
-      context.api.doGet<Target[]>(`targets`)
-      .pipe(first())
-      .subscribe(targets => {
-        setTargets(targets);
-        setLoading(false);
-      })
+      context.targets.queryForTargets().subscribe(() => setLoading(false))
     );
-  }, [context.api]);
+  }, [setLoading, addSubscription, context.targets]);
 
   const onSelect = React.useCallback((evt, selection, isPlaceholder) => {
     if (isPlaceholder) {


### PR DESCRIPTION
Fixes #246

Query `/api/v1/targets` at web-client startup to find initial list of known
targets state. This list is updated incrementally via notification channel
updates asynchronously, which the `TargetSelect` component receives via RxJS
Observable emissions to update the graphical state accordingly.

This removes the need for a `GET /api/v1/targets` on each in-app navigation
(when the TargetSelect component is re-rendered), increasing page
responsiveness and fluidity. Update handling and state logic is also decoupled
from presentational React component and moved into the TargetsService, making
the component smaller and easier to understand/more maintainable.

To test, open your browser's dev tools panel and go to the Network tab (or
simply watch Cryostat backend logs). Click between Recordings and Events or
any other in-app navigation between pages that contain the TargetSelect
component at the top. On the current upstream main branch, observe that the
browser/logs record a `GET /api/v1/targets` (or even two, actually) on each
in-app navigation. On this PR branch, perform the same test and observe that
only one `GET` is performed at the application startup. The + and trashcan
icons can be used to test the custom target creation/deletion, which should
now update the UI without performing any `GET`. `podman kill/podman run`
(if running the backend using `smoketest.sh`) can be used to trigger async
discovery `FOUND/LOST` events as well, which should also cause the UI to
update without a `GET` query. Clicking the refresh circular-arrow icon on
the TargetSelect should prompt a single `GET /api/v1/targets` query. Enabling
view auto-refresh (gear icon on top nav bar) should cause singular `GET`s to
occur at the specified refresh interval.