### PR TITLE
fix(notifications): style badge 'attention' if unread danger/warn notifications

### DIFF
--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -36,9 +36,11 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { Dropdown, DropdownItem, DropdownPosition, KebabToggle, NotificationDrawer, NotificationDrawerBody, NotificationDrawerHeader,
-  NotificationDrawerList, NotificationDrawerListItem, NotificationDrawerListItemBody,
-  NotificationDrawerListItemHeader, Text, TextVariants } from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownPosition, KebabToggle,
+  NotificationDrawer, NotificationDrawerBody, NotificationDrawerHeader,
+  NotificationDrawerList, NotificationDrawerListItem,
+  NotificationDrawerListItemBody, NotificationDrawerListItemHeader, Text,
+  TextVariants } from '@patternfly/react-core';
 import { Notification, NotificationsContext } from './Notifications';
 
 export interface NotificationCenterProps {


### PR DESCRIPTION
Fixes #254

If danger/warning level graphical notifications are emitted they are "stored" in the notification drawer, and the notification badge on the masthead is updated to the "attention" (red) variant to call the user's focus. Additionally, these notifications (and only these - not the "lower" levels) will be displayed once again as "toast"-style notifications, as they used to be, to help ensure the user notices them in a timely fashion. Closing the toast will mark the notification as read in the drawer as well, but not remove it.

To test, create a recording on a target. Then attempt to create another recording on the same target and using the same recording name.