### PR TITLE
feat(notifications): Sort notifications by category

### DIFF
--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -67,14 +67,14 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
   React.useEffect(() => {
     const sub = combineLatest([context.actionsNotifications(), context.networkInfoNotifications(), context.problemsNotifications()])
     .subscribe(notificationLists => {
-      const updatedDrawerCategories = [...drawerCategories];
+      setDrawerCategories(drawerCategories => {
+        drawerCategories.map((category: NotificationDrawerCategory, idx) => {
 
-      updatedDrawerCategories.map((category: NotificationDrawerCategory, idx) => {
-        category.notifications = notificationLists[idx];
-        category.unreadCount = countUnreadNotifications(notificationLists[idx]);
+          category.notifications = notificationLists[idx];
+          category.unreadCount = countUnreadNotifications(notificationLists[idx]);
+        });
+        return drawerCategories;
       });
-
-      setDrawerCategories(updatedDrawerCategories);
     });
     return () => sub.unsubscribe();
   },[context, context.notifications, setDrawerCategories]);
@@ -90,12 +90,14 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
   }, [setHeaderDropdownOpen]);
 
   const handleToggleExpandCategory = React.useCallback((categoryIdx) => {
-    const updatedDrawerCategories = [...drawerCategories];
-    updatedDrawerCategories.map((category: NotificationDrawerCategory, idx) => {
+    setDrawerCategories(drawerCategories => {
+      let newDrawerCategories = [...drawerCategories];
+      newDrawerCategories.map((category: NotificationDrawerCategory, idx) => {
+
         category.isExpanded = (idx === categoryIdx) ? !category.isExpanded : false
       });
-
-    setDrawerCategories(updatedDrawerCategories);
+      return newDrawerCategories;
+    });
   }, [setDrawerCategories]);
 
   // Expands the Problems tab when unread errors/warnings are present
@@ -103,12 +105,13 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
     if(drawerCategories[PROBLEMS_CATEGORY_IDX].unreadCount === 0) {
       return;
     }
+    setDrawerCategories(drawerCategories => {
+      drawerCategories.map((category: NotificationDrawerCategory, idx) => {
 
-    const updatedDrawerCategories = [...drawerCategories];
-    updatedDrawerCategories.map((category: NotificationDrawerCategory, idx) => {
-      category.isExpanded = (idx === PROBLEMS_CATEGORY_IDX) ? true : false;
+        category.isExpanded = (idx === PROBLEMS_CATEGORY_IDX) ? true : false;
+      });
+      return drawerCategories;
     });
-    setDrawerCategories(updatedDrawerCategories);
   }, [setDrawerCategories, unreadProblemsCount]);
 
   const handleMarkAllRead = React.useCallback(() => {

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -113,7 +113,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
 
     setDrawerCategories(drawerCategories => {
       return drawerCategories.map((category: NotificationDrawerCategory, idx) => {
-        category.isExpanded = (idx === PROBLEMS_CATEGORY_IDX) ? true : false;
+        category.isExpanded = idx === PROBLEMS_CATEGORY_IDX;
         return category;
       });
     });

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -102,18 +102,23 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
     setHeaderDropdownOpen(v => !v);
   }, [setHeaderDropdownOpen]);
 
-  const handleExpandCategory = React.useCallback((groupIdx) => {
-    setSelectedCategoryIdx(groupIdx);
+  const handleExpandCategory = React.useCallback((categoryIdx) => {
+    setSelectedCategoryIdx(categoryIdx);
   }, [setSelectedCategoryIdx]);
 
-  // Expands one notification category at a time and
-  // also expands the first category on first render
+  // Expands the first category by default unless
+  // there are unread errors/warnings
   React.useEffect(() => {
+    if(unreadProblemsCount > 0) {
+      setExpandedCategories([false, false, true]);
+      return;
+    }
+
     const newExpandedCategory = expandedCategories.map((isExpanded, idx) => {
       return idx === selectedCategoryIdx ? !isExpanded : false;
     });
     setExpandedCategories(newExpandedCategory);
-  }, [setExpandedCategories, selectedCategoryIdx]);
+  }, [setExpandedCategories, selectedCategoryIdx, unreadProblemsCount]);
 
   const handleMarkAllRead = React.useCallback(() => {
     context.markAllRead();

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -58,6 +58,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
     {title: "Network Info", isExpanded: false, notifications: [] as Notification[], unreadCount: 0},
     {title: "Problems", isExpanded: false, notifications: [] as Notification[], unreadCount: 0}
   ] as NotificationDrawerCategory[]);
+  const unreadProblemsCount = drawerCategories[PROBLEMS_CATEGORY_IDX].unreadCount;
 
   const countUnreadNotifications = (notifications: Notification[]) => {
     return notifications.filter(n => !n.read).length;
@@ -97,7 +98,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
     setDrawerCategories(updatedDrawerCategories);
   }, [setDrawerCategories]);
 
-  // Automatically expands the Problems category when unread errors/warnings exist
+  // Expands the Problems tab when unread errors/warnings are present
   React.useEffect(() => {
     if(drawerCategories[PROBLEMS_CATEGORY_IDX].unreadCount === 0) {
       return;
@@ -108,7 +109,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
       category.isExpanded = (idx === PROBLEMS_CATEGORY_IDX) ? true : false;
     });
     setDrawerCategories(updatedDrawerCategories);
-  }, [setDrawerCategories, drawerCategories[PROBLEMS_CATEGORY_IDX].unreadCount]);
+  }, [setDrawerCategories, unreadProblemsCount]);
 
   const handleMarkAllRead = React.useCallback(() => {
     context.markAllRead();
@@ -175,7 +176,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
           </NotificationDrawerList>
           </NotificationDrawerGroup>
         ))}
-    </NotificationDrawerGroupList>
+      </NotificationDrawerGroupList>
       </NotificationDrawerBody>
     </NotificationDrawer>
   </>);

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -52,69 +52,61 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
   const [actionsNotifications, setActionsNotifications] = React.useState([] as Notification[]);
   const [networkInfoNotifications, setNetworkInfoNotifications] = React.useState([] as Notification[]);
   const [problemsNotifications, setProblemsNotifications] = React.useState([] as Notification[]);
-  const [notifications, setNotifications] = React.useState([] as Notification[]);
-  const [actionsExpanded, setActionsExpanded] = React.useState(true);
-  const [networkInfoExpanded, setNetworkInfoExpanded] = React.useState(true);
-  const [problemsExpanded, setProblemsExpanded] = React.useState(true);
+  const [groupExpanded, setGroupExpanded] = React.useState([true, false, false]);
   const [unreadNotificationsCount, setUnreadNotificationsCount] = React.useState(0);
   const [unreadActionsCount, setUnreadActionsCount] = React.useState(0);
   const [unreadNetworkInfoCount, setUnreadNetworkInfoCount] = React.useState(0);
   const [unreadProblemsCount, setUnreadProblemsCount] = React.useState(0);
-
   const [isHeaderDropdownOpen, setHeaderDropdownOpen] = React.useState(false);
-
-  React.useEffect(() => {
-    const sub = context.notifications().subscribe(setNotifications);
-    return () => sub.unsubscribe();
-  }, [context, context.notifications, notifications, setNotifications]);
-
-  React.useEffect(() => {
-    const sub = context.unreadNotifications().subscribe(s => {
-      setUnreadNotificationsCount(s.length)});
-    return () => sub.unsubscribe();
-  }, [context, context.unreadNotifications, unreadNotificationsCount, setUnreadNotificationsCount]);
 
   // TODO reduce duplication
   React.useEffect(() => {
     const sub = context.actionsNotifications().subscribe(setActionsNotifications);
     return () => sub.unsubscribe();
-  }, [context, context.actionsNotifications, notifications, setActionsNotifications]);
+  }, [context, context.actionsNotifications, setActionsNotifications]);
 
   React.useEffect(() => {
     const sub = context.networkInfoNotifications().subscribe(setNetworkInfoNotifications);
     return () => sub.unsubscribe();
-  }, [context, context.networkInfoNotifications, notifications, setNetworkInfoNotifications]);
+  }, [context, context.networkInfoNotifications, setNetworkInfoNotifications]);
 
   React.useEffect(() => {
     const sub = context.problemsNotifications().subscribe(setProblemsNotifications);
     return () => sub.unsubscribe();
-  }, [context, context.problemsNotifications, notifications, setProblemsNotifications]);
+  }, [context, context.problemsNotifications, setProblemsNotifications]);
+
+  React.useEffect(() => {
+    const sub = context.unreadNotifications().subscribe(s => {
+      setUnreadActionsCount(s.length)});
+    return () => sub.unsubscribe();
+  }, [context, context.unreadNotifications, setUnreadNotificationsCount]);
 
   React.useEffect(() => {
     const sub = context.unreadActionsNotifications().subscribe(s => {
       setUnreadActionsCount(s.length)});
     return () => sub.unsubscribe();
-  }, [context, context.unreadActionsNotifications, unreadNotificationsCount, setUnreadActionsCount]);
+  }, [context, context.unreadActionsNotifications, setUnreadActionsCount]);
 
   React.useEffect(() => {
     const sub = context.unreadNetworkInfoNotifications().subscribe(s => {
       setUnreadNetworkInfoCount(s.length)});
     return () => sub.unsubscribe();
-  }, [context, context.unreadNetworkInfoNotifications, unreadNotificationsCount, setUnreadNetworkInfoCount]);
+  }, [context, context.unreadNetworkInfoNotifications, setUnreadNetworkInfoCount]);
 
   React.useEffect(() => {
     const sub = context.unreadProblemsNotifications().subscribe(s => {
       setUnreadProblemsCount(s.length)});
     return () => sub.unsubscribe();
-  }, [context, context.unreadProblemsNotifications, unreadNotificationsCount, setUnreadProblemsCount]);
+  }, [context, context.unreadProblemsNotifications, setUnreadProblemsCount]);
 
   const handleToggleDropdown = React.useCallback(() => {
     setHeaderDropdownOpen(v => !v);
-  }, []);
+  }, [setHeaderDropdownOpen]);
 
-  const handleToggleDrawerGroup = React.useCallback((setGroupExpanded) => {
-    setGroupExpanded(v => !v);
-  },[]); // dependencies?
+  const handleToggleDrawerGroup = React.useCallback(index => {
+    const updatedGroupExpanded = groupExpanded.map((isExpanded, idx) => idx === index ? !isExpanded : false);
+    setGroupExpanded(updatedGroupExpanded);
+  }, [setGroupExpanded]);
 
   const handleMarkAllRead = React.useCallback(() => {
     context.markAllRead();
@@ -145,14 +137,14 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
     </DropdownItem>,
   ];
 
-  const NotificationDrawerGroupItems = ({title, isExpanded, notifications, count, onExpand}) => (
+  const NotificationDrawerGroupItems = ({title, notifications, count, idx}) => (
     <NotificationDrawerGroup
       title={title}
-      isExpanded={isExpanded}
+      isExpanded={groupExpanded[idx]}
       count={count}
-      onExpand={() => handleToggleDrawerGroup(onExpand)}
+      onExpand={() => handleToggleDrawerGroup(idx)}
     >
-      <NotificationDrawerList isHidden={!isExpanded}>
+      <NotificationDrawerList isHidden={!groupExpanded[idx]}>
             {
               notifications.map(({ key, title, message, variant, timestamp, read }) => (
                 <NotificationDrawerListItem key={key} variant={variant} onClick={() => markRead(key)} isRead={read} >
@@ -183,24 +175,21 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
       <NotificationDrawerGroupList>
         <NotificationDrawerGroupItems
           title="Completed Actions"
-          isExpanded={actionsExpanded}
           notifications={actionsNotifications}
           count={unreadActionsCount}
-          onExpand={setActionsExpanded}
+          idx={0}
         />
         <NotificationDrawerGroupItems
           title="Network Info"
-          isExpanded={networkInfoExpanded}
           notifications={networkInfoNotifications}
           count={unreadNetworkInfoCount}
-          onExpand={setNetworkInfoExpanded}
+          idx={1}
         />
         <NotificationDrawerGroupItems
           title="Problems"
-          isExpanded={problemsExpanded}
           notifications={problemsNotifications}
           count={unreadProblemsCount}
-          onExpand={setProblemsExpanded}
+          idx={2}
         />
       </NotificationDrawerGroupList>
       </NotificationDrawerBody>

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -73,13 +73,13 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
   React.useEffect(() => {
     const sub = combineLatest([context.actionsNotifications(), context.networkInfoNotifications(), context.problemsNotifications()])
     .subscribe(notificationLists => {
-      setDrawerCategories(drawerCategories => {
-        drawerCategories.map((category: NotificationDrawerCategory, idx) => {
+        setDrawerCategories(drawerCategories => {
 
-          category.notifications = notificationLists[idx];
-          category.unreadCount = countUnreadNotifications(notificationLists[idx]);
-        });
-        return drawerCategories;
+          return drawerCategories.map((category: NotificationDrawerCategory, idx) => {
+            category.notifications = notificationLists[idx];
+            category.unreadCount = countUnreadNotifications(notificationLists[idx]);
+            return category;
+        }) as unknown as NotificationDrawerCategory[];
       });
     });
     return () => sub.unsubscribe();
@@ -97,12 +97,11 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
 
   const handleToggleExpandCategory = React.useCallback((categoryIdx) => {
     setDrawerCategories(drawerCategories => {
-      let newDrawerCategories = [...drawerCategories];
-      newDrawerCategories.map((category: NotificationDrawerCategory, idx) => {
 
-        category.isExpanded = (idx === categoryIdx) ? !category.isExpanded : false
-      });
-      return newDrawerCategories;
+      return drawerCategories.map((category: NotificationDrawerCategory, idx) => {
+        category.isExpanded = (idx === categoryIdx) ? !category.isExpanded : false;
+        return category;
+      }) as unknown as NotificationDrawerCategory[];
     });
   }, [setDrawerCategories]);
 
@@ -111,14 +110,14 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
     if(drawerCategories[PROBLEMS_CATEGORY_IDX].unreadCount === 0) {
       return;
     }
-    setDrawerCategories(drawerCategories => {
-      drawerCategories.map((category: NotificationDrawerCategory, idx) => {
 
+    setDrawerCategories(drawerCategories => {
+      return drawerCategories.map((category: NotificationDrawerCategory, idx) => {
         category.isExpanded = (idx === PROBLEMS_CATEGORY_IDX) ? true : false;
-      });
-      return drawerCategories;
+        return category;
+      }) as unknown as NotificationDrawerCategory[];
     });
-  }, [setDrawerCategories, drawerCategories]);
+  }, [setDrawerCategories, drawerCategories[PROBLEMS_CATEGORY_IDX].unreadCount]);
 
   const handleMarkAllRead = React.useCallback(() => {
     context.markAllRead();

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -139,33 +139,6 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
     </DropdownItem>,
   ];
 
-  const NotificationDrawerCategories = () => (
-    <NotificationDrawerGroupList>
-      { drawerCategories.map(({title, isExpanded, notifications, unreadCount}, idx) => (
-        <NotificationDrawerGroup
-          title={title}
-          isExpanded={isExpanded}
-          count={unreadCount}
-          onExpand={() => handleToggleExpandCategory(idx)}
-          key={idx}
-        >
-        <NotificationDrawerList isHidden={!isExpanded}>
-              {
-                notifications.map(({ key, title, message, variant, timestamp, read }) => (
-                  <NotificationDrawerListItem key={key} variant={variant} onClick={() => markRead(key)} isRead={read} >
-                    <NotificationDrawerListItemHeader title={title} variant={variant} />
-                    <NotificationDrawerListItemBody timestamp={timestampToDateTimeString(timestamp)} >
-                      <Text component={TextVariants.p}>{message}</Text>
-                    </NotificationDrawerListItemBody>
-                  </NotificationDrawerListItem>
-                ))
-              }
-        </NotificationDrawerList>
-        </NotificationDrawerGroup>
-      ))}
-    </NotificationDrawerGroupList>
-);
-
   return (<>
     <NotificationDrawer>
       <NotificationDrawerHeader count={totalUnreadNotificationsCount} onClose={props.onClose} >
@@ -179,7 +152,30 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
         />
       </NotificationDrawerHeader>
       <NotificationDrawerBody>
-        <NotificationDrawerCategories />
+      <NotificationDrawerGroupList>
+        { drawerCategories.map(({title, isExpanded, notifications, unreadCount}, idx) => (
+          <NotificationDrawerGroup
+            title={title}
+            isExpanded={isExpanded}
+            count={unreadCount}
+            onExpand={() => handleToggleExpandCategory(idx)}
+            key={idx}
+          >
+          <NotificationDrawerList isHidden={!isExpanded}>
+                {
+                  notifications.map(({ key, title, message, variant, timestamp, read }) => (
+                    <NotificationDrawerListItem key={key} variant={variant} onClick={() => markRead(key)} isRead={read} >
+                      <NotificationDrawerListItemHeader title={title} variant={variant} />
+                      <NotificationDrawerListItemBody timestamp={timestampToDateTimeString(timestamp)} >
+                        <Text component={TextVariants.p}>{message}</Text>
+                      </NotificationDrawerListItemBody>
+                    </NotificationDrawerListItem>
+                  ))
+                }
+          </NotificationDrawerList>
+          </NotificationDrawerGroup>
+        ))}
+    </NotificationDrawerGroupList>
       </NotificationDrawerBody>
     </NotificationDrawer>
   </>);

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -79,7 +79,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
             category.notifications = notificationLists[idx];
             category.unreadCount = countUnreadNotifications(notificationLists[idx]);
             return category;
-        }) as unknown as NotificationDrawerCategory[];
+        });
       });
     });
     return () => sub.unsubscribe();
@@ -101,7 +101,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
       return drawerCategories.map((category: NotificationDrawerCategory, idx) => {
         category.isExpanded = (idx === categoryIdx) ? !category.isExpanded : false;
         return category;
-      }) as unknown as NotificationDrawerCategory[];
+      });
     });
   }, [setDrawerCategories]);
 
@@ -115,7 +115,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
       return drawerCategories.map((category: NotificationDrawerCategory, idx) => {
         category.isExpanded = (idx === PROBLEMS_CATEGORY_IDX) ? true : false;
         return category;
-      }) as unknown as NotificationDrawerCategory[];
+      });
     });
   }, [setDrawerCategories, drawerCategories[PROBLEMS_CATEGORY_IDX].unreadCount]);
 

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -41,11 +41,18 @@ import { Dropdown, DropdownItem, DropdownPosition, KebabToggle,
   NotificationDrawerList, NotificationDrawerListItem,
   NotificationDrawerListItemBody, NotificationDrawerListItemHeader, Text,
   TextVariants } from '@patternfly/react-core';
-import { Notification, NotificationDrawerCategory, NotificationsContext } from './Notifications';
+import { Notification, NotificationsContext } from './Notifications';
 import { combineLatest } from 'rxjs';
 
 export interface NotificationCenterProps {
   onClose: () => void;
+}
+
+export interface NotificationDrawerCategory {
+  title: string;
+  isExpanded: boolean;
+  notifications: Notification[];
+  unreadCount: number;
 }
 
 export const NotificationCenter: React.FunctionComponent<NotificationCenterProps> = props => {

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -65,7 +65,6 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
     {title: "Network Info", isExpanded: false, notifications: [] as Notification[], unreadCount: 0},
     {title: "Problems", isExpanded: false, notifications: [] as Notification[], unreadCount: 0}
   ] as NotificationDrawerCategory[]);
-  const unreadProblemsCount = drawerCategories[PROBLEMS_CATEGORY_IDX].unreadCount;
 
   const countUnreadNotifications = (notifications: Notification[]) => {
     return notifications.filter(n => !n.read).length;
@@ -119,7 +118,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
       });
       return drawerCategories;
     });
-  }, [setDrawerCategories, unreadProblemsCount]);
+  }, [setDrawerCategories, drawerCategories]);
 
   const handleMarkAllRead = React.useCallback(() => {
     context.markAllRead();

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -96,7 +96,7 @@ export class Notifications {
   actionsNotifications(): Observable<Notification[]> {
     return this.notifications()
     .pipe(
-      map(a => a.filter(this.isActionNotification))
+      map(a => a.filter(n => this.isActionNotification(n)))
     );
   }
 
@@ -141,8 +141,7 @@ export class Notifications {
   }
 
   private isActionNotification(n: Notification): boolean {
-    return (n.category !== 'WsClientActivity' && n.category !== 'TargetJvmDiscovery')
-      && (n.variant === AlertVariant.success || n.variant === AlertVariant.info);
+    return !this.isNetworkInfoNotification(n) && !this.isProblemNotification(n);
   }
 
   private isNetworkInfoNotification(n: Notification): boolean {

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -51,13 +51,6 @@ export interface Notification {
   timestamp?: number;
 }
 
-export interface NotificationDrawerCategory {
-  title: string;
-  isExpanded: boolean;
-  notifications: Notification[];
-  unreadCount: number;
-}
-
 export class Notifications {
 
   private readonly _notifications: Notification[] = [];

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -51,6 +51,13 @@ export interface Notification {
   timestamp?: number;
 }
 
+export interface NotificationDrawerCategory {
+  title: string;
+  isExpanded: boolean;
+  notifications: Notification[];
+  unreadCount: number;
+}
+
 export class Notifications {
 
   private readonly _notifications: Notification[] = [];

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -100,13 +100,6 @@ export class Notifications {
     );
   }
 
-  unreadProblemsNotifications(): Observable<Notification[]> {
-    return this.problemsNotifications()
-    .pipe(
-      map(a => a.filter(n => !n.read))
-    );
-  }
-
   networkInfoNotifications(): Observable<Notification[]> {
     return this.notifications()
     .pipe(
@@ -115,25 +108,11 @@ export class Notifications {
     );
   }
 
-  unreadNetworkInfoNotifications(): Observable<Notification[]> {
-    return this.networkInfoNotifications()
-    .pipe(
-      map(a => a.filter(n => !n.read))
-    );
-  }
-
   actionsNotifications(): Observable<Notification[]> {
     return this.notifications()
     .pipe(
       map(a => a.filter(n => (n.category !== 'WsClientActivity' && n.category !== 'TargetJvmDiscovery')
       && (n.variant === AlertVariant.success || n.variant === AlertVariant.info)))
-    );
-  }
-
-  unreadActionsNotifications(): Observable<Notification[]> {
-    return this.actionsNotifications()
-    .pipe(
-      map(a => a.filter(n => !n.read))
     );
   }
 

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { BehaviorSubject, Observable, of } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AlertVariant } from '@patternfly/react-core';
 import { nanoid } from 'nanoid';
@@ -46,6 +46,7 @@ export interface Notification {
   key?: string;
   title: string;
   message?: string;
+  category?: string;
   variant: AlertVariant;
   timestamp?: number;
 }
@@ -65,20 +66,20 @@ export class Notifications {
     this._notifications$.next(this._notifications);
   }
 
-  success(title: string, message?: string): void {
-    this.notify({ title, message, variant: AlertVariant.success });
+  success(title: string, message?: string, category?: string): void {
+    this.notify({ title, message, category, variant: AlertVariant.success });
   }
 
-  info(title: string, message?: string): void {
-    this.notify({ title, message, variant: AlertVariant.info });
+  info(title: string, message?: string, category?: string): void {
+    this.notify({ title, message, category, variant: AlertVariant.info });
   }
 
-  warning(title: string, message?: string): void {
-    this.notify({ title, message, variant: AlertVariant.warning });
+  warning(title: string, message?: string, category?: string): void {
+    this.notify({ title, message, category, variant: AlertVariant.warning });
   }
 
-  danger(title: string, message?: string): void {
-    this.notify({ title, message, variant: AlertVariant.danger });
+  danger(title: string, message?: string, category?: string): void {
+    this.notify({ title, message, category, variant: AlertVariant.danger });
   }
 
   notifications(): Observable<Notification[]> {
@@ -87,6 +88,50 @@ export class Notifications {
 
   unreadNotifications(): Observable<Notification[]> {
     return this.notifications()
+    .pipe(
+      map(a => a.filter(n => !n.read))
+    );
+  }
+
+  problemsNotifications(): Observable<Notification[]> {
+    return this.notifications()
+    .pipe(
+      map(a => a.filter(n => n.variant === AlertVariant.warning || n.variant === AlertVariant.danger))
+    );
+  }
+
+  unreadProblemsNotifications(): Observable<Notification[]> {
+    return this.problemsNotifications()
+    .pipe(
+      map(a => a.filter(n => !n.read))
+    );
+  }
+
+  networkInfoNotifications(): Observable<Notification[]> {
+    return this.notifications()
+    .pipe(
+      map(a => a.filter(n => (n.category === 'WsClientActivity' || n.category === 'TargetJvmDiscovery')
+      && (n.variant === AlertVariant.info)))
+    );
+  }
+
+  unreadNetworkInfoNotifications(): Observable<Notification[]> {
+    return this.networkInfoNotifications()
+    .pipe(
+      map(a => a.filter(n => !n.read))
+    );
+  }
+
+  actionsNotifications(): Observable<Notification[]> {
+    return this.notifications()
+    .pipe(
+      map(a => a.filter(n => (n.category !== 'WsClientActivity' && n.category !== 'TargetJvmDiscovery')
+      && (n.variant === AlertVariant.success || n.variant === AlertVariant.info)))
+    );
+  }
+
+  unreadActionsNotifications(): Observable<Notification[]> {
+    return this.actionsNotifications()
     .pipe(
       map(a => a.filter(n => !n.read))
     );

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -125,7 +125,7 @@ export class Notifications {
     if (!key) {
       return;
     }
-    for (var n of this._notifications) {
+    for (let n of this._notifications) {
       if (n.key === key) {
         n.read = read;
       }
@@ -134,7 +134,7 @@ export class Notifications {
   }
 
   markAllRead(): void {
-    for (var n of this._notifications) {
+    for (let n of this._notifications) {
       n.read = true;
     }
     this._notifications$.next(this._notifications);

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -93,6 +93,27 @@ export class Notifications {
     );
   }
 
+  actionsNotifications(): Observable<Notification[]> {
+    return this.notifications()
+    .pipe(
+      map(a => a.filter(this.isActionNotification))
+    );
+  }
+
+  networkInfoNotifications(): Observable<Notification[]> {
+    return this.notifications()
+    .pipe(
+      map(a => a.filter(this.isNetworkInfoNotification))
+    );
+  }
+
+  problemsNotifications(): Observable<Notification[]> {
+    return this.notifications()
+    .pipe(
+      map(a => a.filter(this.isProblemNotification))
+    );
+  }
+
   setRead(key?: string, read: boolean = true): void {
     if (!key) {
       return;
@@ -117,6 +138,20 @@ export class Notifications {
       this._notifications.shift();
     }
     this._notifications$.next(this._notifications);
+  }
+
+  private isActionNotification(n: Notification): boolean {
+    return (n.category !== 'WsClientActivity' && n.category !== 'TargetJvmDiscovery')
+      && (n.variant === AlertVariant.success || n.variant === AlertVariant.info);
+  }
+
+  private isNetworkInfoNotification(n: Notification): boolean {
+    return (n.category === 'WsClientActivity' || n.category === 'TargetJvmDiscovery')
+      && (n.variant === AlertVariant.info);
+  }
+
+  private isProblemNotification(n: Notification): boolean {
+    return (n.variant === AlertVariant.warning) || (n.variant === AlertVariant.danger);
   }
 }
 

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -93,29 +93,6 @@ export class Notifications {
     );
   }
 
-  problemsNotifications(): Observable<Notification[]> {
-    return this.notifications()
-    .pipe(
-      map(a => a.filter(n => n.variant === AlertVariant.warning || n.variant === AlertVariant.danger))
-    );
-  }
-
-  networkInfoNotifications(): Observable<Notification[]> {
-    return this.notifications()
-    .pipe(
-      map(a => a.filter(n => (n.category === 'WsClientActivity' || n.category === 'TargetJvmDiscovery')
-      && (n.variant === AlertVariant.info)))
-    );
-  }
-
-  actionsNotifications(): Observable<Notification[]> {
-    return this.notifications()
-    .pipe(
-      map(a => a.filter(n => (n.category !== 'WsClientActivity' && n.category !== 'TargetJvmDiscovery')
-      && (n.variant === AlertVariant.success || n.variant === AlertVariant.info)))
-    );
-  }
-
   setRead(key?: string, read: boolean = true): void {
     if (!key) {
       return;

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -39,7 +39,7 @@ import { Notifications } from '@app/Notifications/Notifications';
 import { BehaviorSubject, combineLatest, from, Observable, Subject } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
-import { concatMap, filter, first, map } from 'rxjs/operators';
+import { concatMap, filter, map } from 'rxjs/operators';
 import { Base64 } from 'js-base64';
 import { ApiService } from './Api.service';
 
@@ -58,7 +58,7 @@ export class NotificationChannel {
     this.messages(NOTIFICATION_CATEGORY).subscribe(v => {
       const addr = Object.keys(v.message)[0];
       const status = v.message[addr];
-      notifications.info('WebSocket Client Activity', `Client at ${addr} ${status}`);
+      notifications.info('WebSocket Client Activity', `Client at ${addr} ${status}`, NOTIFICATION_CATEGORY);
     });
 
     const notificationsUrl = fromFetch(`${this.apiSvc.authority}/api/v1/notifications_url`)
@@ -90,7 +90,7 @@ export class NotificationChannel {
             closeObserver: {
               next: () => {
                 this._ready.next(false);
-                this.notifications.info('WebSocket connection lost');
+                this.notifications.info('WebSocket connection lost', undefined, NOTIFICATION_CATEGORY);
               }
             }
           });

--- a/src/app/Shared/Services/Targets.service.tsx
+++ b/src/app/Shared/Services/Targets.service.tsx
@@ -69,11 +69,11 @@ export class TargetsService {
         switch (evt.kind) {
           case 'FOUND':
             this._targets$.next(_.unionBy(this._targets$.getValue(), [evt.serviceRef], t => t.connectUrl));
-            notifications.info('Target Appeared', `Target "${target.alias}" appeared (${target.connectUrl})"`);
+            notifications.info('Target Appeared', `Target "${target.alias}" appeared (${target.connectUrl})"`, NOTIFICATION_CATEGORY);
             break;
           case 'LOST':
             this._targets$.next(_.filter(this._targets$.getValue(), t => t.connectUrl !== evt.serviceRef.connectUrl));
-            notifications.info('Target Disappeared', `Target "${target.alias}" disappeared (${target.connectUrl})"`);
+            notifications.info('Target Disappeared', `Target "${target.alias}" disappeared (${target.connectUrl})"`, NOTIFICATION_CATEGORY);
             break;
           default:
             notifications.danger(`Invalid Message Received`, `Received a notification with category ${NOTIFICATION_CATEGORY} and unrecognized kind ${evt.kind}`);

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright The Cryostat Authors
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -39,7 +39,6 @@ import * as React from 'react';
 import { BreadcrumbPage, BreadcrumbTrail } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetSelect } from '@app/TargetSelect/TargetSelect';
-import { map } from 'rxjs/operators';
 import { NoTargetSelected } from './NoTargetSelected';
 
 interface TargetViewProps {

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -157,9 +157,7 @@ const AppRoutes = () => {
   const [authenticated, setAuthenticated] = React.useState(false);
 
   React.useEffect(() => {
-    const sub = context.notificationChannel
-      .isReady()
-      .subscribe(v => setAuthenticated(v));
+    const sub = context.notificationChannel.isReady().subscribe((v) => setAuthenticated(v));
     return () => sub.unsubscribe();
   }, [context.notificationChannel, setAuthenticated]);
 

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -49,7 +49,6 @@ import { useDocumentTitle } from '@app/utils/useDocumentTitle';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
-import { filter } from 'rxjs/operators';
 
 let routeFocusTimer: number;
 


### PR DESCRIPTION
Fixes #268

Groups notifications into three categories: "Completed Actions", "Network Info", and "Problems". 
Notifications confirming a user's action has succeeded will appear in "Completed Actions". "Network Info" contains any messages related to JVM target discovery and WebSocket disconnection. All warning and error notifications appear in the "Problems" category.

When opening the drawer, "Completed Actions" is expanded by default. If there are unread errors, the "Problems" tab is expanded instead. Only one category can be expanded at once.