### PR TITLE
fix(notifications): Fix inconsistent action notification categories

### DIFF
--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -62,7 +62,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
   const PROBLEMS_CATEGORY_IDX = 2;
   const [drawerCategories, setDrawerCategories] = React.useState([
     {title: "Completed Actions", isExpanded: true, notifications: [] as Notification[], unreadCount: 0},
-    {title: "Backend Status", isExpanded: false, notifications: [] as Notification[], unreadCount: 0},
+    {title: "Cryostat Status", isExpanded: false, notifications: [] as Notification[], unreadCount: 0},
     {title: "Problems", isExpanded: false, notifications: [] as Notification[], unreadCount: 0}
   ] as NotificationDrawerCategory[]);
 
@@ -71,7 +71,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
   }
 
   React.useEffect(() => {
-    const sub = combineLatest([context.actionsNotifications(), context.backendStatusNotifications(), context.problemsNotifications()])
+    const sub = combineLatest([context.actionsNotifications(), context.cryostatStatusNotifications(), context.problemsNotifications()])
     .subscribe(notificationLists => {
         setDrawerCategories(drawerCategories => {
 

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -62,7 +62,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
   const PROBLEMS_CATEGORY_IDX = 2;
   const [drawerCategories, setDrawerCategories] = React.useState([
     {title: "Completed Actions", isExpanded: true, notifications: [] as Notification[], unreadCount: 0},
-    {title: "Network Info", isExpanded: false, notifications: [] as Notification[], unreadCount: 0},
+    {title: "Backend Status", isExpanded: false, notifications: [] as Notification[], unreadCount: 0},
     {title: "Problems", isExpanded: false, notifications: [] as Notification[], unreadCount: 0}
   ] as NotificationDrawerCategory[]);
 
@@ -71,7 +71,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
   }
 
   React.useEffect(() => {
-    const sub = combineLatest([context.actionsNotifications(), context.networkInfoNotifications(), context.problemsNotifications()])
+    const sub = combineLatest([context.actionsNotifications(), context.backendStatusNotifications(), context.problemsNotifications()])
     .subscribe(notificationLists => {
         setDrawerCategories(drawerCategories => {
 

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -101,10 +101,12 @@ export class Notifications {
     );
   }
 
-  networkInfoNotifications(): Observable<Notification[]> {
+  backendStatusNotifications(): Observable<Notification[]> {
     return this.notifications()
     .pipe(
-      map(a => a.filter(this.isNetworkInfoNotification))
+      map(a => a.filter(n =>
+        (this.isWsClientActivity(n) || this.isJvmDiscovery(n))
+      ))
     );
   }
 
@@ -142,13 +144,17 @@ export class Notifications {
   }
 
   private isActionNotification(n: Notification): boolean {
-    return !this.isNetworkInfoNotification(n) && !this.isProblemNotification(n);
+    return !this.isWsClientActivity(n)
+      && !this.isJvmDiscovery(n)
+      && !this.isProblemNotification(n);
   }
 
-  private isNetworkInfoNotification(n: Notification): boolean {
-    return (n.category === NotificationCategory.WsClientActivity
-      || n.category === NotificationCategory.JvmDiscovery)
-      && (n.variant === AlertVariant.info);
+  private isWsClientActivity(n: Notification): boolean {
+    return (n.category === NotificationCategory.WsClientActivity);
+  }
+
+  private isJvmDiscovery(n: Notification): boolean {
+    return (n.category === NotificationCategory.JvmDiscovery);
   }
 
   private isProblemNotification(n: Notification): boolean {

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -101,7 +101,7 @@ export class Notifications {
     );
   }
 
-  backendStatusNotifications(): Observable<Notification[]> {
+  cryostatStatusNotifications(): Observable<Notification[]> {
     return this.notifications()
     .pipe(
       map(a => a.filter(n =>

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -40,6 +40,7 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AlertVariant } from '@patternfly/react-core';
 import { nanoid } from 'nanoid';
+import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 
 export interface Notification {
   read?: boolean;
@@ -145,7 +146,8 @@ export class Notifications {
   }
 
   private isNetworkInfoNotification(n: Notification): boolean {
-    return (n.category === 'WsClientActivity' || n.category === 'TargetJvmDiscovery')
+    return (n.category === NotificationCategory.WsClientActivity
+      || n.category === NotificationCategory.JvmDiscovery)
       && (n.variant === AlertVariant.info);
   }
 

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -133,7 +133,7 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
     ]).subscribe(
       refreshRecordingList
     );
-  }, [addSubscription, context, context.notificationChannel, notifications, refreshRecordingList]);
+  }, [context, context.notificationChannel, refreshRecordingList]);
 
   React.useEffect(() => {
     const sub = context.target.authFailure().subscribe(() => {

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -44,7 +44,7 @@ import {useSubscriptions} from '@app/utils/useSubscriptions';
 import {Button, DataListAction, DataListCell, DataListCheck, DataListContent, DataListItem, DataListItemCells, DataListItemRow, DataListToggle, Dropdown, DropdownItem, DropdownPosition, KebabToggle, Text, Toolbar, ToolbarContent, ToolbarItem} from '@patternfly/react-core';
 import * as React from 'react';
 import {useHistory, useRouteMatch} from 'react-router-dom';
-import {forkJoin, Observable} from 'rxjs';
+import {combineLatest, forkJoin, Observable} from 'rxjs';
 import {concatMap, filter, first} from 'rxjs/operators';
 import {RecordingsDataTable} from './RecordingsDataTable';
 import {ReportFrame} from './ReportFrame';
@@ -136,39 +136,14 @@ export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListP
   }, [addSubscription, context, context.target, refreshRecordingList]);
 
   React.useEffect(() => {
-    addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingCreated)
-      .subscribe(v => {
-        const event: RecordingNotificationEvent = v.message;
-        notifications.info('Recording Created', `${event.recording} created in target: ${event.target}`);
-        refreshRecordingList();
-      }));
-  }, [addSubscription, context, context.notificationChannel, notifications, refreshRecordingList]);
-
-  React.useEffect(() => {
-    addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingSaved)
-      .subscribe(v => {
-         const event: RecordingNotificationEvent = v.message;
-         notifications.info('Recording Archived', `${event.recording} was archived`);
-         refreshRecordingList();
-      }));
-  }, [addSubscription, context, context.notificationChannel, notifications, refreshRecordingList]);
-
-  React.useEffect(() => {
-    addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingArchived)
-      .subscribe(v => {
-         const event: RecordingNotificationEvent = v.message;
-         notifications.info('Recording Archived', `${event.recording} was archived`);
-         refreshRecordingList();
-      }));
-  }, [addSubscription, context, context.notificationChannel, notifications, refreshRecordingList]);
-
-  React.useEffect(() => {
-    addSubscription(context.notificationChannel.messages(NotificationCategory.RecordingDeleted)
-      .subscribe(v => {
-         const event: RecordingNotificationEvent = v.message;
-         notifications.info('Recording Deleted', `${event.recording} was deleted`);
-         refreshRecordingList();
-      }));
+    combineLatest([
+      context.notificationChannel.messages(NotificationCategory.RecordingCreated),
+      context.notificationChannel.messages(NotificationCategory.RecordingSaved),
+      context.notificationChannel.messages(NotificationCategory.RecordingArchived),
+      context.notificationChannel.messages(NotificationCategory.RecordingDeleted)
+    ]).subscribe(
+      refreshRecordingList
+    );
   }, [addSubscription, context, context.notificationChannel, notifications, refreshRecordingList]);
 
   React.useEffect(() => {

--- a/src/app/RecordingList/ActiveRecordingsList.tsx
+++ b/src/app/RecordingList/ActiveRecordingsList.tsx
@@ -38,6 +38,7 @@
 
 import {NotificationsContext} from '@app/Notifications/Notifications';
 import {Recording, RecordingState} from '@app/Shared/Services/Api.service';
+import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import {ServiceContext} from '@app/Shared/Services/Services';
 import {NO_TARGET} from '@app/Shared/Services/Target.service';
 import {useSubscriptions} from '@app/utils/useSubscriptions';
@@ -53,18 +54,6 @@ export interface ActiveRecordingsListProps {
   archiveEnabled: boolean;
   onArchive?: Function;
 }
-
-interface RecordingNotificationEvent {
-  recording : string;
-  target : string;
-}
-
-enum NotificationCategory {
-  RecordingCreated = 'RecordingCreated',
-  RecordingDeleted = 'RecordingDeleted',
-  RecordingSaved = 'RecordingSaved',
-  RecordingArchived = 'RecordingArchived'
-};
 
 export const ActiveRecordingsList: React.FunctionComponent<ActiveRecordingsListProps> = (props) => {
   const notifications = React.useContext(NotificationsContext);

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -209,11 +209,6 @@ export class ApiService {
         method: 'POST',
         body: form,
       }).pipe(
-        tap(resp => {
-          if (resp.ok) {
-            this.notifications.success('Recording created');
-          }
-        }),
         map(resp => resp.ok),
         first(),
       )));

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -45,6 +45,19 @@ import { ApiService } from './Api.service';
 
 const NOTIFICATION_CATEGORY = 'WsClientActivity';
 
+interface RecordingNotificationEvent {
+  recording : string;
+  target : string;
+}
+
+enum NotificationCategory {
+  RecordingCreated = 'RecordingCreated',
+  RecordingDeleted = 'RecordingDeleted',
+  RecordingSaved = 'RecordingSaved',
+  RecordingArchived = 'RecordingArchived',
+  WsClientActivity = 'WsClientActivity'
+};
+
 export class NotificationChannel {
 
   private ws: WebSocketSubject<any> | null = null;
@@ -55,10 +68,30 @@ export class NotificationChannel {
     private readonly apiSvc: ApiService,
     private readonly notifications: Notifications
   ) {
-    this.messages(NOTIFICATION_CATEGORY).subscribe(v => {
+    this.messages(NotificationCategory.WsClientActivity).subscribe(v => {
       const addr = Object.keys(v.message)[0];
       const status = v.message[addr];
-      notifications.info('WebSocket Client Activity', `Client at ${addr} ${status}`, NOTIFICATION_CATEGORY);
+      notifications.info('WebSocket Client Activity', `Client at ${addr} ${status}`, NotificationCategory.WsClientActivity);
+    });
+
+    this.messages(NotificationCategory.RecordingCreated).subscribe(v => {
+      const event: RecordingNotificationEvent = v.message;
+      notifications.info('Recording Created', `${event.recording} created in target: ${event.target}`);
+    });
+
+    this.messages(NotificationCategory.RecordingSaved).subscribe(v => {
+      const event: RecordingNotificationEvent = v.message;
+      notifications.info('Recording Archived', `${event.recording} was archived`);
+    });
+
+    this.messages(NotificationCategory.RecordingArchived).subscribe(v => {
+      const event: RecordingNotificationEvent = v.message;
+      notifications.info('Recording Archived', `${event.recording} was archived`);
+    });
+
+    this.messages(NotificationCategory.RecordingDeleted).subscribe(v => {
+      const event: RecordingNotificationEvent = v.message;
+      notifications.info('Recording Deleted', `${event.recording} was deleted`);
     });
 
     const notificationsUrl = fromFetch(`${this.apiSvc.authority}/api/v1/notifications_url`)
@@ -90,7 +123,7 @@ export class NotificationChannel {
             closeObserver: {
               next: () => {
                 this._ready.next(false);
-                this.notifications.info('WebSocket connection lost', undefined, NOTIFICATION_CATEGORY);
+                this.notifications.info('WebSocket connection lost', undefined, NotificationCategory.WsClientActivity);
               }
             }
           });

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -76,22 +76,22 @@ export class NotificationChannel {
 
     this.messages(NotificationCategory.RecordingCreated).subscribe(v => {
       const event: RecordingNotificationEvent = v.message;
-      notifications.info('Recording Created', `${event.recording} created in target: ${event.target}`);
+      notifications.success('Recording Created', `${event.recording} created in target: ${event.target}`);
     });
 
     this.messages(NotificationCategory.RecordingSaved).subscribe(v => {
       const event: RecordingNotificationEvent = v.message;
-      notifications.info('Recording Archived', `${event.recording} was archived`);
+      notifications.success('Recording Archived', `${event.recording} was archived`);
     });
 
     this.messages(NotificationCategory.RecordingArchived).subscribe(v => {
       const event: RecordingNotificationEvent = v.message;
-      notifications.info('Recording Archived', `${event.recording} was archived`);
+      notifications.success('Recording Archived', `${event.recording} was archived`);
     });
 
     this.messages(NotificationCategory.RecordingDeleted).subscribe(v => {
       const event: RecordingNotificationEvent = v.message;
-      notifications.info('Recording Deleted', `${event.recording} was deleted`);
+      notifications.success('Recording Deleted', `${event.recording} was deleted`);
     });
 
     const notificationsUrl = fromFetch(`${this.apiSvc.authority}/api/v1/notifications_url`)

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -43,20 +43,19 @@ import { concatMap, filter, map } from 'rxjs/operators';
 import { Base64 } from 'js-base64';
 import { ApiService } from './Api.service';
 
-const NOTIFICATION_CATEGORY = 'WsClientActivity';
-
 interface RecordingNotificationEvent {
-  recording : string;
-  target : string;
+  recording: string;
+  target: string;
 }
 
-enum NotificationCategory {
+export enum NotificationCategory {
+  JvmDiscovery = 'TargetJvmDiscovery',
   RecordingCreated = 'RecordingCreated',
   RecordingDeleted = 'RecordingDeleted',
   RecordingSaved = 'RecordingSaved',
   RecordingArchived = 'RecordingArchived',
   WsClientActivity = 'WsClientActivity'
-};
+}
 
 export class NotificationChannel {
 

--- a/src/app/Shared/Services/Targets.service.tsx
+++ b/src/app/Shared/Services/Targets.service.tsx
@@ -40,11 +40,9 @@ import * as _ from 'lodash';
 import { ApiService } from './Api.service';
 import { Target } from './Target.service';
 import { Notifications } from '@app/Notifications/Notifications';
-import { NotificationChannel } from './NotificationChannel.service';
+import { NotificationCategory, NotificationChannel } from './NotificationChannel.service';
 import { Observable, BehaviorSubject, of } from 'rxjs';
 import { catchError, first, map, tap } from 'rxjs/operators';
-
-const NOTIFICATION_CATEGORY = 'TargetJvmDiscovery';
 
 export interface TargetDiscoveryEvent {
   kind: 'LOST' | 'FOUND';
@@ -62,21 +60,21 @@ export class TargetsService {
     this.queryForTargets().subscribe(() => {
       ; // just trigger a startup query
     });
-    notificationChannel.messages(NOTIFICATION_CATEGORY)
+    notificationChannel.messages(NotificationCategory.JvmDiscovery)
       .subscribe(v => {
         const evt: TargetDiscoveryEvent = v.message.event;
         const target: Target = evt.serviceRef;
         switch (evt.kind) {
           case 'FOUND':
             this._targets$.next(_.unionBy(this._targets$.getValue(), [evt.serviceRef], t => t.connectUrl));
-            notifications.info('Target Appeared', `Target "${target.alias}" appeared (${target.connectUrl})"`, NOTIFICATION_CATEGORY);
+            notifications.info('Target Appeared', `Target "${target.alias}" appeared (${target.connectUrl})"`, NotificationCategory.JvmDiscovery);
             break;
           case 'LOST':
             this._targets$.next(_.filter(this._targets$.getValue(), t => t.connectUrl !== evt.serviceRef.connectUrl));
-            notifications.info('Target Disappeared', `Target "${target.alias}" disappeared (${target.connectUrl})"`, NOTIFICATION_CATEGORY);
+            notifications.info('Target Disappeared', `Target "${target.alias}" disappeared (${target.connectUrl})"`, NotificationCategory.JvmDiscovery);
             break;
           default:
-            notifications.danger(`Invalid Message Received`, `Received a notification with category ${NOTIFICATION_CATEGORY} and unrecognized kind ${evt.kind}`);
+            notifications.danger(`Invalid Message Received`, `Received a notification with category ${NotificationCategory.JvmDiscovery} and unrecognized kind ${evt.kind}`);
             break;
         }
       });


### PR DESCRIPTION
Fixes #284 

Only one notification should appear when recordings are created. All notifications indicating that a user's action was successfully processed now display the green "success" message style.

>  the subscription to this notification category should be somewhere long-lived

The NotificationChannel now subscribes to all WebSocket messages related to updating recording state (ie recording created/archived/saved/deleted) so that these notifications are displayed even if users navigate away from the Recordings page.