### PR TITLE
feat(notifications): Show toast on user action success

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -48,7 +48,7 @@ import { AboutModal, Alert, AlertGroup, AlertVariant, AlertActionCloseButton,
 import { BellIcon, CogIcon, HelpIcon } from '@patternfly/react-icons';
 import { map } from 'rxjs/operators';
 import { matchPath, NavLink, useHistory, useLocation } from 'react-router-dom';
-import { Notification, NotificationsContext } from '../Notifications/Notifications';
+import { Notification, Notifications, NotificationsContext } from '../Notifications/Notifications';
 import { AuthModal } from './AuthModal';
 import { SslErrorModal } from './SslErrorModal';
 
@@ -301,7 +301,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
     <AlertGroup isToast>
       {
         notifications
-          .filter(n => !n.read && (n.variant === AlertVariant.danger || n.variant === AlertVariant.warning))
+          .filter(n => !n.read && Notifications.isProblemNotification(n))
           .map(( { key, title, message, variant } ) => (
             <Alert
               variant={variant}

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -301,12 +301,13 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
     <AlertGroup isToast>
       {
         notifications
-          .filter(n => !n.read && Notifications.isProblemNotification(n))
+          .filter(n => !n.read && (Notifications.isProblemNotification(n) || n.variant === AlertVariant.success))
           .map(( { key, title, message, variant } ) => (
             <Alert
               variant={variant}
               title={title}
               actionClose={<AlertActionCloseButton onClose={() => handleMarkNotificationRead(key)} />}
+              timeout={true}
             >{message}
             </Alert>
         ))

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -113,7 +113,7 @@ export class Notifications {
   problemsNotifications(): Observable<Notification[]> {
     return this.notifications()
     .pipe(
-      map(a => a.filter(this.isProblemNotification))
+      map(a => a.filter(Notifications.isProblemNotification))
     );
   }
 
@@ -146,7 +146,7 @@ export class Notifications {
   private isActionNotification(n: Notification): boolean {
     return !this.isWsClientActivity(n)
       && !this.isJvmDiscovery(n)
-      && !this.isProblemNotification(n);
+      && !Notifications.isProblemNotification(n);
   }
 
   private isWsClientActivity(n: Notification): boolean {
@@ -157,7 +157,7 @@ export class Notifications {
     return (n.category === NotificationCategory.JvmDiscovery);
   }
 
-  private isProblemNotification(n: Notification): boolean {
+  static isProblemNotification(n: Notification): boolean {
     return (n.variant === AlertVariant.warning) || (n.variant === AlertVariant.danger);
   }
 }


### PR DESCRIPTION
Fixes #267 

Since the purpose of adding toast notifications is to confirm a user’s action was processed successfully and Patternfly recommends that all of those notifications should have the “success” message variant, I decided to change all “user action confirmed” notifications to use the “success” variant in #288. 

Then the alert group would just need to filter and display messages that have either error, warning, or success variants. 
Adding a default 8-second timeout also seemed appropriate since toasts will appear after completing user actions. Any unread errors will still appear in the notifications drawer.
