### PR TITLE
feat(targets): Persist selected target in localStorage

### DIFF
--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -81,8 +81,8 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
       const previouslyCachedTarget = getCachedTargetSelection();
       context.target.setTarget(previouslyCachedTarget);
     } catch (error) {
-      removeCachedTargetSelection();
       context.target.setTarget(NO_TARGET);
+      removeCachedTargetSelection();
     }
   }, [context.target]);
 

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -95,7 +95,11 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   React.useEffect(() => {
     const cachedTargetSelection = getCachedTargetSelection();
     if(cachedTargetSelection) {
-      context.target.setTarget(cachedTargetSelection);
+      try {
+        context.target.setTarget(cachedTargetSelection);
+      } catch (error) {
+        removeCachedTargetSelection();
+      }
     }
   }, [context.target]);
 

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -86,20 +86,16 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
 
   const getCachedTargetSelection = () => {
     const cachedTarget = localStorage.getItem(TARGET_KEY);
-    if(cachedTarget) {
-      return JSON.parse(cachedTarget);
-    }
-    return NO_TARGET;
+    return cachedTarget ? JSON.parse(cachedTarget) : NO_TARGET;
   };
 
   React.useEffect(() => {
-    const cachedTargetSelection = getCachedTargetSelection();
-    if(cachedTargetSelection) {
-      try {
-        context.target.setTarget(cachedTargetSelection);
-      } catch (error) {
-        removeCachedTargetSelection();
-      }
+    try {
+      const previouslyCachedTarget = getCachedTargetSelection();
+      context.target.setTarget(previouslyCachedTarget);
+    } catch (error) {
+      removeCachedTargetSelection();
+      context.target.setTarget(NO_TARGET);
     }
   }, [context.target]);
 

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -76,6 +76,16 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
     );
   }, [setLoading, addSubscription, context.targets]);
 
+  React.useEffect(() => {
+    try {
+      const previouslyCachedTarget = getCachedTargetSelection();
+      context.target.setTarget(previouslyCachedTarget);
+    } catch (error) {
+      removeCachedTargetSelection();
+      context.target.setTarget(NO_TARGET);
+    }
+  }, [context.target]);
+
   const setCachedTargetSelection = (target) => {
     localStorage.setItem(TARGET_KEY, JSON.stringify(target));
   };
@@ -88,16 +98,6 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
     const cachedTarget = localStorage.getItem(TARGET_KEY);
     return cachedTarget ? JSON.parse(cachedTarget) : NO_TARGET;
   };
-
-  React.useEffect(() => {
-    try {
-      const previouslyCachedTarget = getCachedTargetSelection();
-      context.target.setTarget(previouslyCachedTarget);
-    } catch (error) {
-      removeCachedTargetSelection();
-      context.target.setTarget(NO_TARGET);
-    }
-  }, [context.target]);
 
   const onSelect = React.useCallback((evt, selection, isPlaceholder) => {
     if (isPlaceholder) {

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -36,7 +36,6 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import * as _ from 'lodash';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { NotificationsContext } from '@app/Notifications/Notifications';
 import { NO_TARGET, Target } from '@app/Shared/Services/Target.service';
@@ -77,6 +76,29 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
     );
   }, [setLoading, addSubscription, context.targets]);
 
+  const setCachedTargetSelection = (target) => {
+    localStorage.setItem(TARGET_KEY, JSON.stringify(target));
+  };
+
+  const removeCachedTargetSelection = () => {
+    localStorage.removeItem(TARGET_KEY);
+  };
+
+  const getCachedTargetSelection = () => {
+    const cachedTarget = localStorage.getItem(TARGET_KEY);
+    if(cachedTarget) {
+      return JSON.parse(cachedTarget);
+    }
+    return NO_TARGET;
+  };
+
+  React.useEffect(() => {
+    const cachedTargetSelection = getCachedTargetSelection();
+    if(cachedTargetSelection) {
+      context.target.setTarget(cachedTargetSelection);
+    }
+  }, [context.target]);
+
   const onSelect = React.useCallback((evt, selection, isPlaceholder) => {
     if (isPlaceholder) {
       context.target.setTarget(NO_TARGET);
@@ -95,38 +117,15 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
     setExpanded(false);
   }, [context, context.target, selected, notifications, setExpanded]);
 
-  const getCachedTargetSelection = () => {
-    const cachedTarget = localStorage.getItem(TARGET_KEY);
-    if(!!cachedTarget) {
-      return JSON.parse(cachedTarget);
-    }
-    return NO_TARGET;
-  };
-
-  const setCachedTargetSelection = (target) => {
-    localStorage.setItem(TARGET_KEY, JSON.stringify(target));
-  };
-
-  const removeCachedTargetSelection = () => {
-    localStorage.removeItem(TARGET_KEY);
-  };
-
   const selectNone = React.useCallback(() => {
     onSelect(undefined, undefined, true);
   }, [onSelect]);
-
-  React.useEffect(() => {
-    const cachedTargetSelection = getCachedTargetSelection();
-    if(cachedTargetSelection) {
-      context.target.setTarget(cachedTargetSelection);
-    }
-  }, [context.target]);
 
   React.useLayoutEffect(() => {
     addSubscription(
       context.target.target().subscribe(setSelected)
     );
-  }, [context.target]);
+  }, [context.target, addSubscription]);
 
   React.useEffect(() => {
     if (!context.settings.autoRefreshEnabled()) {
@@ -153,7 +152,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
           }
         })
     );
-  }, [context.api, notifications, setModalOpen]);
+  }, [context.api, notifications, setModalOpen, addSubscription]);
 
   const deleteTarget = React.useCallback(() => {
     setLoading(true);


### PR DESCRIPTION
Fixes #278

> This is overall a stopgap measure to enhance the current state management and routing. The better solution is outlined in #78 - the target selection should be included in the view route.