### PR TITLE
fix(AppLayout): remove target from logoProps to prevent opening a new tab

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -63,8 +63,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   const notificationsContext = React.useContext(NotificationsContext);
   const routerHistory = useHistory();
   const logoProps = {
-    href: '/',
-    target: '_blank'
+    href: '/'
   };
   const [isNavOpen, setIsNavOpen] = React.useState(true);
   const [isMobileView, setIsMobileView] = React.useState(true);


### PR DESCRIPTION
This one-liner address https://github.com/cryostatio/cryostat-web/issues/296

The target '_blank' opens a new tab when the logo in the top left is clicked, which is probably not desirable. Now it'll just reload the page in place.