### PR TITLE
feat(about): View About info from PageSideBar

### DIFF
--- a/src/app/About/About.tsx
+++ b/src/app/About/About.tsx
@@ -37,17 +37,22 @@
  */
 
 import React from 'react';
+import cryostatLogoHorizontal from '@app/assets/logo-cryostat-3-horizontal.svg';
 import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
-import { AboutDescription } from './AboutDescription';
-import { Card, CardBody } from '@patternfly/react-core';
+import { AboutDescription, CRYOSTAT_TRADEMARK } from './AboutDescription';
+import { Brand, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react-core';
 
 export const About = () => {
   return (
     <BreadcrumbPage pageTitle="About Cryostat">
       <Card>
+        <CardHeader>
+          <Brand alt="Cryostat" src={cryostatLogoHorizontal} className="cryostat-logo" />
+        </CardHeader>
         <CardBody>
           <AboutDescription />
         </CardBody>
+        <CardFooter>{CRYOSTAT_TRADEMARK}</CardFooter>
       </Card>
     </BreadcrumbPage>
   );

--- a/src/app/About/About.tsx
+++ b/src/app/About/About.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import React from 'react';
+import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
+import { AboutDescription } from './AboutDescription';
+import { Card, CardBody } from '@patternfly/react-core';
+
+export const About = () => {
+  return (
+    <BreadcrumbPage pageTitle="About Cryostat">
+      <Card>
+        <CardBody>
+          <AboutDescription />
+        </CardBody>
+      </Card>
+    </BreadcrumbPage>
+  );
+};

--- a/src/app/About/About.tsx
+++ b/src/app/About/About.tsx
@@ -44,7 +44,7 @@ import { Brand, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react
 
 export const About = () => {
   return (
-    <BreadcrumbPage pageTitle="About Cryostat">
+    <BreadcrumbPage pageTitle="About">
       <Card>
         <CardHeader>
           <Brand alt="Cryostat" src={cryostatLogoHorizontal} className="cryostat-logo" />

--- a/src/app/About/AboutCryostatModal.tsx
+++ b/src/app/About/AboutCryostatModal.tsx
@@ -51,7 +51,7 @@ export const AboutCryostatModal = ({isOpen, onClose}) => {
         brandImageSrc={cryostatLogoWhite}
         brandImageAlt='Cryostat Logo'
       >
-       <AboutDescription />
+      <AboutDescription />
     </AboutModal>
     </>);
 }

--- a/src/app/About/AboutCryostatModal.tsx
+++ b/src/app/About/AboutCryostatModal.tsx
@@ -39,7 +39,7 @@
 import { AboutModal } from "@patternfly/react-core"
 import React from "react"
 import cryostatLogoWhite from '@app/assets/logo-cryostat-3.svg';
-import { AboutDescription } from "./AboutDescription";
+import { AboutDescription, CRYOSTAT_TRADEMARK } from "./AboutDescription";
 
 export const AboutCryostatModal = ({isOpen, onClose}) => {
 
@@ -47,7 +47,7 @@ export const AboutCryostatModal = ({isOpen, onClose}) => {
     <AboutModal
         isOpen={isOpen}
         onClose={onClose}
-        trademark='Copyright The Cryostat Authors, The Universal Permissive License (UPL), Version 1.0'
+        trademark={CRYOSTAT_TRADEMARK}
         brandImageSrc={cryostatLogoWhite}
         brandImageAlt='Cryostat Logo'
       >

--- a/src/app/About/AboutCryostatModal.tsx
+++ b/src/app/About/AboutCryostatModal.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { AboutModal } from "@patternfly/react-core"
+import React from "react"
+import cryostatLogoWhite from '@app/assets/logo-cryostat-3.svg';
+import { AboutDescription } from "./AboutDescription";
+
+export const AboutCryostatModal = ({isOpen, onClose}) => {
+
+  return(<>
+    <AboutModal
+        isOpen={isOpen}
+        onClose={onClose}
+        trademark='Copyright The Cryostat Authors, The Universal Permissive License (UPL), Version 1.0'
+        brandImageSrc={cryostatLogoWhite}
+        brandImageAlt='Cryostat Logo'
+      >
+       <AboutDescription />
+    </AboutModal>
+    </>);
+}

--- a/src/app/About/AboutDescription.tsx
+++ b/src/app/About/AboutDescription.tsx
@@ -36,23 +36,20 @@
  * SOFTWARE.
  */
 
-import { AboutModal, Text, TextContent, TextList, TextListItem, TextVariants } from "@patternfly/react-core"
+import { Text, TextContent, TextList, TextListItem, TextVariants } from "@patternfly/react-core"
 import React from "react"
 import { ServiceContext } from "@app/Shared/Services/Services";
 import { NotificationsContext } from "@app/Notifications/Notifications";
-import { useHistory } from 'react-router-dom';
-import cryostatLogoWhite from '@app/assets/logo-cryostat-3.svg';
 
-export const AboutCryostatModal = () => {
+export const AboutDescription = () => {
   const serviceContext = React.useContext(ServiceContext);
   const notificationsContext = React.useContext(NotificationsContext);
-  const routerHistory = useHistory();
   const [cryostatVersion, setCryostatVersion] = React.useState(undefined as string | undefined);
 
   React.useEffect(() => {
     const sub = serviceContext.api.cryostatVersion().subscribe(setCryostatVersion);
     return () => sub.unsubscribe();
-  })
+  }, [serviceContext])
 
   const cryostatCommitHash = React.useMemo(() => {
     if (!cryostatVersion) {
@@ -65,69 +62,56 @@ export const AboutCryostatModal = () => {
       return 'main';
     }
     return result.groups?.describe || 'main';
-  }, [cryostatVersion]);
-
-  const onClose = () => {
-    return routerHistory.location.state ?
-      routerHistory.goBack() : routerHistory.push('/');
-  }
+  }, [cryostatVersion, notificationsContext]);
 
   return(<>
-    <AboutModal
-        isOpen={true}
-        onClose={onClose}
-        trademark='Copyright The Cryostat Authors, The Universal Permissive License (UPL), Version 1.0'
-        brandImageSrc={cryostatLogoWhite}
-        brandImageAlt='Cryostat Logo'
-      >
-        <TextContent>
-        <TextList component="dl">
-          <TextListItem component="dt">
-            Version
-          </TextListItem>
-          <TextListItem component="dd">
-            <Text
-              component={TextVariants.a}
-              target="_blank"
-              href={`https://github.com/cryostatio/cryostat/commits/${cryostatCommitHash}`}
-            >{cryostatVersion}</Text>
-          </TextListItem>
-          <TextListItem component="dt">
-            Homepage
-          </TextListItem>
-          <TextListItem component="dd">
-            <Text component={TextVariants.a} target="_blank" href='https://cryostat.io'>cryostat.io</Text>
-          </TextListItem>
-          <TextListItem component="dt">
-            Bugs
-          </TextListItem>
-          <TextListItem component="dd">
-            <Text>
-            <Text component={TextVariants.a} target="_blank" href='https://github.com/cryostatio/cryostat/issues'>Known Issues</Text>
-            &nbsp;|&nbsp;
-            <Text
-              component={TextVariants.a}
-              target="_blank"
-              href={`https://github.com/cryostatio/cryostat/issues/new?labels=user+report,bug&body=Affects+${cryostatVersion}`}
-            >
-              File a Report
-            </Text>
-            </Text>
-          </TextListItem>
-          <TextListItem component="dt">
-            Mailing List
-          </TextListItem>
-          <TextListItem component="dd">
-            <Text component={TextVariants.a} target="_blank" href='https://groups.google.com/g/cryostat-development'>Google Groups</Text>
-          </TextListItem>
-          <TextListItem component="dt">
-            Open Source License
-          </TextListItem>
-          <TextListItem component="dd">
-            <Text component={TextVariants.a} target="_blank" href='https://github.com/cryostatio/cryostat/blob/main/LICENSE'>License</Text>
-          </TextListItem>
-        </TextList>
-      </TextContent>
-    </AboutModal>
+      <TextContent>
+      <TextList component="dl">
+        <TextListItem component="dt">
+          Version
+        </TextListItem>
+        <TextListItem component="dd">
+          <Text
+            component={TextVariants.a}
+            target="_blank"
+            href={`https://github.com/cryostatio/cryostat/commits/${cryostatCommitHash}`}
+          >{cryostatVersion}</Text>
+        </TextListItem>
+        <TextListItem component="dt">
+          Homepage
+        </TextListItem>
+        <TextListItem component="dd">
+          <Text component={TextVariants.a} target="_blank" href='https://cryostat.io'>cryostat.io</Text>
+        </TextListItem>
+        <TextListItem component="dt">
+          Bugs
+        </TextListItem>
+        <TextListItem component="dd">
+          <Text>
+          <Text component={TextVariants.a} target="_blank" href='https://github.com/cryostatio/cryostat/issues'>Known Issues</Text>
+          &nbsp;|&nbsp;
+          <Text
+            component={TextVariants.a}
+            target="_blank"
+            href={`https://github.com/cryostatio/cryostat/issues/new?labels=user+report,bug&body=Affects+${cryostatVersion}`}
+          >
+            File a Report
+          </Text>
+          </Text>
+        </TextListItem>
+        <TextListItem component="dt">
+          Mailing List
+        </TextListItem>
+        <TextListItem component="dd">
+          <Text component={TextVariants.a} target="_blank" href='https://groups.google.com/g/cryostat-development'>Google Groups</Text>
+        </TextListItem>
+        <TextListItem component="dt">
+          Open Source License
+        </TextListItem>
+        <TextListItem component="dd">
+          <Text component={TextVariants.a} target="_blank" href='https://github.com/cryostatio/cryostat/blob/main/LICENSE'>License</Text>
+        </TextListItem>
+      </TextList>
+    </TextContent>
     </>);
 }

--- a/src/app/About/AboutDescription.tsx
+++ b/src/app/About/AboutDescription.tsx
@@ -41,6 +41,8 @@ import React from "react"
 import { ServiceContext } from "@app/Shared/Services/Services";
 import { NotificationsContext } from "@app/Notifications/Notifications";
 
+export const CRYOSTAT_TRADEMARK = 'Copyright The Cryostat Authors, The Universal Permissive License (UPL), Version 1.0';
+
 export const AboutDescription = () => {
   const serviceContext = React.useContext(ServiceContext);
   const notificationsContext = React.useContext(NotificationsContext);

--- a/src/app/AppLayout/AboutCryostatModal.tsx
+++ b/src/app/AppLayout/AboutCryostatModal.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { AboutModal, AboutModalProps, Text, TextContent, TextList, TextListItem, TextVariants } from "@patternfly/react-core"
+import React from "react"
+import { ServiceContext } from "@app/Shared/Services/Services";
+import { NotificationsContext } from "@app/Notifications/Notifications";
+
+export const AboutCryostatModal: React.FunctionComponent<AboutModalProps> = ({children, isOpen, onClose, brandImageSrc, brandImageAlt}) => {
+  const serviceContext = React.useContext(ServiceContext);
+  const notificationsContext = React.useContext(NotificationsContext);
+
+  const [cryostatVersion, setCryostatVersion] = React.useState(undefined as string | undefined);
+
+  React.useEffect(() => {
+    const sub = serviceContext.api.cryostatVersion().subscribe(setCryostatVersion);
+    return () => sub.unsubscribe();
+  })
+
+  const cryostatCommitHash = React.useMemo(() => {
+    if (!cryostatVersion) {
+      return;
+    }
+    const expr = /^(?<describe>[a-zA-Z0-9-_.]+-[0-9]+-[a-z0-9]+)(?:-dirty)?$/;
+    const result = cryostatVersion.match(expr);
+    if (!result) {
+      notificationsContext.warning('Cryostat Version Parse Failure', `Could not parse Cryostat version string '${cryostatVersion}'.`);
+      return 'main';
+    }
+    return result.groups?.describe || 'main';
+  }, [cryostatVersion]);
+
+  return(<>
+    <AboutModal
+        isOpen={isOpen}
+        onClose={onClose}
+        trademark='Copyright The Cryostat Authors, The Universal Permissive License (UPL), Version 1.0'
+        brandImageSrc={brandImageSrc}
+        brandImageAlt={brandImageAlt}
+      >
+        <TextContent>
+        <TextList component="dl">
+          <TextListItem component="dt">
+            Version
+          </TextListItem>
+          <TextListItem component="dd">
+            <Text
+              component={TextVariants.a}
+              target="_blank"
+              href={`https://github.com/cryostatio/cryostat/commits/${cryostatCommitHash}`}
+            >{cryostatVersion}</Text>
+          </TextListItem>
+          <TextListItem component="dt">
+            Homepage
+          </TextListItem>
+          <TextListItem component="dd">
+            <Text component={TextVariants.a} target="_blank" href='https://cryostat.io'>cryostat.io</Text>
+          </TextListItem>
+          <TextListItem component="dt">
+            Bugs
+          </TextListItem>
+          <TextListItem component="dd">
+            <Text>
+            <Text component={TextVariants.a} target="_blank" href='https://github.com/cryostatio/cryostat/issues'>Known Issues</Text>
+            &nbsp;|&nbsp;
+            <Text
+              component={TextVariants.a}
+              target="_blank"
+              href={`https://github.com/cryostatio/cryostat/issues/new?labels=user+report,bug&body=Affects+${cryostatVersion}`}
+            >
+              File a Report
+            </Text>
+            </Text>
+          </TextListItem>
+          <TextListItem component="dt">
+            Mailing List
+          </TextListItem>
+          <TextListItem component="dd">
+            <Text component={TextVariants.a} target="_blank" href='https://groups.google.com/g/cryostat-development'>Google Groups</Text>
+          </TextListItem>
+          <TextListItem component="dt">
+            Open Source License
+          </TextListItem>
+          <TextListItem component="dd">
+            <Text component={TextVariants.a} target="_blank" href='https://github.com/cryostatio/cryostat/blob/main/LICENSE'>License</Text>
+          </TextListItem>
+        </TextList>
+      </TextContent>
+    </AboutModal>
+    </>);
+}

--- a/src/app/AppLayout/AboutCryostatModal.tsx
+++ b/src/app/AppLayout/AboutCryostatModal.tsx
@@ -68,7 +68,8 @@ export const AboutCryostatModal = () => {
   }, [cryostatVersion]);
 
   const onClose = () => {
-    return routerHistory.goBack();
+    return routerHistory.location.state ?
+      routerHistory.goBack() : routerHistory.push('/');
   }
 
   return(<>

--- a/src/app/AppLayout/AboutCryostatModal.tsx
+++ b/src/app/AppLayout/AboutCryostatModal.tsx
@@ -36,15 +36,17 @@
  * SOFTWARE.
  */
 
-import { AboutModal, AboutModalProps, Text, TextContent, TextList, TextListItem, TextVariants } from "@patternfly/react-core"
+import { AboutModal, Text, TextContent, TextList, TextListItem, TextVariants } from "@patternfly/react-core"
 import React from "react"
 import { ServiceContext } from "@app/Shared/Services/Services";
 import { NotificationsContext } from "@app/Notifications/Notifications";
+import { useHistory } from 'react-router-dom';
+import cryostatLogoWhite from '@app/assets/logo-cryostat-3.svg';
 
-export const AboutCryostatModal: React.FunctionComponent<AboutModalProps> = ({children, isOpen, onClose, brandImageSrc, brandImageAlt}) => {
+export const AboutCryostatModal = () => {
   const serviceContext = React.useContext(ServiceContext);
   const notificationsContext = React.useContext(NotificationsContext);
-
+  const routerHistory = useHistory();
   const [cryostatVersion, setCryostatVersion] = React.useState(undefined as string | undefined);
 
   React.useEffect(() => {
@@ -65,13 +67,17 @@ export const AboutCryostatModal: React.FunctionComponent<AboutModalProps> = ({ch
     return result.groups?.describe || 'main';
   }, [cryostatVersion]);
 
+  const onClose = () => {
+    return routerHistory.goBack();
+  }
+
   return(<>
     <AboutModal
-        isOpen={isOpen}
+        isOpen={true}
         onClose={onClose}
         trademark='Copyright The Cryostat Authors, The Universal Permissive License (UPL), Version 1.0'
-        brandImageSrc={brandImageSrc}
-        brandImageAlt={brandImageAlt}
+        brandImageSrc={cryostatLogoWhite}
+        brandImageAlt='Cryostat Logo'
       >
         <TextContent>
         <TextList component="dl">

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -52,6 +52,7 @@ import { Notification, Notifications, NotificationsContext } from '@app/Notifica
 import { AuthModal } from './AuthModal';
 import { SslErrorModal } from './SslErrorModal';
 import cryostatLogoHorizontal from '@app/assets/logo-cryostat-3-horizontal.svg';
+import { AboutCryostatModal } from '@app/About/AboutCryostatModal';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -69,6 +70,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   const [isNavOpenMobile, setIsNavOpenMobile] = React.useState(false);
   const [showAuthModal, setShowAuthModal] = React.useState(false);
   const [showSslErrorModal, setShowSslErrorModal] = React.useState(false);
+  const [aboutModalOpen, setAboutModalOpen] = React.useState(false);
   const [isNotificationDrawerExpanded, setNotificationDrawerExpanded] = React.useState(false);
   const [notifications, setNotifications] = React.useState([] as Notification[]);
   const [unreadNotificationsCount, setUnreadNotificationsCount] = React.useState(0);
@@ -142,15 +144,8 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
     setNotificationDrawerExpanded(false);
   };
 
-  const getModalRoute = (modalPath: string) => {
-    if(location.pathname !== '/') {
-      modalPath = `${location.pathname}${modalPath}`;
-    }
-    return {pathname: modalPath, state: { modalBackground: location }};
-  }
-
   const handleAboutModalToggle = () => {
-    routerHistory.push(getModalRoute('/about'));
+    setAboutModalOpen(!aboutModalOpen);
   };
 
   const HeaderTools = (<>
@@ -189,6 +184,10 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
       onNavToggle={isMobileView ? onNavToggleMobile : onNavToggle}
       headerTools={HeaderTools}
     />
+    <AboutCryostatModal
+      isOpen={aboutModalOpen}
+      onClose={handleAboutModalToggle}
+    />
   </>);
 
   const isActiveRoute = (route: IAppRoute): boolean => {
@@ -211,7 +210,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
         {routes.map((route, idx) => route.label && (
             <NavItem key={`${route.label}-${idx}`} id={`${route.label}-${idx}`} isActive={isActiveRoute(route)}>
               <NavLink
-                exact to={route.isModal? getModalRoute(route.path) : route.path}
+                exact to={route.path}
                 activeClassName="pf-m-current">{route.label}
               </NavLink>
             </NavItem>

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -52,8 +52,6 @@ import { Notification, Notifications, NotificationsContext } from '@app/Notifica
 import { AuthModal } from './AuthModal';
 import { SslErrorModal } from './SslErrorModal';
 import cryostatLogoHorizontal from '@app/assets/logo-cryostat-3-horizontal.svg';
-import cryostatLogoWhite from '@app/assets/logo-cryostat-3.svg';
-import { AboutCryostatModal } from './AboutCryostatModal';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -71,7 +69,6 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   const [isNavOpenMobile, setIsNavOpenMobile] = React.useState(false);
   const [showAuthModal, setShowAuthModal] = React.useState(false);
   const [showSslErrorModal, setShowSslErrorModal] = React.useState(false);
-  const [aboutModalOpen, setAboutModalOpen] = React.useState(false);
   const [isNotificationDrawerExpanded, setNotificationDrawerExpanded] = React.useState(false);
   const [notifications, setNotifications] = React.useState([] as Notification[]);
   const [unreadNotificationsCount, setUnreadNotificationsCount] = React.useState(0);
@@ -145,7 +142,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
     setNotificationDrawerExpanded(false);
   };
   const handleAboutModalToggle = () => {
-    setAboutModalOpen(!aboutModalOpen);
+    routerHistory.push('/about');
   };
   const HeaderTools = (<>
     <PageHeaderTools>
@@ -182,13 +179,6 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
       isNavOpen={isNavOpen}
       onNavToggle={isMobileView ? onNavToggleMobile : onNavToggle}
       headerTools={HeaderTools}
-    />
-    <AboutCryostatModal
-      isOpen={aboutModalOpen}
-      onClose={handleAboutModalToggle}
-      children={children}
-      brandImageSrc={cryostatLogoWhite}
-      brandImageAlt='Cryostat Logo'
     />
   </>);
 

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -141,9 +141,18 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   const handleCloseNotificationCenter = () => {
     setNotificationDrawerExpanded(false);
   };
+
+  const getModalRoute = (modalPath: string) => {
+    if(location.pathname !== '/') {
+      modalPath = `${location.pathname}${modalPath}`;
+    }
+    return {pathname: modalPath, state: { modalBackground: location }};
+  }
+
   const handleAboutModalToggle = () => {
-    routerHistory.push('/about');
+    routerHistory.push(getModalRoute('/about'));
   };
+
   const HeaderTools = (<>
     <PageHeaderTools>
       <PageHeaderToolsGroup>
@@ -201,7 +210,10 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
       <NavList id="nav-list-simple">
         {routes.map((route, idx) => route.label && (
             <NavItem key={`${route.label}-${idx}`} id={`${route.label}-${idx}`} isActive={isActiveRoute(route)}>
-              <NavLink exact to={route.path} activeClassName="pf-m-current">{route.label}</NavLink>
+              <NavLink
+                exact to={route.isModal? getModalRoute(route.path) : route.path}
+                activeClassName="pf-m-current">{route.label}
+              </NavLink>
             </NavItem>
           ))}
       </NavList>

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -40,10 +40,10 @@ import * as _ from 'lodash';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { NotificationCenter } from '@app/Notifications/NotificationCenter';
 import { IAppRoute, routes } from '@app/routes';
-import { AboutModal, Alert, AlertGroup, AlertVariant, AlertActionCloseButton,
+import { Alert, AlertGroup, AlertVariant, AlertActionCloseButton,
   Brand, Button, Nav, NavItem, NavList, NotificationBadge, Page, PageHeader,
   PageHeaderTools, PageHeaderToolsGroup, PageHeaderToolsItem, PageSidebar,
-  SkipToContent, Text, TextContent, TextList, TextListItem, TextVariants
+  SkipToContent
 } from '@patternfly/react-core';
 import { BellIcon, CogIcon, HelpIcon } from '@patternfly/react-icons';
 import { map } from 'rxjs/operators';
@@ -53,6 +53,7 @@ import { AuthModal } from './AuthModal';
 import { SslErrorModal } from './SslErrorModal';
 import cryostatLogoHorizontal from '@app/assets/logo-cryostat-3-horizontal.svg';
 import cryostatLogoWhite from '@app/assets/logo-cryostat-3.svg';
+import { AboutCryostatModal } from './AboutCryostatModal';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -72,7 +73,6 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   const [showSslErrorModal, setShowSslErrorModal] = React.useState(false);
   const [aboutModalOpen, setAboutModalOpen] = React.useState(false);
   const [isNotificationDrawerExpanded, setNotificationDrawerExpanded] = React.useState(false);
-  const [cryostatVersion, setCryostatVersion] = React.useState(undefined as string | undefined);
   const [notifications, setNotifications] = React.useState([] as Notification[]);
   const [unreadNotificationsCount, setUnreadNotificationsCount] = React.useState(0);
   const [errorNotificationsCount, setErrorNotificationsCount] = React.useState(0);
@@ -84,24 +84,6 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
     });
     return () => sub.unsubscribe();
   }, [serviceContext.target]);
-
-  React.useEffect(() => {
-    const sub = serviceContext.api.cryostatVersion().subscribe(setCryostatVersion);
-    return () => sub.unsubscribe();
-  })
-
-  const cryostatCommitHash = React.useMemo(() => {
-    if (!cryostatVersion) {
-      return;
-    }
-    const expr = /^(?<describe>[a-zA-Z0-9-_.]+-[0-9]+-[a-z0-9]+)(?:-dirty)?$/;
-    const result = cryostatVersion.match(expr);
-    if (!result) {
-      notificationsContext.warning('Cryostat Version Parse Failure', `Could not parse Cryostat version string '${cryostatVersion}'.`);
-      return 'main';
-    }
-    return result.groups?.describe || 'main';
-  }, [cryostatVersion]);
 
   React.useEffect(() => {
     const sub = notificationsContext.notifications().subscribe(setNotifications);
@@ -201,62 +183,13 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
       onNavToggle={isMobileView ? onNavToggleMobile : onNavToggle}
       headerTools={HeaderTools}
     />
-    <AboutModal
+    <AboutCryostatModal
       isOpen={aboutModalOpen}
       onClose={handleAboutModalToggle}
-      trademark='Copyright The Cryostat Authors, The Universal Permissive License (UPL), Version 1.0'
+      children={children}
       brandImageSrc={cryostatLogoWhite}
       brandImageAlt='Cryostat Logo'
-    >
-      <TextContent>
-        <TextList component="dl">
-          <TextListItem component="dt">
-            Version
-          </TextListItem>
-          <TextListItem component="dd">
-            <Text
-              component={TextVariants.a}
-              target="_blank"
-              href={`https://github.com/cryostatio/cryostat/commits/${cryostatCommitHash}`}
-            >{cryostatVersion}</Text>
-          </TextListItem>
-          <TextListItem component="dt">
-            Homepage
-          </TextListItem>
-          <TextListItem component="dd">
-            <Text component={TextVariants.a} target="_blank" href='https://cryostat.io'>cryostat.io</Text>
-          </TextListItem>
-          <TextListItem component="dt">
-            Bugs
-          </TextListItem>
-          <TextListItem component="dd">
-            <Text>
-            <Text component={TextVariants.a} target="_blank" href='https://github.com/cryostatio/cryostat/issues'>Known Issues</Text>
-            &nbsp;|&nbsp;
-            <Text
-              component={TextVariants.a}
-              target="_blank"
-              href={`https://github.com/cryostatio/cryostat/issues/new?labels=user+report,bug&body=Affects+${cryostatVersion}`}
-            >
-              File a Report
-            </Text>
-            </Text>
-          </TextListItem>
-          <TextListItem component="dt">
-            Mailing List
-          </TextListItem>
-          <TextListItem component="dd">
-            <Text component={TextVariants.a} target="_blank" href='https://groups.google.com/g/cryostat-development'>Google Groups</Text>
-          </TextListItem>
-          <TextListItem component="dt">
-            Open Source License
-          </TextListItem>
-          <TextListItem component="dd">
-            <Text component={TextVariants.a} target="_blank" href='https://github.com/cryostatio/cryostat/blob/main/LICENSE'>License</Text>
-          </TextListItem>
-        </TextList>
-      </TextContent>
-    </AboutModal>
+    />
   </>);
 
   const isActiveRoute = (route: IAppRoute): boolean => {

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -143,11 +143,9 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   const handleCloseNotificationCenter = () => {
     setNotificationDrawerExpanded(false);
   };
-
   const handleAboutModalToggle = () => {
     setAboutModalOpen(!aboutModalOpen);
   };
-
   const HeaderTools = (<>
     <PageHeaderTools>
       <PageHeaderToolsGroup>
@@ -209,10 +207,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
       <NavList id="nav-list-simple">
         {routes.map((route, idx) => route.label && (
             <NavItem key={`${route.label}-${idx}`} id={`${route.label}-${idx}`} isActive={isActiveRoute(route)}>
-              <NavLink
-                exact to={route.path}
-                activeClassName="pf-m-current">{route.label}
-              </NavLink>
+              <NavLink exact to={route.path} activeClassName="pf-m-current">{route.label}</NavLink>
             </NavItem>
           ))}
       </NavList>

--- a/src/app/NotFound/NotFound.tsx
+++ b/src/app/NotFound/NotFound.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright The Cryostat Authors
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -164,7 +164,6 @@ const PageNotFound = ({ title }: { title: string }) => {
 const AppRoutes = () => {
   const context = React.useContext(ServiceContext);
   const [authenticated, setAuthenticated] = React.useState(false);
-  const location = useLocation();
 
   React.useEffect(() => {
     const sub = context.notificationChannel.isReady().subscribe((v) => setAuthenticated(v));

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -49,6 +49,8 @@ import { useDocumentTitle } from '@app/utils/useDocumentTitle';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
+import { AboutCryostatModal } from './AppLayout/AboutCryostatModal';
+
 
 let routeFocusTimer: number;
 
@@ -106,6 +108,13 @@ const routes: IAppRoute[] = [
     exact: true,
     path: '/settings',
     title: 'Settings',
+  },
+  {
+    component: AboutCryostatModal,
+    exact: true,
+    label: 'About',
+    path: '/about',
+    title: 'About Cryostat',
   },
 ];
 

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -49,7 +49,7 @@ import { useDocumentTitle } from '@app/utils/useDocumentTitle';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
 import { Route, RouteComponentProps, Switch, useLocation } from 'react-router-dom';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
-import { AboutCryostatModal } from './AppLayout/AboutCryostatModal';
+import { About } from './About/About';
 
 let routeFocusTimer: number;
 
@@ -110,7 +110,7 @@ const routes: IAppRoute[] = [
     title: 'Settings',
   },
   {
-    component: AboutCryostatModal,
+    component: About,
     exact: true,
     label: 'About',
     path: '/about',
@@ -165,7 +165,6 @@ const AppRoutes = () => {
   const context = React.useContext(ServiceContext);
   const [authenticated, setAuthenticated] = React.useState(false);
   const location = useLocation();
-  const modalBackground = location.state && location.state.modalBackground;
 
   React.useEffect(() => {
     const sub = context.notificationChannel.isReady().subscribe((v) => setAuthenticated(v));
@@ -178,7 +177,7 @@ const AppRoutes = () => {
 
   return (
     <LastLocationProvider>
-      <Switch location={modalBackground || location}>
+      <Switch>
         {authenticated ? (
           flatten(routes).map(({ path, exact, component, title, isAsync }, idx) => (
             <RouteWithTitleUpdates
@@ -195,21 +194,6 @@ const AppRoutes = () => {
         )}
         <PageNotFound title="404 Page Not Found" />
       </Switch>
-
-      {/* Renders the modal routes on top of the page components in the background */}
-      {modalBackground &&
-        flatten(routes)
-          .filter(({ isModal }) => isModal)
-          .map(({ exact, component, title, isAsync }, idx) => (
-            <RouteWithTitleUpdates
-              path={location.pathname}
-              exact={exact}
-              component={component}
-              key={idx}
-              title={title}
-              isAsync={isAsync}
-            />
-          ))}
     </LastLocationProvider>
   );
 };

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -47,7 +47,7 @@ import { SecurityPanel } from '@app/SecurityPanel/SecurityPanel';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useDocumentTitle } from '@app/utils/useDocumentTitle';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
-import { Route, RouteComponentProps, Switch, useLocation } from 'react-router-dom';
+import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
 import { About } from './About/About';
 
@@ -62,7 +62,6 @@ export interface IAppRoute {
   path: string;
   title: string;
   isAsync?: boolean;
-  isModal?: boolean;
   children?: IAppRoute[];
 }
 
@@ -114,8 +113,7 @@ const routes: IAppRoute[] = [
     exact: true,
     label: 'About',
     path: '/about',
-    title: 'About Cryostat',
-    isModal: true,
+    title: 'About',
   },
 ];
 


### PR DESCRIPTION
Fixes #266.

Would appreciate some suggestions to improve this design since my current approach causes the bug listed below.

1) In addition to the existing masthead help icon, clicking the "About" nav link on the PageSideBar will display the AboutModal. Unlike the other nav links, users can view the AboutModal by clicking the nav link without logging in.

2) The url http://localhost:9000/about allows users to view/copy a link to the AboutModal. Followed this example to create the modal route: https://reactrouter.com/web/example/modal-gallery
Note: The example only displays their modal when the route matches “/img/:id”. Since I wanted to display the modal on top of any page, the `RouteWithTitleUpdates``path` prop is set to `location.pathname`

Bug: if you open a new tab and enter http://localhost:9000/recordings/about, the `modalBackground` - which renders the previous web page content in the background - is undefined. The `<Switch>` will then render the `NotFound` page. If I instead replace the `RouteWithTitleUpdates``path` prop to `/about` on line 204 and comment lines 146-148 in `AppLayout`, the previous page content does not render in the background behind the modal.

![image](https://user-images.githubusercontent.com/84587295/134963598-520e54e2-44f7-4ff8-9310-4af4d4b1ec48.png)
