### PR TITLE
fix(login): do not re-attempt ws connection on auth fail

### DIFF
--- a/src/app/Login/Login.tsx
+++ b/src/app/Login/Login.tsx
@@ -46,16 +46,15 @@ import { Base64 } from 'js-base64';
 import { BasicAuthDescriptionText, BasicAuthForm } from './BasicAuthForm';
 import { BearerAuthDescriptionText, BearerAuthForm } from './BearerAuthForm';
 
-export const Login = (props) => {
+export const Login = () => {
   const serviceContext = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
 
   const [token, setToken] = React.useState('');
   const [authMethod, setAuthMethod] = React.useState('');
   const addSubscription = useSubscriptions();
-  const onLoginSuccess = props.onLoginSuccess;
 
-  const checkAuth = React.useCallback((token, authMethod, userSubmission = false) => {
+  const checkAuth = React.useCallback((token, authMethod, userSubmission) => {
     let tok = token;
     if (authMethod === 'Basic') {
       tok = Base64.encodeURL(token);
@@ -64,14 +63,12 @@ export const Login = (props) => {
       serviceContext.api.checkAuth(tok, authMethod)
       .pipe(first())
       .subscribe(v => {
-        if (v) {
-          onLoginSuccess();
-        } else if (userSubmission) {
+        if (!v && userSubmission) {
           notifications.danger('Authentication Failure', `${authMethod} authentication failed`);
         }
       })
     );
-  }, [serviceContext, serviceContext.api, addSubscription, onLoginSuccess, notifications, authMethod]);
+  }, [serviceContext, serviceContext.api, addSubscription, notifications, authMethod]);
 
   const handleSubmit = React.useCallback((evt, token, authMethod) => {
     setToken(token);
@@ -82,7 +79,7 @@ export const Login = (props) => {
 
   React.useEffect(() => {
     const sub = serviceContext.api.getAuthMethod().subscribe(setAuthMethod);
-    checkAuth('', 'Basic'); // check auth once at component load to query the server's auth method
+    checkAuth('', 'Basic', false); // check auth once at component load to query the server's auth method
     return () => sub.unsubscribe();
   }, [serviceContext, serviceContext.api, setAuthMethod, checkAuth]);
 
@@ -96,7 +93,7 @@ export const Login = (props) => {
         if (authMethod === 'Basic') {
           token = Base64.decode(token);
         }
-        checkAuth(token, authMethod);
+        checkAuth(token, authMethod, false);
     });
     return () => sub.unsubscribe();
   }, [serviceContext, serviceContext.api, checkAuth]);

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -133,19 +133,22 @@ export class NotificationChannel {
             closeObserver: {
               next: (evt) => {
                 let code: CloseStatus;
+                let msg: string | undefined = undefined;
                 switch (evt.code) {
                   case CloseStatus.PROTOCOL_FAILURE:
                     code = CloseStatus.PROTOCOL_FAILURE;
+                    msg = 'Authentication failed';
                     break;
                   case CloseStatus.INTERNAL_ERROR:
                     code = CloseStatus.INTERNAL_ERROR;
+                    msg = 'Internal server error';
                     break;
                   default:
                     code = CloseStatus.UNKNOWN;
                     break;
                 }
                 this._ready.next({ ready: false, code });
-                this.notifications.info('WebSocket connection lost', undefined, NotificationCategory.WsClientActivity);
+                this.notifications.info('WebSocket connection lost', msg, NotificationCategory.WsClientActivity);
               }
             }
           });

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -134,21 +134,25 @@ export class NotificationChannel {
               next: (evt) => {
                 let code: CloseStatus;
                 let msg: string | undefined = undefined;
+                let fn: Function;
                 switch (evt.code) {
                   case CloseStatus.PROTOCOL_FAILURE:
                     code = CloseStatus.PROTOCOL_FAILURE;
                     msg = 'Authentication failed';
+                    fn = this.notifications.danger;
                     break;
                   case CloseStatus.INTERNAL_ERROR:
                     code = CloseStatus.INTERNAL_ERROR;
                     msg = 'Internal server error';
+                    fn = this.notifications.danger;
                     break;
                   default:
                     code = CloseStatus.UNKNOWN;
+                    fn = this.notifications.info;
                     break;
                 }
                 this._ready.next({ ready: false, code });
-                this.notifications.info('WebSocket connection lost', msg, NotificationCategory.WsClientActivity);
+                fn.apply(this.notifications, ['WebSocket connection lost', msg, NotificationCategory.WsClientActivity]);
               }
             }
           });

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -132,7 +132,7 @@ export class NotificationChannel {
             },
             closeObserver: {
               next: (evt) => {
-                let code;
+                let code: CloseStatus;
                 switch (evt.code) {
                   case CloseStatus.PROTOCOL_FAILURE:
                     code = CloseStatus.PROTOCOL_FAILURE;

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -156,13 +156,9 @@ const AppRoutes = () => {
   const [authenticated, setAuthenticated] = React.useState(false);
 
   React.useEffect(() => {
-    const sub = context.notificationChannel.isReady().subscribe((v) => setAuthenticated(v));
+    const sub = context.notificationChannel.isReady().subscribe(setAuthenticated);
     return () => sub.unsubscribe();
   }, [context.notificationChannel, setAuthenticated]);
-
-  const handleAuthenticated = React.useCallback(() => {
-    setAuthenticated(true);
-  }, [setAuthenticated]);
 
   return (
     <LastLocationProvider>
@@ -179,7 +175,7 @@ const AppRoutes = () => {
             />
           ))
         ) : (
-          <Login onLoginSuccess={handleAuthenticated} />
+          <Login />
         )}
         <PageNotFound title="404 Page Not Found" />
       </Switch>

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -156,7 +156,7 @@ const AppRoutes = () => {
   const [authenticated, setAuthenticated] = React.useState(false);
 
   React.useEffect(() => {
-    const sub = context.notificationChannel.isReady().subscribe(setAuthenticated);
+    const sub = context.notificationChannel.isReady().subscribe(v => setAuthenticated(v.ready));
     return () => sub.unsubscribe();
   }, [context.notificationChannel, setAuthenticated]);
 


### PR DESCRIPTION
Fixes #300

Detect WebSocket connection rejection reason status code. If the code indicates that the connection was rejected/closed because the authenticating user has insufficient permissions, do not attempt automatic reconnections.

This should fix the looping problem described in cryostatio/cryostat#687 , where a full OpenShift reduced-permissions user account is set up. A possibly easier test case is to run this web-client using the typical devserver setup against a Cryostat smoketest.sh, but where the Cryostat image has been modified to reject WebSocket subprotocol authentication. I have prepared one such image that can be used like:

```
CRYOSTAT_IMAGE=quay.io/andrewazores/cryostat:fail-ws-subproto CRYOSTAT_AUTH_MANAGER=io.cryostat.net.BasicAuthManager CRYOSTAT_CORS_ORIGIN=http://localhost:9000 CRYOSTAT_DISABLE_SSL=true CRYOSTAT_DISABLE_JMX_AUTH=true sh smoketest.sh
```

This image will immediately fail all websocket connection attempts, reportedly due to a failed permissions check, but pass basic auth checks otherwise according to normal Cryostat basic auth.