### PR TITLE
fix(notifications): handle Error type messages

### DIFF
--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -46,7 +46,7 @@ export interface Notification {
   read?: boolean;
   key?: string;
   title: string;
-  message?: string;
+  message?: string | Error;
   category?: string;
   variant: AlertVariant;
   timestamp?: number;
@@ -63,6 +63,11 @@ export class Notifications {
     }
     notification.read = false;
     notification.timestamp = +Date.now();
+    if (notification.message instanceof Error) {
+      notification.message = JSON.stringify(notification.message, Object.getOwnPropertyNames(notification.message));
+    } else if (typeof notification.message !== 'string') {
+      notification.message = JSON.stringify(notification.message);
+    }
     this._notifications.unshift(notification);
     this._notifications$.next(this._notifications);
   }


### PR DESCRIPTION
Fixes #304

The root cause of the bug is that services and components may attempt to display a notification with an Error object as the message to display to the user. This fails because the rendered child component (content of the graphical notification) must be a string. This is a bit tricky because the Notification data type specifies that the message property should be a string, however many/most places where an Error object may be obtained it is typed as 'any', which breaks some of the TS compiler's type-checking guarantees at compile time. To work around this, I apply a simple fix to the notifications service: do a runtime check of the message type, and if it isn't an actual string, apply "JSON.stringify" to serialize it to a string before it is displayed.