### PR TITLE
fix(archiveuploads): display prompt on cancel or navigation

### DIFF
--- a/src/app/Recordings/ArchiveUploadModal.tsx
+++ b/src/app/Recordings/ArchiveUploadModal.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright The Cryostat Authors
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,10 +36,12 @@
  * SOFTWARE.
  */
 import * as React from 'react';
+import { Prompt } from 'react-router-dom';
 import { ActionGroup, Button, FileUpload, Form, FormGroup, Modal, ModalVariant } from '@patternfly/react-core';
 import { first, tap } from 'rxjs/operators';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { NotificationsContext } from '@app/Notifications/Notifications';
+import { CancelUploadModal } from './CancelUploadModal';
 
 export interface ArchiveUploadModalProps {
   visible: boolean;
@@ -53,44 +55,61 @@ export const ArchiveUploadModal: React.FunctionComponent<ArchiveUploadModalProps
   const [filename, setFilename] = React.useState('' as string | undefined);
   const [uploading, setUploading] = React.useState(false);
   const [rejected, setRejected] = React.useState(false);
+  const [showCancelPrompt, setShowCancelPrompt] = React.useState(false);
+  const [abort, setAbort] = React.useState(new AbortController());
 
-  const reset = () => {
+  const reset = React.useCallback(() => {
     setUploadFile(undefined);
     setFilename('');
     setUploading(false);
     setRejected(true);
-  };
+    setShowCancelPrompt(false);
+    setAbort(new AbortController());
+  }, [setUploadFile, setFilename, setUploading, setRejected, setShowCancelPrompt, setAbort]);
 
-  const handleFileChange = (file, filename) => {
+  const handleFileChange = React.useCallback((file, filename) => {
     setRejected(false);
     setUploadFile(file);
     setFilename(filename);
-  };
+    setShowCancelPrompt(false);
+  }, [setRejected, setUploadFile, setFilename, setShowCancelPrompt]);
 
-  const handleReject = () => {
+  const handleReject = React.useCallback(() => {
     setRejected(true);
-  };
+    setShowCancelPrompt(false);
+  }, [setRejected, setShowCancelPrompt]);
 
-  const handleClose = () => {
-    reset();
-    props.onClose();
-  };
+  const handleClose = React.useCallback(() => {
+    if (uploading) {
+      setShowCancelPrompt(true);
+    } else {
+      reset();
+      props.onClose();
+    }
+  }, [uploading, setShowCancelPrompt, reset]);
 
-  const handleSubmit = () => {
+  const handleSubmit = React.useCallback(() => {
     if (!uploadFile) {
       notifications.warning('Attempted to submit JFR upload without a file selected');
       return;
     }
     setUploading(true);
-    context.api.uploadRecording(uploadFile)
-      .pipe(
-        first(),
-        tap(() => setUploading(false)),
-      )
+    context.api.uploadRecording(uploadFile, abort.signal)
+      .pipe(first())
       .subscribe(handleClose, reset);
-  };
+  }, [context.api, notifications, setUploading, uploadFile, abort, handleClose, reset]);
 
-  return (
+  const handleAbort = React.useCallback(() => {
+    abort.abort();
+    reset();
+    props.onClose();
+  }, [abort, reset, handleClose]);
+
+  return (<>
+    <Prompt
+      when={uploading}
+      message="Are you sure you wish to cancel the file upload?"
+    />
     <Modal
       isOpen={props.visible}
       variant={ModalVariant.large}
@@ -99,6 +118,13 @@ export const ArchiveUploadModal: React.FunctionComponent<ArchiveUploadModalProps
       title="Re-Upload Archived Recording"
       description="Select a JDK Flight Recorder file to re-upload. Files must be .jfr binary format and follow the naming convention used by Cryostat when archiving recordings."
       >
+      <CancelUploadModal
+        visible={showCancelPrompt}
+        title="Upload in Progress"
+        message="Are you sure you wish to cancel the file upload?"
+        onYes={handleAbort}
+        onNo={() => setShowCancelPrompt(false)}
+      />
       <Form>
         <FormGroup
           label="JFR File"
@@ -125,5 +151,5 @@ export const ArchiveUploadModal: React.FunctionComponent<ArchiveUploadModalProps
         </ActionGroup>
       </Form>
     </Modal>
-  );
+  </>);
 };

--- a/src/app/Recordings/CancelUploadModal.tsx
+++ b/src/app/Recordings/CancelUploadModal.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import * as React from 'react';
+import { Button, Modal } from '@patternfly/react-core';
+
+export interface CancelUploadModalProps {
+    visible: boolean;
+    onYes: () => void;
+    onNo: () => void;
+    title: string;
+    message: string;
+}
+
+export const CancelUploadModal: React.FunctionComponent<CancelUploadModalProps> = (props) => {
+  return (
+    <Modal
+      width={'40%'}
+      isOpen={props.visible}
+      showClose={true}
+      onClose={props.onNo}
+      title={props.title}
+      actions={[
+        <Button variant="primary" onClick={props.onYes}>
+          Yes
+        </Button>,
+        <Button variant="secondary" onClick={props.onNo}>
+          No
+        </Button>
+      ]}
+    >
+      {props.message}
+    </Modal>
+  );
+}
+

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -395,21 +395,27 @@ export class ApiService {
     });
   }
 
-  uploadRecording(file: File): Observable<string> {
-    const body = new window.FormData(); // as multipart/form-data
-    body.append('recording', file);
-    return this.sendRequest('v1', 'recordings', {
-        method: 'POST',
-        body,
-      })
-      .pipe(
-        concatMap(resp => {
-          if (resp.ok) {
-            return from(resp.text());
-          }
-          throw resp.statusText;
-        }),
-      );
+  uploadRecording(file: File, signal?: AbortSignal): Observable<string> {
+    window.onbeforeunload = () => true;
+    return this.login.getHeaders().pipe(
+      concatMap(headers => {
+        const body = new window.FormData();
+        body.append('recording', file);
+        return fromFetch(`${this.login.authority}/api/v1/recordings`, {
+          credentials: 'include',
+          mode: 'cors',
+          method: 'POST',
+          body,
+          headers,
+          selector: response => response.text(),
+          signal,
+        });
+      }),
+      tap({
+        next: () => window.onbeforeunload = null,
+        error: () => window.onbeforeunload = null,
+      }),
+    );
   }
 
   uploadSSLCertificate(file: File): Observable<string> {
@@ -432,14 +438,14 @@ export class ApiService {
 
   private sendRequest(apiVersion: ApiVersion, path: string, config?: RequestInit): Observable<Response> {
     const req = () => this.login.getHeaders().pipe(
-      concatMap(headers =>
-        fromFetch(`${this.login.authority}/api/${apiVersion}/${path}`, {
+      concatMap(headers => {
+        return fromFetch(`${this.login.authority}/api/${apiVersion}/${path}`, {
           credentials: 'include',
           mode: 'cors',
           headers,
           ...config,
-        }),
-      ),
+        });
+      }),
       map(resp => {
         if (resp.ok) return resp;
         throw new HttpError(resp);


### PR DESCRIPTION
Fixes #331
Fixes #332

Displays a React dialog prompt when the user clicks the Cancel button during an active upload, and displays the browser's native prompt to confirm when the user tries to refresh or close the tab/window. Also uses an AbortController/AbortSignal to actually instruct the browser to stop the file upload request if the user does confirm they wish to cancel the upload.

To test, it's probably best to use the browser devtools' simulated request throttling during the upload, so that there is a reasonable human amount of reaction time to cancel the upload before it completes. If testing in podman the upload is likely to complete very quickly for small-ish JFR files otherwise. After cancelling the request, the devtools' Network tab should show that the request was stopped with less than the total JFR filesize transferred, and subsequent `GET /api/v1/recordings` requests should show that the uploaded file is not present in the archives.