### PR TITLE
feat(auth): Add OAuth logout

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -79,8 +79,6 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   const [notifications, setNotifications] = React.useState([] as Notification[]);
   const [unreadNotificationsCount, setUnreadNotificationsCount] = React.useState(0);
   const [errorNotificationsCount, setErrorNotificationsCount] = React.useState(0);
-  const [token, setToken] = React.useState("");
-  const [authMethod, setAuthMethod] = React.useState("");
   const location = useLocation();
 
   React.useEffect(() => {
@@ -161,18 +159,8 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   }, [serviceContext.target]);
 
   const handleLogout = React.useCallback(() => {
-      const sub = serviceContext.login.setLoggedOut(token, authMethod).subscribe();
+      const sub = serviceContext.login.setLoggedOut().subscribe();
       return () => sub.unsubscribe();
-  }, [serviceContext.login, token, authMethod]);
-
-  React.useEffect(() => {
-    combineLatest([serviceContext.login.getToken(), serviceContext.login.getAuthMethod()]).subscribe(
-    parts => {
-      const token = parts[0];
-      const method = parts[1];
-      setToken(token);
-      setAuthMethod(method);
-    });
   }, [serviceContext.login]);
 
   const handleUserInfoToggle = React.useCallback(() =>

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -53,6 +53,7 @@ import { SslErrorModal } from './SslErrorModal';
 import { AboutCryostatModal } from '@app/About/AboutCryostatModal';
 import cryostatLogoHorizontal from '@app/assets/logo-cryostat-3-horizontal.svg';
 import { SessionState } from '@app/Shared/Services/Login.service';
+import { combineLatest } from 'rxjs';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -78,6 +79,8 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
   const [notifications, setNotifications] = React.useState([] as Notification[]);
   const [unreadNotificationsCount, setUnreadNotificationsCount] = React.useState(0);
   const [errorNotificationsCount, setErrorNotificationsCount] = React.useState(0);
+  const [token, setToken] = React.useState("");
+  const [authMethod, setAuthMethod] = React.useState("");
   const location = useLocation();
 
   React.useEffect(() => {
@@ -157,9 +160,20 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
     return () => sub.unsubscribe();
   }, [serviceContext.target]);
 
-  const handleLogout = React.useCallback(() =>
-    serviceContext.login.setLoggedOut(),
-    [serviceContext.login]);
+  const handleLogout = React.useCallback(() => {
+      const sub = serviceContext.login.setLoggedOut(token, authMethod).subscribe();
+      return () => sub.unsubscribe();
+  }, [serviceContext.login, token, authMethod]);
+
+  React.useEffect(() => {
+    combineLatest([serviceContext.login.getToken(), serviceContext.login.getAuthMethod()]).subscribe(
+    parts => {
+      const token = parts[0];
+      const method = parts[1];
+      setToken(token);
+      setAuthMethod(method);
+    });
+  }, [serviceContext.login]);
 
   const handleUserInfoToggle = React.useCallback(() =>
     setShowUserInfoDropdown(v => !v),

--- a/src/app/Shared/Services/Login.service.tsx
+++ b/src/app/Shared/Services/Login.service.tsx
@@ -85,7 +85,7 @@ export class LoginService {
       });
   }
 
-  checkAuth(token: string, method: string, rememberMe = false): Observable<boolean> {
+  checkAuth(token: string, method: string, rememberMe = true): Observable<boolean> {
     token = Base64.encodeURL(token || this.getTokenFromUrlFragment());
     token = token || this.getCachedEncodedTokenIfAvailable();
 

--- a/src/app/Shared/Services/Login.service.tsx
+++ b/src/app/Shared/Services/Login.service.tsx
@@ -248,7 +248,7 @@ export class LoginService {
   }
 
   private navigateToLoginPage(): void {
-    window.location.replace(`${this.authority}`);
+    window.location.reload();
   }
 
   private getTokenFromUrlFragment(): string {

--- a/src/app/Shared/Services/Login.service.tsx
+++ b/src/app/Shared/Services/Login.service.tsx
@@ -211,6 +211,7 @@ export class LoginService {
             }
 
             return fromFetch(redirectUrl, {
+              credentials: 'include',
               mode: 'cors',
               method: 'POST',
               body: null,

--- a/src/app/Shared/Services/Login.service.tsx
+++ b/src/app/Shared/Services/Login.service.tsx
@@ -256,7 +256,7 @@ export class LoginService {
   private navigateToLoginPage(): void {
     this.authMethod.next(AuthMethod.UNKNOWN);
     this.removeCacheItem(this.AUTH_METHOD_KEY);
-    window.location.reload();
+    window.location.href = window.location.href.split('#')[0];
   }
 
   private getTokenFromUrlFragment(): string {

--- a/src/app/Shared/Services/Login.service.tsx
+++ b/src/app/Shared/Services/Login.service.tsx
@@ -60,6 +60,7 @@ export class LoginService {
 
   private readonly TOKEN_KEY: string = 'token';
   private readonly USER_KEY: string = 'user';
+  private readonly AUTH_METHOD_KEY: string = 'auth_method';
   private readonly token = new ReplaySubject<string>(1);
   private readonly authMethod = new ReplaySubject<AuthMethod>(1);
   private readonly logout = new ReplaySubject<void>(1);
@@ -75,6 +76,7 @@ export class LoginService {
     this.authority = apiAuthority;
     this.token.next(this.getCacheItem(this.TOKEN_KEY));
     this.username.next(this.getCacheItem(this.USER_KEY));
+    this.authMethod.next(this.getCacheItem(this.AUTH_METHOD_KEY) as AuthMethod);
     this.sessionState.next(SessionState.NO_USER_SESSION);
     this.queryAuthMethod();
   }
@@ -91,6 +93,10 @@ export class LoginService {
 
     if(this.hasBearerTokenUrlHash()) {
       method = AuthMethod.BEARER;
+    }
+
+    if(!method) {
+      method = this.getCacheItem(this.AUTH_METHOD_KEY);
     }
 
     return fromFetch(`${this.authority}/api/v2.1/auth`, {
@@ -248,6 +254,8 @@ export class LoginService {
   }
 
   private navigateToLoginPage(): void {
+    this.authMethod.next(AuthMethod.UNKNOWN);
+    this.removeCacheItem(this.AUTH_METHOD_KEY);
     window.location.reload();
   }
 
@@ -286,6 +294,7 @@ export class LoginService {
     }
 
     this.authMethod.next(validMethod);
+    this.setCacheItem(this.AUTH_METHOD_KEY, validMethod);
     this.authMethod.complete();
   }
 


### PR DESCRIPTION
Related https://github.com/cryostatio/cryostat/issues/717

In order to log out of the OAuth server, the frontend needs to make a POST request to the OAuth server's `/logout` endpoint, which removes the session cookie stored in the OAuth server. The backend will delete the access token and return the `/logout` url. Note that deleting the access token without removing the session cookie will cause the OAuth server to immediately login a user after logging out.

[OpenShift OAuth logout docs](https://docs.openshift.com/container-platform/4.9/authentication/managing-oauth-access-tokens.html#oauth-delete-tokens_managing-oauth-access-tokens)
[OpenShift OAuth endpoint for deleting access tokens](https://docs.openshift.com/container-platform/4.9/rest_api/oauth_apis/oauthaccesstoken-oauth-openshift-io-v1.html#oauthaccesstoken-oauth-openshift-io-v1)
[OpenShift console UI code explaining logout behaviour](https://github.com/openshift/console/blob/22c6951efe7c4bca87f3f934063b9f4dcb0a4058/frontend/public/module/auth.js#L90)