### PR TITLE
feat(targets): Add example JMX service url

### DIFF
--- a/src/app/TargetSelect/CreateTargetModal.tsx
+++ b/src/app/TargetSelect/CreateTargetModal.tsx
@@ -75,7 +75,7 @@ export const CreateTargetModal: React.FunctionComponent<CreateTargetModalProps> 
           label="Connection URL"
           isRequired
           fieldId="connect-url"
-          helperText="JMX Service URL"
+          helperText="JMX Service URL, e.g. service:jmx:rmi:///jndi/rmi://localhost:0/jmxrmi"
         >
           <TextInput
             value={connectUrl}


### PR DESCRIPTION
Fixes #347 

The accepted JMX service url format is now indicated in the helper text below the form input. I decided to use helper text instead of pre-filling the field with a default value to avoid the need for users to delete the default value before pasting their own url.