### PR TITLE
feat(notifications): service handles and displays all incoming WS messages

### DIFF
--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -48,7 +48,7 @@ export enum NotificationCategory {
   WsClientActivity = 'WsClientActivity',
   JvmDiscovery = 'TargetJvmDiscovery',
   ActiveRecordingCreated = 'ActiveRecordingCreated',
-  ActiveRecordingStopped = 'ActiveRecordingStopped',
+  ActiveRecordingStopped = 'RecordingStopped',
   ActiveRecordingSaved = 'ActiveRecordingSaved',
   ActiveRecordingDeleted = 'ActiveRecordingDeleted',
   ArchivedRecordingCreated = 'ArchivedRecordingCreated',

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -69,6 +69,12 @@ interface ReadyState {
 
 const messageKeys = new Map([
   [
+    // explicitly configure this category with a null mapper.
+    // This is a special case because we do not want to display an alert,
+    // the Targets.service already handles this
+    NotificationCategory.JvmDiscovery, null
+  ],
+  [
     NotificationCategory.WsClientActivity, {
       variant: AlertVariant.info,
       title: 'WebSocket Client Activity',
@@ -77,53 +83,53 @@ const messageKeys = new Map([
         const status = evt.message[addr];
         return `Client at ${addr} ${status}`
       }
-    } as NotificationMessageMap
+    } as NotificationMessageMapper
   ],
   [
     NotificationCategory.ActiveRecordingCreated, {
       variant: AlertVariant.success,
       title: 'Recording Created',
       body: evt => `${evt.message.recording} created in target: ${evt.message.target}`,
-    } as NotificationMessageMap
+    } as NotificationMessageMapper
   ],
   [
     NotificationCategory.ActiveRecordingStopped, {
       variant: AlertVariant.success,
       title: 'Recording Stopped',
       body: evt => `${evt.message.recording} was stopped`
-    } as NotificationMessageMap
+    } as NotificationMessageMapper
   ],
   [
     NotificationCategory.ActiveRecordingSaved, {
       variant: AlertVariant.success,
       title: 'Recording Saved',
       body: evt => `${evt.message.recording.name} was archived`
-    } as NotificationMessageMap
+    } as NotificationMessageMapper
   ],
   [
     NotificationCategory.ActiveRecordingDeleted, {
       variant: AlertVariant.success,
       title: 'Recording Deleted',
       body: evt => `${evt.message.recording} was deleted`
-    } as NotificationMessageMap
+    } as NotificationMessageMapper
   ],
   [
     NotificationCategory.ArchivedRecordingCreated, {
       variant: AlertVariant.success,
       title: 'Recording Archived',
       body: evt => `${evt.message.recording.name} was uploaded into archives`
-    } as NotificationMessageMap
+    } as NotificationMessageMapper
   ],
   [
     NotificationCategory.ActiveRecordingDeleted, {
       variant: AlertVariant.success,
       title: 'Recording Deleted',
       body: evt => `${evt.message.recording.name} was deleted`
-    } as NotificationMessageMap
+    } as NotificationMessageMapper
   ],
 ]);
 
-interface NotificationMessageMap {
+interface NotificationMessageMapper {
   title: string;
   body: (evt: NotificationMessage) => string;
   variant: AlertVariant;
@@ -140,6 +146,9 @@ export class NotificationChannel {
     private readonly login: LoginService
   ) {
     messageKeys.forEach((value, key) => {
+      if (!value) {
+        return;
+      }
       this.messages(key).subscribe((msg: NotificationMessage) => {
         const message = value.body.call(this, msg);
         notifications.notify({ title: value.title, message, category: key, variant: value.variant })

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -145,6 +145,21 @@ export class NotificationChannel {
         notifications.notify({ title: value.title, message, category: key, variant: value.variant })
       });
     });
+    this._messages.pipe(
+      filter(msg => !messageKeys.has(msg.meta.category as NotificationCategory))
+    ).subscribe(msg => {
+      const category = NotificationCategory[msg.meta.category as keyof typeof NotificationCategory];
+
+      var variant: AlertVariant;
+      if (category == NotificationCategory.WsClientActivity) {
+        variant = AlertVariant.info;
+      } else if (category == NotificationCategory.JvmDiscovery) {
+        variant = AlertVariant.info;
+      } else {
+        variant = AlertVariant.success;
+      }
+      notifications.notify({ title: msg.meta.category, message: msg.message, category, variant });
+    });
 
     const notificationsUrl = fromFetch(`${this.login.authority}/api/v1/notifications_url`)
       .pipe(

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -36,18 +36,13 @@
  * SOFTWARE.
  */
 import { Notifications } from '@app/Notifications/Notifications';
+import _ from 'lodash';
 import { BehaviorSubject, combineLatest, Observable, Subject, timer } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
+import { AlertVariant } from '@patternfly/react-core';
 import { concatMap, distinctUntilChanged, filter } from 'rxjs/operators';
-import * as _ from 'lodash';
 import { AuthMethod, LoginService, SessionState } from './Login.service';
-import { ArchivedRecording } from '@app/Shared/Services/Api.service';
-
-interface RecordingNotificationEvent {
-  recording: ArchivedRecording;
-  target: string;
-}
 
 export enum NotificationCategory {
   WsClientActivity = 'WsClientActivity',
@@ -72,6 +67,68 @@ interface ReadyState {
   code?: CloseStatus;
 }
 
+const messageKeys = new Map([
+  [
+    NotificationCategory.WsClientActivity, {
+      variant: AlertVariant.info,
+      title: 'WebSocket Client Activity',
+      body: evt => {
+        const addr = Object.keys(evt.message)[0];
+        const status = evt.message[addr];
+        return `Client at ${addr} ${status}`
+      }
+    } as NotificationMessageMap
+  ],
+  [
+    NotificationCategory.ActiveRecordingCreated, {
+      variant: AlertVariant.success,
+      title: 'Recording Created',
+      body: evt => `${evt.message.recording} created in target: ${evt.message.target}`,
+    } as NotificationMessageMap
+  ],
+  [
+    NotificationCategory.ActiveRecordingStopped, {
+      variant: AlertVariant.success,
+      title: 'Recording Stopped',
+      body: evt => `${evt.message.recording} was stopped`
+    } as NotificationMessageMap
+  ],
+  [
+    NotificationCategory.ActiveRecordingSaved, {
+      variant: AlertVariant.success,
+      title: 'Recording Saved',
+      body: evt => `${evt.message.recording.name} was archived`
+    } as NotificationMessageMap
+  ],
+  [
+    NotificationCategory.ActiveRecordingDeleted, {
+      variant: AlertVariant.success,
+      title: 'Recording Deleted',
+      body: evt => `${evt.message.recording} was deleted`
+    } as NotificationMessageMap
+  ],
+  [
+    NotificationCategory.ArchivedRecordingCreated, {
+      variant: AlertVariant.success,
+      title: 'Recording Archived',
+      body: evt => `${evt.message.recording.name} was uploaded into archives`
+    } as NotificationMessageMap
+  ],
+  [
+    NotificationCategory.ActiveRecordingDeleted, {
+      variant: AlertVariant.success,
+      title: 'Recording Deleted',
+      body: evt => `${evt.message.recording.name} was deleted`
+    } as NotificationMessageMap
+  ],
+]);
+
+interface NotificationMessageMap {
+  title: string;
+  body: (evt: NotificationMessage) => string;
+  variant: AlertVariant;
+}
+
 export class NotificationChannel {
 
   private ws: WebSocketSubject<any> | null = null;
@@ -82,40 +139,11 @@ export class NotificationChannel {
     private readonly notifications: Notifications,
     private readonly login: LoginService
   ) {
-    this.messages(NotificationCategory.WsClientActivity).subscribe(v => {
-      const addr = Object.keys(v.message)[0];
-      const status = v.message[addr];
-      notifications.info('WebSocket Client Activity', `Client at ${addr} ${status}`, NotificationCategory.WsClientActivity);
-    });
-
-    this.messages(NotificationCategory.ActiveRecordingCreated).subscribe(v => {
-      const event: RecordingNotificationEvent = v.message;
-      notifications.success('Recording Created', `${event.recording} created in target: ${event.target}`);
-    });
-
-    this.messages(NotificationCategory.ActiveRecordingStopped).subscribe(v => {
-      const event: RecordingNotificationEvent = v.message;
-      notifications.success('Recording Stopped', `${event.recording} was stopped`);
-    });
-
-    this.messages(NotificationCategory.ActiveRecordingSaved).subscribe(v => {
-      const event: RecordingNotificationEvent = v.message;
-      notifications.success('Recording Archived', `${event.recording.name} was archived`);
-    });
-
-    this.messages(NotificationCategory.ActiveRecordingDeleted).subscribe(v => {
-      const event: RecordingNotificationEvent = v.message;
-      notifications.success('Recording Deleted', `${event.recording} was deleted`);
-    });
-
-    this.messages(NotificationCategory.ArchivedRecordingCreated).subscribe(v => {
-      const event: RecordingNotificationEvent = v.message;
-      notifications.success('Recording Archived', `${event.recording.name} was uploaded into archives`);
-    });
-
-    this.messages(NotificationCategory.ArchivedRecordingDeleted).subscribe(v => {
-      const event: RecordingNotificationEvent = v.message;
-      notifications.success('Recording Deleted', `${event.recording.name} was deleted`);
+    messageKeys.forEach((value, key) => {
+      this.messages(key).subscribe((msg: NotificationMessage) => {
+        const message = value.body.call(this, msg);
+        notifications.notify({ title: value.title, message, category: key, variant: value.variant })
+      });
     });
 
     const notificationsUrl = fromFetch(`${this.login.authority}/api/v1/notifications_url`)

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -121,7 +121,7 @@ const messageKeys = new Map([
     } as NotificationMessageMapper
   ],
   [
-    NotificationCategory.ActiveRecordingDeleted, {
+    NotificationCategory.ArchivedRecordingDeleted, {
       variant: AlertVariant.success,
       title: 'Recording Deleted',
       body: evt => `${evt.message.recording.name} was deleted`

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -150,7 +150,7 @@ export class NotificationChannel {
         return;
       }
       this.messages(key).subscribe((msg: NotificationMessage) => {
-        const message = value.body.call(this, msg);
+        const message = value.body(msg);
         notifications.notify({ title: value.title, message, category: key, variant: value.variant })
       });
     });


### PR DESCRIPTION
Related to #349

This refactors the explicit notification handling in the `NotificationChannel`, extracting out some configuration objects into a `Map` to redefine the existing notifications handling for things like WebSocket client activity, or recording start/stop/archive/delete actions.

This is then further extended by adding handling for notifications that have a category not specified in the above configuration map. The client will still attempt to display these notifications, but the display will include the raw message category from the WebSocket notification message, and the notification body will simply be the body field of the notification message, without any further contextual information, and likely with JSON formatting tokens present. This is just a catch-all handler in case some backend message is emitted that no frontend support was specifically implemented for. Ideally, it should never actually be triggered, because all message types are accounted for with the customized configuration objects.