### PR TITLE
fix(notifications): add template notification handling

### DIFF
--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -133,14 +133,14 @@ const messageKeys = new Map([
     NotificationCategory.TemplateCreated, {
       variant: AlertVariant.success,
       title: 'Template Created',
-      body: evt => `${evt.message.template} was created`
+      body: evt => `${evt.message.template.name} was created`
     } as NotificationMessageMapper
   ],
   [
     NotificationCategory.TemplateDeleted, {
       variant: AlertVariant.success,
       title: 'Template Deleted',
-      body: evt => `${evt.message.template} was deleted`
+      body: evt => `${evt.message.template.name} was deleted`
     } as NotificationMessageMapper
   ],
 ]);

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -53,6 +53,8 @@ export enum NotificationCategory {
   ActiveRecordingDeleted = 'ActiveRecordingDeleted',
   ArchivedRecordingCreated = 'ArchivedRecordingCreated',
   ArchivedRecordingDeleted = 'ArchivedRecordingDeleted',
+  TemplateCreated = 'TemplateUploaded',
+  TemplateDeleted = 'TemplateDeleted',
 }
 
 export enum CloseStatus {
@@ -125,6 +127,20 @@ const messageKeys = new Map([
       variant: AlertVariant.success,
       title: 'Recording Deleted',
       body: evt => `${evt.message.recording.name} was deleted`
+    } as NotificationMessageMapper
+  ],
+  [
+    NotificationCategory.TemplateCreated, {
+      variant: AlertVariant.success,
+      title: 'Template Created',
+      body: evt => `${evt.message.template} was created`
+    } as NotificationMessageMapper
+  ],
+  [
+    NotificationCategory.TemplateDeleted, {
+      variant: AlertVariant.success,
+      title: 'Template Deleted',
+      body: evt => `${evt.message.template} was deleted`
     } as NotificationMessageMapper
   ],
 ]);


### PR DESCRIPTION
Fixes #349

Since #367 a notification is already shown when uploading or deleting event templates, but this PR adds a specific handler so that the notification is displayed with a nicely formatted title and message.