### PR TITLE
feat(recordings): Add metadata recording labels

### DIFF
--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -39,7 +39,7 @@ import * as React from 'react';
 import { NotificationsContext } from '@app/Notifications/Notifications';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { ActionGroup, Button, Checkbox, ExpandableSection, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, Split, SplitItem, Text, TextArea, TextInput, TextVariants, Tooltip, TooltipPosition, ValidatedOptions } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon, StroopwafelIcon } from '@patternfly/react-icons';
+import { HelpIcon, OutlinedQuestionCircleIcon, StroopwafelIcon } from '@patternfly/react-icons';
 import { useHistory } from 'react-router-dom';
 import { concatMap } from 'rxjs/operators';
 import { EventTemplate, TemplateType } from './CreateRecording';
@@ -239,7 +239,14 @@ export const CustomRecordingForm = (props) => {
         <FormGroup
           label="Labels"
           fieldId="labels"
-          helperText="Alphanumeric key value pairs. Keys must be unique. '.' and '-' accepted."
+          labelIcon={
+            <Tooltip
+              content={
+                <div>Alphanumeric key value pairs. Keys must be unique.'.' and '-' accepted.</div>
+              }>
+                <HelpIcon noVerticalAlign/>
+            </Tooltip>
+          }
         >
           <EditRecordingLabels labels={labels} setLabels={setLabels}/>
         </FormGroup>

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -238,7 +238,15 @@ export const CustomRecordingForm = (props) => {
           onChange={handleTemplateChange}
         />
       </FormGroup>
-      <EditRecordingLabels labels={labels} setLabels={setLabels}/>
+      <ExpandableSection toggleTextExpanded="Hide metadata options" toggleTextCollapsed="Show metadata options">
+        <FormGroup
+          label="Labels"
+          fieldId="labels"
+          helperText="Alphanumeric key value pairs. Keys must be unique. '.' and '-' accepted."
+        >
+          <EditRecordingLabels labels={labels} setLabels={setLabels}/>
+        </FormGroup>
+      </ExpandableSection>
       <ExpandableSection toggleTextExpanded="Hide advanced options" toggleTextCollapsed="Show advanced options">
         <Form>
           <Text component={TextVariants.small}>

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -104,15 +104,15 @@ export const CustomRecordingForm = (props) => {
   };
 
   const getFormattedLabels = () => {
-    let arr = [] as Map<string, string>[];
+    let obj = {};
   
       labels.forEach(l => { 
         if(!!l.key && !!l.value) {
-          arr[l.key] = l.value;
+          obj[l.key] = l.value;
         }
       });
 
-    return JSON.stringify(Object.entries(arr));
+    return obj;
   }
 
   const handleRecordingNameChange = (name) => {
@@ -170,7 +170,7 @@ export const CustomRecordingForm = (props) => {
       events: getEventString(),
       duration: continuous ? undefined : duration * (durationUnit/1000),
       options: options,
-      labels: getFormattedLabels()
+      metadata: { labels: getFormattedLabels() }
     }
     props.onSubmit(recordingAttributes);
   };

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -107,7 +107,9 @@ export const CustomRecordingForm = (props) => {
     let arr = [] as Map<string, string>[];
   
       labels.forEach(l => { 
-        arr[l.key] = l.value;
+        if(!!l.key && !!l.value) {
+          arr[l.key] = l.value;
+        }
       });
 
     return JSON.stringify(Object.entries(arr));
@@ -151,11 +153,13 @@ export const CustomRecordingForm = (props) => {
     if (nameValid !== ValidatedOptions.success) {
       notificationMessages.push(`Recording name ${recordingName} is invalid`);
     }
+
     if (notificationMessages.length > 0) {
       const message = notificationMessages.join('. ').trim() + '.';
       notifications.warning('Invalid form data', message);
       return;
     }
+
     const options: RecordingOptions = {
       toDisk: toDisk,
       maxAge: toDisk? continuous? maxAge * maxAgeUnits : undefined : undefined,
@@ -236,20 +240,7 @@ export const CustomRecordingForm = (props) => {
         />
       </FormGroup>
       <ExpandableSection toggleTextExpanded="Hide metadata options" toggleTextCollapsed="Show metadata options">
-        <FormGroup
-          label="Labels"
-          fieldId="labels"
-          labelIcon={
-            <Tooltip
-              content={
-                <div>Alphanumeric key value pairs. Keys must be unique.'.' and '-' accepted.</div>
-              }>
-                <HelpIcon noVerticalAlign/>
-            </Tooltip>
-          }
-        >
           <EditRecordingLabels labels={labels} setLabels={setLabels}/>
-        </FormGroup>
       </ExpandableSection>
       <ExpandableSection toggleTextExpanded="Hide advanced options" toggleTextCollapsed="Show advanced options">
         <Form>

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -39,13 +39,14 @@ import * as React from 'react';
 import { NotificationsContext } from '@app/Notifications/Notifications';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { ActionGroup, Button, Checkbox, ExpandableSection, Form, FormGroup, FormSelect, FormSelectOption, FormSelectOptionGroup, Split, SplitItem, Text, TextArea, TextInput, TextVariants, Tooltip, TooltipPosition, ValidatedOptions } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon, StroopwafelIcon } from '@patternfly/react-icons';
 import { useHistory } from 'react-router-dom';
 import { concatMap } from 'rxjs/operators';
 import { EventTemplate, TemplateType } from './CreateRecording';
 import { RecordingOptions, RecordingAttributes, ActiveRecording } from '@app/Shared/Services/Api.service';
 import { DurationPicker } from '@app/DurationPicker/DurationPicker';
 import { FormSelectTemplateSelector } from '../TemplateSelector/FormSelectTemplateSelector';
+import { EditRecordingLabels, RecordingLabel } from './EditRecordingLabels';
 
 export interface CustomRecordingFormProps {
   onSubmit: (recordingAttributes: RecordingAttributes) => void;
@@ -71,6 +72,7 @@ export const CustomRecordingForm = (props) => {
   const [maxSize, setMaxSize] = React.useState(0);
   const [maxSizeUnits, setMaxSizeUnits] = React.useState(1);
   const [toDisk, setToDisk] = React.useState(true);
+  const [labels, setLabels] = React.useState([{ key: '', value: '' } as RecordingLabel]);
 
   const handleContinuousChange = (checked, evt) => {
     setContinuous(evt.target.checked);
@@ -100,6 +102,19 @@ export const CustomRecordingForm = (props) => {
     }
     return str;
   };
+
+  const getFormattedLabels = () => {
+    let str = '';
+    labels.forEach((label, idx) => {
+      str += `${label.key}=${label.value}`;
+
+      if (idx !== labels.length - 1) {
+        str += `,`;
+      }
+    });
+
+    return str;
+  }
 
   const handleRecordingNameChange = (name) => {
     setNameValid(RecordingNamePattern.test(name) ? ValidatedOptions.success : ValidatedOptions.error);
@@ -153,7 +168,8 @@ export const CustomRecordingForm = (props) => {
       name: recordingName,
       events: getEventString(),
       duration: continuous ? undefined : duration * (durationUnit/1000),
-      options: options
+      options: options,
+      labels: getFormattedLabels()
     }
     props.onSubmit(recordingAttributes);
   };
@@ -222,6 +238,7 @@ export const CustomRecordingForm = (props) => {
           onChange={handleTemplateChange}
         />
       </FormGroup>
+      <EditRecordingLabels labels={labels} setLabels={setLabels}/>
       <ExpandableSection toggleTextExpanded="Hide advanced options" toggleTextCollapsed="Show advanced options">
         <Form>
           <Text component={TextVariants.small}>

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -72,7 +72,7 @@ export const CustomRecordingForm = (props) => {
   const [maxSize, setMaxSize] = React.useState(0);
   const [maxSizeUnits, setMaxSizeUnits] = React.useState(1);
   const [toDisk, setToDisk] = React.useState(true);
-  const [labels, setLabels] = React.useState([{ key: '', value: '' } as RecordingLabel]);
+  const [labels, setLabels] = React.useState([] as RecordingLabel[]);
 
   const handleContinuousChange = (checked, evt) => {
     setContinuous(evt.target.checked);

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -104,16 +104,13 @@ export const CustomRecordingForm = (props) => {
   };
 
   const getFormattedLabels = () => {
-    let str = '';
-    labels.forEach((label, idx) => {
-      str += `${label.key}=${label.value}`;
+    let arr = [] as Map<string, string>[];
+  
+      labels.forEach(l => { 
+        arr[l.key] = l.value;
+      });
 
-      if (idx !== labels.length - 1) {
-        str += `,`;
-      }
-    });
-
-    return str;
+    return JSON.stringify(Object.entries(arr));
   }
 
   const handleRecordingNameChange = (name) => {

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -37,7 +37,17 @@
  */
 import * as React from 'react';
 import { CloseIcon } from '@patternfly/react-icons';
-import { Button, ExpandableSection, FormGroup, Split, SplitItem, TextInput, ValidatedOptions } from '@patternfly/react-core';
+import {
+  Button,
+  ExpandableSection,
+  FormGroup,
+  Split,
+  SplitItem,
+  Text,
+  TextInput,
+  TextVariants,
+  ValidatedOptions,
+} from '@patternfly/react-core';
 
 export interface RecordingLabel {
   key: string;
@@ -46,7 +56,7 @@ export interface RecordingLabel {
 
 export const LabelPattern = /^[a-zA-Z0-9.-]+$/;
 
-export const EditRecordingLabels = ({labels, setLabels}) => {
+export const EditRecordingLabels = ({ labels, setLabels }) => {
   const [labelValid, setLabelValid] = React.useState(ValidatedOptions.default);
 
   // TODO enforce unique key names and non-null key/values
@@ -57,7 +67,6 @@ export const EditRecordingLabels = ({labels, setLabels}) => {
     updatedLabels[idx].key = key;
     setLabelValid(LabelPattern.test(key) ? ValidatedOptions.success : ValidatedOptions.error);
     setLabels(updatedLabels);
-    
   };
 
   const handleValueChange = (idx, val) => {
@@ -79,46 +88,56 @@ export const EditRecordingLabels = ({labels, setLabels}) => {
 
   return (
     <ExpandableSection toggleTextExpanded="Hide metadata options" toggleTextCollapsed="Show metadata options">
-      <FormGroup label="Labels" fieldId="labels" helperText="Alphanumeric key/value pairs. Keys must be unique. '.' and '-' accepted.">
+      <FormGroup
+        label="Labels"
+        fieldId="labels"
+        helperText="Alphanumeric key/value pairs ('.' and '-' accepted). Keys should be unique."
+      >
         <Button onClick={handleAddLabelButtonClick} variant="primary">
           Add Label
         </Button>
-        {labels.map((label, idx) => (
-          <Split hasGutter={true}>
-            <SplitItem isFilled>
+      </FormGroup>
+      {labels.map((label, idx) => (
+        <Split hasGutter={true}>
+          <SplitItem isFilled>
+            <FormGroup fieldId="label-key" helperText="Key">
               <TextInput
                 isRequired
                 type="text"
                 id="label-key-input"
                 name="label-key-input"
                 aria-describedby="label-key-input-helper"
+                aria-label="label key"
                 value={label.key}
                 onChange={(e) => handleKeyChange(idx, e)}
                 validated={labelValid}
               />
-            </SplitItem>
-            <SplitItem>
+            </FormGroup>
+          </SplitItem>
+          <SplitItem isFilled>
+            <FormGroup fieldId="label-key" helperText="Value">
               <TextInput
                 isRequired
                 type="text"
                 id="label-value-input"
                 name="label-value-input"
                 aria-describedby="label-value-input-helper"
+                aria-label="label value"
                 value={label.value}
                 onChange={(e) => handleValueChange(idx, e)}
                 validated={labelValid}
               />
-            </SplitItem>
-            <SplitItem>
-              <Button
-                onClick={() => handleDeleteLabelButtonClick(idx)}
-                variant="link"
-                icon={<CloseIcon color="gray" size="sm" />}
-              />
-            </SplitItem>
-          </Split>
-        ))}
-      </FormGroup>
+            </FormGroup>
+          </SplitItem>
+          <SplitItem>
+            <Button
+              onClick={() => handleDeleteLabelButtonClick(idx)}
+              variant="link"
+              icon={<CloseIcon color="gray" size="sm" />}
+            />
+          </SplitItem>
+        </Split>
+      ))}
     </ExpandableSection>
   );
 };

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -69,35 +69,35 @@ export const EditRecordingLabels = (props) => {
   const [validValues, setValidVals] = React.useState(Array(props.labels.size).fill(ValidatedOptions.default));
   const [patchFormValid, setPatchFormValid] = React.useState(ValidatedOptions.default);
 
-  const handleKeyChange = (idx, key) => {
+  const handleKeyChange = React.useCallback((idx, key) => {
     let updatedLabels = [...props.labels];
     updatedLabels[idx].key = key;
     const valid = validKeys;
     valid[idx] = LabelPattern.test(key) ? ValidatedOptions.success : ValidatedOptions.error;
     setValidKeys(valid);
     props.setLabels(updatedLabels);
-  };
+  }, [props.labels, props.setLabels]);
 
-  const handleValueChange = (idx, val) => {
+  const handleValueChange = React.useCallback((idx, val) => {
     let updatedLabels = [...props.labels];
     updatedLabels[idx].value = val;
     const valid = validValues;
     valid[idx] = LabelPattern.test(val) ? ValidatedOptions.success : ValidatedOptions.error;
     setValidVals(valid);
     props.setLabels(updatedLabels);
-  };
+  }, [props.labels, props.setLabels]);
 
-  const handleAddLabelButtonClick = () => {
+  const handleAddLabelButtonClick = React.useCallback(() => {
     props.setLabels([...props.labels, { key: "", value: "" } as RecordingLabel]);
-  };
+  }, [props.labels, props.setLabels]);
 
-  const handleDeleteLabelButtonClick = (idx) => {
+  const handleDeleteLabelButtonClick = React.useCallback((idx) => {
     let updatedLabels = [...props.labels];
     updatedLabels.splice(idx, 1);
     props.setLabels(updatedLabels);
-  };
+  }, [props.labels, props.setLabels]);
 
-  const validateAllLabels = () => {
+  const validateAllLabels = React.useCallback(() => {
     let updatedValidKeys = validKeys;
     let updatedValidVals = validValues;
     let keys = [] as string[];
@@ -124,7 +124,7 @@ export const EditRecordingLabels = (props) => {
     setPatchFormValid(isValid ? ValidatedOptions.success : ValidatedOptions.error);
 
     return isValid;
-  };
+  }, [props.labels]);
 
   return (
     <FormGroup
@@ -142,7 +142,7 @@ export const EditRecordingLabels = (props) => {
         Add Label
       </Button>
       {props.labels.map((label, idx) => (
-        <Split hasGutter key={`${label.key}-${idx}`}>
+        <Split hasGutter key={idx}>
           <SplitItem isFilled>
             <TextInput
               isRequired
@@ -175,6 +175,7 @@ export const EditRecordingLabels = (props) => {
             <Button
               onClick={() => handleDeleteLabelButtonClick(idx)}
               variant="link"
+              aria-label="remove label"
               icon={<CloseIcon color="gray" size="sm" />}
             />
           </SplitItem>

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -200,3 +200,13 @@ export const EditRecordingLabels = (props) => {
     </FormGroup>
   );
 };
+
+export const parseLabels = (jsonLabels) => {
+  if(!jsonLabels) return [];
+
+  const labels = JSON.parse(jsonLabels);
+  return Object.entries(labels).map(([k, v]) => {
+    let val = v as string[];
+    return {key: val[0], value: val[1]} as RecordingLabel;
+  });
+};

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -97,7 +97,7 @@ export const EditRecordingLabels = (props) => {
   };
 
   const handleSave = () => {
-    context.api.patchRecordingLabels(props.recordingName, props.labels);
+    context.api.patchRecordingLabels(props.recordingName, props.labels).subscribe(l => props.setLabels(l));
     props.showForm(false);
   };
 

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -38,96 +38,99 @@
 import * as React from 'react';
 import { CloseIcon } from '@patternfly/react-icons';
 import {
+  ActionGroup,
   Button,
-  ExpandableSection,
   FormGroup,
   Split,
   SplitItem,
   Text,
   TextInput,
-  TextVariants,
   ValidatedOptions,
 } from '@patternfly/react-core';
+import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface RecordingLabel {
   key: string;
   value: string;
 }
 
+export interface EditRecordingLabelsProps {
+  labels: RecordingLabel[];
+  setLabels: (labels: RecordingLabel[]) => void;
+  showSaveButton?: boolean;
+  showForm?: (showForm: boolean) => void;
+}
+
 export const LabelPattern = /^[a-zA-Z0-9.-]+$/;
 
-export const EditRecordingLabels = ({ labels, setLabels }) => {
+export const EditRecordingLabels = (props) => {
+  const context = React.useContext(ServiceContext);
   const [labelValid, setLabelValid] = React.useState(ValidatedOptions.default);
 
   // TODO enforce unique key names and non-null key/values
+  // Only highlight the one field causing the error
   // Add hover error message tooltip on exclamation mark
 
   const handleKeyChange = (idx, key) => {
-    let updatedLabels = [...labels];
+    let updatedLabels = [...props.labels];
     updatedLabels[idx].key = key;
     setLabelValid(LabelPattern.test(key) ? ValidatedOptions.success : ValidatedOptions.error);
-    setLabels(updatedLabels);
+    props.setLabels(updatedLabels);
   };
 
   const handleValueChange = (idx, val) => {
-    let updatedLabels = [...labels];
+    let updatedLabels = [...props.labels];
     updatedLabels[idx].value = val;
     setLabelValid(LabelPattern.test(val) ? ValidatedOptions.success : ValidatedOptions.error);
-    setLabels(updatedLabels);
+    props.setLabels(updatedLabels);
   };
 
   const handleAddLabelButtonClick = () => {
-    setLabels([...labels, { key: '', value: '' } as RecordingLabel]);
+    props.setLabels([...props.labels, { key: '', value: '' } as RecordingLabel]);
   };
 
   const handleDeleteLabelButtonClick = (idx) => {
-    let updatedLabels = [...labels];
+    let updatedLabels = [...props.labels];
     updatedLabels.splice(idx, 1);
-    setLabels(updatedLabels);
+    props.setLabels(updatedLabels);
+  };
+
+  const handleSave = () => {
+    context.api.patchRecordingLabels(props.labels);
   };
 
   return (
-    <ExpandableSection toggleTextExpanded="Hide metadata options" toggleTextCollapsed="Show metadata options">
-      <FormGroup
-        label="Labels"
-        fieldId="labels"
-        helperText="Alphanumeric key/value pairs ('.' and '-' accepted). Keys should be unique."
-      >
-        <Button onClick={handleAddLabelButtonClick} variant="primary">
-          Add Label
-        </Button>
-      </FormGroup>
-      {labels.map((label, idx) => (
+    <>
+      <Button onClick={handleAddLabelButtonClick} variant="primary">
+        Add Label
+      </Button>
+      {props.labels.map((label, idx) => (
         <Split hasGutter={true}>
           <SplitItem isFilled>
-            <FormGroup fieldId="label-key" helperText="Key">
-              <TextInput
-                isRequired
-                type="text"
-                id="label-key-input"
-                name="label-key-input"
-                aria-describedby="label-key-input-helper"
-                aria-label="label key"
-                value={label.key}
-                onChange={(e) => handleKeyChange(idx, e)}
-                validated={labelValid}
-              />
-            </FormGroup>
+            <TextInput
+              isRequired
+              type="text"
+              id="label-key-input"
+              name="label-key-input"
+              aria-describedby="label-key-input-helper"
+              aria-label="label key"
+              value={label.key}
+              onChange={(e) => handleKeyChange(idx, e)}
+              validated={labelValid}
+            />
           </SplitItem>
           <SplitItem isFilled>
-            <FormGroup fieldId="label-key" helperText="Value">
-              <TextInput
-                isRequired
-                type="text"
-                id="label-value-input"
-                name="label-value-input"
-                aria-describedby="label-value-input-helper"
-                aria-label="label value"
-                value={label.value}
-                onChange={(e) => handleValueChange(idx, e)}
-                validated={labelValid}
-              />
-            </FormGroup>
+            <TextInput
+              isRequired
+              type="text"
+              id="label-value-input"
+              name="label-value-input"
+              aria-describedby="label-value-input-helper"
+              aria-label="label value"
+              value={label.value}
+              onChange={(e) => handleValueChange(idx, e)}
+              validated={labelValid}
+            />
           </SplitItem>
           <SplitItem>
             <Button
@@ -138,6 +141,12 @@ export const EditRecordingLabels = ({ labels, setLabels }) => {
           </SplitItem>
         </Split>
       ))}
-    </ExpandableSection>
+      { props.showSaveButton &&
+      <ActionGroup>
+        <Button variant="primary" onClick={handleSave} isDisabled={labelValid !== ValidatedOptions.success}>Save</Button>
+        <Button variant="secondary" onClick={() => props.showForm(false)}>Cancel</Button>
+      </ActionGroup>
+      }
+  </>
   );
 };

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -57,9 +57,9 @@ export interface EditRecordingLabelsProps {
   labels: RecordingLabel[];
   setLabels: (labels: RecordingLabel[]) => void;
   usePatchForm?: boolean;
-  savedRecordingName?: string;
-  showForm?: (showForm: boolean) => void;
+  patchRecordingName?: string;
   onPatchSubmit?: () => void;
+  onPatchCancel?: () => void;
 }
 
 export const LabelPattern = /^[a-zA-Z0-9.-]+$/;
@@ -196,7 +196,7 @@ export const EditRecordingLabels = (props) => {
             </Button>
           </SplitItem>
           <SplitItem>
-            <Button variant="secondary" onClick={() => props.showForm(false)}>
+            <Button variant="secondary" onClick={() => props.onPatchCancel()}>
               Cancel
             </Button>
           </SplitItem>

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -58,6 +58,7 @@ export interface EditRecordingLabelsProps {
   labels: RecordingLabel[];
   setLabels: (labels: RecordingLabel[]) => void;
   showSaveButton?: boolean;
+  savedRecordingName?: string;
   showForm?: (showForm: boolean) => void;
 }
 
@@ -96,7 +97,8 @@ export const EditRecordingLabels = (props) => {
   };
 
   const handleSave = () => {
-    context.api.patchRecordingLabels(props.labels);
+    context.api.patchRecordingLabels(props.recordingName, props.labels);
+    props.showForm(false);
   };
 
   return (

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -124,7 +124,8 @@ export const EditRecordingLabels = (props) => {
               onChange={(e) => handleKeyChange(idx, e)}
               validated={labelValid}
             />
-          </SplitItem>
+            <Text>Key</Text>
+           </SplitItem>
           <SplitItem isFilled>
             <TextInput
               isRequired
@@ -137,6 +138,7 @@ export const EditRecordingLabels = (props) => {
               onChange={(e) => handleValueChange(idx, e)}
               validated={labelValid}
             />
+            <Text>Value</Text>
           </SplitItem>
           <SplitItem>
             <Button

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import * as React from 'react';
+import { CloseIcon } from '@patternfly/react-icons';
+import { Button, ExpandableSection, FormGroup, Split, SplitItem, TextInput, ValidatedOptions } from '@patternfly/react-core';
+
+export interface RecordingLabel {
+  key: string;
+  value: string;
+}
+
+export const LabelPattern = /^[a-zA-Z0-9.-]+$/;
+
+export const EditRecordingLabels = ({labels, setLabels}) => {
+  const [labelValid, setLabelValid] = React.useState(ValidatedOptions.default);
+
+  // TODO enforce unique key names and non-null key/values
+  // add hover error message tooltip thing
+
+  const handleKeyChange = (idx, key) => {
+    let updatedLabels = [...labels];
+    updatedLabels[idx].key = key;
+    setLabelValid(LabelPattern.test(key) ? ValidatedOptions.success : ValidatedOptions.error);
+    setLabels(updatedLabels);
+    
+  };
+
+  const handleValueChange = (idx, val) => {
+    let updatedLabels = [...labels];
+    updatedLabels[idx].value = val;
+    setLabelValid(LabelPattern.test(val) ? ValidatedOptions.success : ValidatedOptions.error);
+    setLabels(updatedLabels);
+  };
+
+  const handleAddLabelButtonClick = () => {
+    setLabels([...labels, { key: '', value: '' } as RecordingLabel]);
+  };
+
+  const handleDeleteLabelButtonClick = (idx) => {
+    let updatedLabels = [...labels];
+    updatedLabels.splice(idx, 1);
+    setLabels(updatedLabels);
+  };
+
+  return (
+    <ExpandableSection toggleTextExpanded="Hide metadata options" toggleTextCollapsed="Show metadata options">
+      <FormGroup label="Labels" fieldId="labels" helperText="Alphanumeric key/value pairs. Keys must be unique. '.' and '-' accepted.">
+        <Button onClick={handleAddLabelButtonClick} variant="primary">
+          Add Label
+        </Button>
+        {labels.map((label, idx) => (
+          <Split hasGutter={true}>
+            <SplitItem isFilled>
+              <TextInput
+                isRequired
+                type="text"
+                id="label-key-input"
+                name="label-key-input"
+                aria-describedby="label-key-input-helper"
+                value={label.key}
+                onChange={(e) => handleKeyChange(idx, e)}
+                validated={labelValid}
+              />
+            </SplitItem>
+            <SplitItem>
+              <TextInput
+                isRequired
+                type="text"
+                id="label-value-input"
+                name="label-value-input"
+                aria-describedby="label-value-input-helper"
+                value={label.value}
+                onChange={(e) => handleValueChange(idx, e)}
+                validated={labelValid}
+              />
+            </SplitItem>
+            <SplitItem>
+              <Button
+                onClick={() => handleDeleteLabelButtonClick(idx)}
+                variant="link"
+                icon={<CloseIcon color="gray" size="sm" />}
+              />
+            </SplitItem>
+          </Split>
+        ))}
+      </FormGroup>
+    </ExpandableSection>
+  );
+};

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -210,9 +210,7 @@ export const EditRecordingLabels = (props) => {
 export const parseLabels = (jsonLabels) => {
   if(!jsonLabels) return [];
 
-  const labels = JSON.parse(jsonLabels);
-  return Object.entries(labels).map(([k, v]) => {
-    let val = v as string[];
-    return {key: val[0], value: val[1]} as RecordingLabel;
+  return Object.entries(jsonLabels).map(([k, v]) => {
+    return {key: k, value: v} as RecordingLabel;
   });
 };

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { CloseIcon } from '@patternfly/react-icons';
+import { CloseIcon, PlusIcon } from '@patternfly/react-icons';
 import {
   ActionGroup,
   Button,
@@ -57,7 +57,7 @@ export interface RecordingLabel {
 export interface EditRecordingLabelsProps {
   labels: RecordingLabel[];
   setLabels: (labels: RecordingLabel[]) => void;
-  showSaveButton?: boolean;
+  usePatchForm?: boolean;
   savedRecordingName?: string;
   showForm?: (showForm: boolean) => void;
 }
@@ -103,11 +103,15 @@ export const EditRecordingLabels = (props) => {
 
   return (
     <>
-      <Button onClick={handleAddLabelButtonClick} variant="primary">
-        Add Label
-      </Button>
+      {props.usePatchForm ? (
+        <Button onClick={handleAddLabelButtonClick} variant="link" icon={<PlusIcon color="gray" size="sm" />} />
+      ) : (
+        <Button onClick={handleAddLabelButtonClick} variant="primary">
+          Add Label
+        </Button>
+      )}
       {props.labels.map((label, idx) => (
-        <Split hasGutter={true}>
+        <Split hasGutter>
           <SplitItem isFilled>
             <TextInput
               isRequired
@@ -143,12 +147,20 @@ export const EditRecordingLabels = (props) => {
           </SplitItem>
         </Split>
       ))}
-      { props.showSaveButton &&
-      <ActionGroup>
-        <Button variant="primary" onClick={handleSave} isDisabled={labelValid !== ValidatedOptions.success}>Save</Button>
-        <Button variant="secondary" onClick={() => props.showForm(false)}>Cancel</Button>
-      </ActionGroup>
-      }
-  </>
+      {props.usePatchForm && (
+        <Split hasGutter>
+          <SplitItem>
+            <Button variant="primary" onClick={handleSave} isDisabled={labelValid !== ValidatedOptions.success}>
+              Save
+            </Button>
+          </SplitItem>
+          <SplitItem>
+            <Button variant="secondary" onClick={() => props.showForm(false)}>
+              Cancel
+            </Button>
+          </SplitItem>
+        </Split>
+      )}
+    </>
   );
 };

--- a/src/app/CreateRecording/EditRecordingLabels.tsx
+++ b/src/app/CreateRecording/EditRecordingLabels.tsx
@@ -60,7 +60,7 @@ export const EditRecordingLabels = ({ labels, setLabels }) => {
   const [labelValid, setLabelValid] = React.useState(ValidatedOptions.default);
 
   // TODO enforce unique key names and non-null key/values
-  // add hover error message tooltip thing
+  // Add hover error message tooltip on exclamation mark
 
   const handleKeyChange = (idx, key) => {
     let updatedLabels = [...labels];

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -266,9 +266,22 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
       };
 
       const RecordingDuration = (props) => {
-        const str = props.duration === 0 ? 'Continuous' : `${props.duration / 1000}s`
+        const str = props.duration === 0 ? 'Continuous' : `${props.duration / 1000}s`;
         return (<span>{str}</span>);
       };
+
+      const formattedLabels = React.useMemo(() => {
+        const labels = JSON.parse(props.recording.labels);
+        return (
+          <>
+            {Object.entries(labels).map(([k, v]) => (
+              <Text>
+                {k}={v}
+              </Text>
+            ))}
+          </>
+        );
+      }, [props.recording.labels]);
 
       return (
         <Tr key={`${props.index}_parent`}>
@@ -302,13 +315,16 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
           <Td key={`active-table-row-${props.index}_5`} dataLabel={tableColumns[3]}>
             {props.recording.state}
           </Td>
+          <Td key={`active-table-row-${props.index}_6`} dataLabel={tableColumns[4]}>
+            {formattedLabels || '-'}
+          </Td>
           <RecordingActions
             index={props.index}
             recording={props.recording}
             uploadFn={() => context.api.uploadActiveRecordingToGrafana(props.recording.name)}
           />
         </Tr>
-      )
+      );
     }, [
       props.duration,
       props.index,
@@ -318,12 +334,13 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
       props.recording.startTime,
       props.recording.state,
       props.timeStr,
+      props.recording.labels,
       context.api,
       checkedIndices,
       handleCheck,
       handleToggle,
       isExpanded,
-      tableColumns
+      tableColumns,
     ]);
 
     const childRow = React.useMemo(() => {

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -45,7 +45,7 @@ import { Button, Checkbox, Text, Toolbar, ToolbarContent, ToolbarItem } from '@p
 import {  Tbody, Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
-import { combineLatest, forkJoin, Observable } from 'rxjs';
+import { combineLatest, forkJoin, Observable, of } from 'rxjs';
 import { concatMap, filter, first } from 'rxjs/operators';
 import { RecordingActions } from './RecordingActions';
 import { RecordingsTable } from './RecordingsTable';
@@ -323,6 +323,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
             index={props.index}
             recording={props.recording}
             uploadFn={() => context.api.uploadActiveRecordingToGrafana(props.recording.name)}
+            editMetadataFn={() => { return of(true)}}
           />
         </Tr>
       );

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -332,6 +332,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
                 labels={rowLabels} 
                 setLabels={setRowLabels} 
                 showSaveButton={editingMetadata} 
+                recordingName={props.recording.name}
                 showForm={setEditingMetadata}
               />
               : (formattedLabels || '-')

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -251,11 +251,11 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
     const parsedLabels = React.useMemo(() => {
       if(!props.recording.labels) return [];
 
-      console.log(props.recording.labels);
       const labels = JSON.parse(props.recording.labels);
-      return Object.entries(labels).map(([k, v]) => (
-           {key: k, value: v} as RecordingLabel
-          ));
+      return Object.entries(labels).map(([k, v]) => {
+        let val = v as string[];
+        return {key: val[0], value: val[1]} as RecordingLabel;
+      });
     }, [props.recording.labels]);
 
     const expandedRowId =`active-table-row-${props.recording.name}-${props.recording.startTime}-exp`;

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -268,14 +268,10 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
       handleRowCheck(checked, props.index);
     };
 
-    const handleSubmitLabelPatch = React.useMemo(() => {
-      if (!!!props.labels) {
-        return;
-      }
-
-      context.api.patchTargetRecordingLabels(props.recordingName, props.labels).subscribe((l) => props.setLabels(l));
-      props.showForm(false);
-    }, [props.recordingName, props.labels]);
+    const handleSubmitLabelPatch = () => {
+      context.api.patchTargetRecordingLabels(props.recording.name, rowLabels).subscribe((l) => props.setLabels(l));
+      setEditingMetadata(false);
+    };
 
     const parentRow = React.useMemo(() => {
       const ISOTime = (props) => {

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -72,6 +72,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
     'Start Time',
     'Duration',
     'State',
+    'Labels',
   ];
 
   const addSubscription = useSubscriptions();

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -276,7 +276,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
     };
 
     const handleSubmitLabelPatch = React.useCallback(() => {
-      context.api.patchTargetRecordingMetadata(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
+      context.api.postTargetRecordingMetadata(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
       setEditingMetadata(false);
     }, [props.recording.name, rowLabels, context, context.api, setEditingMetadata]);
 

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -334,7 +334,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
               <EditRecordingLabels 
                 labels={rowLabels} 
                 setLabels={setRowLabels} 
-                showSaveButton={editingMetadata} 
+                usePatchForm={editingMetadata} 
                 recordingName={props.recording.name}
                 showForm={setEditingMetadata}
               />

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -249,6 +249,9 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
 
   const RecordingRow = (props) => {
     const parsedLabels = React.useMemo(() => {
+      if(!props.recording.labels) return [];
+
+      console.log(props.recording.labels);
       const labels = JSON.parse(props.recording.labels);
       return Object.entries(labels).map(([k, v]) => (
            {key: k, value: v} as RecordingLabel

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -275,15 +275,15 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
       handleRowCheck(checked, props.index);
     };
 
-    const handleSubmitLabelPatch = () => {
+    const handleSubmitLabelPatch = React.useCallback(() => {
       context.api.patchTargetRecordingLabels(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
       setEditingMetadata(false);
-    };
+    }, [props.recording.name, rowLabels, context, context.api, setEditingMetadata]);
 
-    const handleCancelLabelPatch = () => {
+    const handleCancelLabelPatch = React.useCallback(() => {
       setRowLabels(parseLabels(props.recording.labels));
       setEditingMetadata(false);
-    }
+    }, [props.recording.labels, setRowLabels, setEditingMetadata]);
 
     const parentRow = React.useMemo(() => {
       const ISOTime = (props) => {

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -194,7 +194,8 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
   React.useEffect(() => {
     addSubscription(
       context.notificationChannel.messages(NotificationCategory.RecordingMetadataUpdated)
-        .subscribe(v => setRecordings(old => old.map(o => o.name == v.message.recordingName ? { ...o, labels: v.message.labels } : o)))
+        .subscribe(v => setRecordings(old => old.map(
+          o => o.name == v.message.recordingName ? { ...o, metadata: { labels: v.message.labels } } : o)))
     );
   }, [addSubscription, context, context.notificationChannel, setRecordings]);
 
@@ -256,8 +257,8 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
 
   const RecordingRow = (props) => {
     const parsedLabels = React.useMemo(() => {
-      return parseLabels(props.recording.labels);
-    }, [props.recording.labels]);
+      return parseLabels(props.recording.metadata.labels);
+    }, [props.recording.metadata.labels]);
 
     const expandedRowId =`active-table-row-${props.recording.name}-${props.recording.startTime}-exp`;
     const [rowLabels, setRowLabels] = React.useState(parsedLabels);
@@ -281,9 +282,9 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
     }, [props.recording.name, rowLabels, context, context.api, setEditingMetadata]);
 
     const handleCancelLabelPatch = React.useCallback(() => {
-      setRowLabels(parseLabels(props.recording.labels));
+      setRowLabels(parseLabels(props.recording.metadata.labels));
       setEditingMetadata(false);
-    }, [props.recording.labels, setRowLabels, setEditingMetadata]);
+    }, [props.recording.metadata.labels, setRowLabels, setEditingMetadata]);
 
     const parentRow = React.useMemo(() => {
       const ISOTime = (props) => {
@@ -363,7 +364,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
       props.recording.startTime,
       props.recording.state,
       props.timeStr,
-      props.recording.labels,
+      props.recording.metadata.labels,
       context.api,
       checkedIndices,
       handleCheck,

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -42,7 +42,7 @@ import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.s
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { useSubscriptions} from '@app/utils/useSubscriptions';
-import { Button, Checkbox, Text, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import { Button, Checkbox, Label, Text, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 import {  Tbody, Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
@@ -338,11 +338,12 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
                 onPatchSubmit={handleSubmitLabelPatch}
                 onPatchCancel={handleCancelLabelPatch}
               />
-              : rowLabels.map(l => (
-                <Text>
-                  {l.key}={l.value}
-                </Text>
-              ))
+              : rowLabels.length ? rowLabels.map(l => (
+                <Label color="grey">
+                  {`${l.key}: ${l.value}`}
+                </Label>
+                ))
+              : <Text>-</Text>
             }
           </Td>
           <RecordingActions

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -276,7 +276,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
     };
 
     const handleSubmitLabelPatch = React.useCallback(() => {
-      context.api.patchTargetRecordingLabels(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
+      context.api.patchTargetRecordingMetadata(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
       setEditingMetadata(false);
     }, [props.recording.name, rowLabels, context, context.api, setEditingMetadata]);
 

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -40,7 +40,7 @@ import { ArchivedRecording } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { Button, Checkbox, Text, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { Button, Checkbox, Label, Text, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import { Tbody, Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { RecordingActions } from './RecordingActions';
 import { RecordingsTable } from './RecordingsTable';
@@ -215,16 +215,17 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
               <EditRecordingLabels 
                 labels={rowLabels} 
                 setLabels={setRowLabels} 
-                usePatchForm={editingMetadata} 
-                patchRecordingName={props.recording.name}
+                usePatchForm={editingMetadata}
+                patchRecordingName={props.recording.name} 
                 onPatchSubmit={handleSubmitLabelPatch}
                 onPatchCancel={handleCancelLabelPatch}
               />
-              : rowLabels.map(l => (
-                <Text>
-                  {l.key}={l.value}
-                </Text>
-              ))
+              : rowLabels.length ? rowLabels.map(l => (
+                <Label color="grey">
+                  {`${l.key}: ${l.value}`}
+                </Label>
+                ))
+              : <Text>-</Text>
             }
           </Td>
           <RecordingActions

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -176,15 +176,15 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
       handleRowCheck(checked, props.index);
     };
 
-    const handleSubmitLabelPatch = () => {
+    const handleSubmitLabelPatch = React.useCallback(() => {
       context.api.patchRecordingLabels(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
       setEditingMetadata(false);
-    };
+    }, [props.recording.name, rowLabels, context, context.api, setEditingMetadata]);
 
-    const handleCancelLabelPatch = () => {
+    const handleCancelLabelPatch = React.useCallback(() => {
       setRowLabels(parseLabels(props.recording.labels));
       setEditingMetadata(false);
-    }
+    }, [props.recording.labels, setRowLabels, setEditingMetadata]);
 
     const parentRow = React.useMemo(() => {
       return(

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -168,14 +168,10 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
       handleRowCheck(checked, props.index);
     };
 
-    const handleSubmitLabelPatch = React.useMemo(() => {
-      if (!!!props.labels) {
-        return;
-      }
-
-      context.api.patchRecordingLabels(props.recordingName, props.labels).subscribe((l) => props.setLabels(l));
-      props.showForm(false);
-  }, [props.recordingName, props.labels]);
+    const handleSubmitLabelPatch = () => {
+      context.api.patchRecordingLabels(props.recording.name, rowLabels).subscribe((l) => props.setLabels(l));
+      setEditingMetadata(false);
+    };
 
     const parentRow = React.useMemo(() => {
       return(

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -45,7 +45,7 @@ import { Tbody, Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
 import { RecordingActions } from './RecordingActions';
 import { RecordingsTable } from './RecordingsTable';
 import { ReportFrame } from './ReportFrame';
-import { Observable, forkJoin, merge } from 'rxjs';
+import { Observable, forkJoin, merge, of } from 'rxjs';
 import { first } from 'rxjs/operators';
 import { PlusIcon } from '@patternfly/react-icons';
 import { ArchiveUploadModal } from './ArchiveUploadModal';
@@ -188,6 +188,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
             recording={props.recording}
             index={props.index}
             uploadFn={() => context.api.uploadArchivedRecordingToGrafana(props.recording.name)}
+            editMetadataFn={() => { return of(true)}}
           />
         </Tr>
       );

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -119,6 +119,14 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
     )
   }, [addSubscription, context, context.notificationChannel, setRecordings]);
 
+  React.useEffect(() => {
+    addSubscription(
+      context.notificationChannel.messages(NotificationCategory.RecordingMetadataUpdated)
+        .subscribe(v => setRecordings(old => old.map(o => o.name == v.message.recordingName ? { ...o, labels: v.message.labels } : o)))
+    );
+  }, [addSubscription, context, context.notificationChannel, setRecordings]);
+
+
   const handleDeleteRecordings = () => {
     const tasks: Observable<any>[] = [];
     recordings.forEach((r: ArchivedRecording, idx) => {
@@ -169,9 +177,14 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
     };
 
     const handleSubmitLabelPatch = () => {
-      context.api.patchRecordingLabels(props.recording.name, rowLabels).subscribe((l) => props.setLabels(l));
+      context.api.patchRecordingLabels(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
       setEditingMetadata(false);
     };
+
+    const handleCancelLabelPatch = () => {
+      setRowLabels(parseLabels(props.recording.labels));
+      setEditingMetadata(false);
+    }
 
     const parentRow = React.useMemo(() => {
       return(
@@ -203,9 +216,9 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
                 labels={rowLabels} 
                 setLabels={setRowLabels} 
                 usePatchForm={editingMetadata} 
-                recordingName={props.recording.name}
-                showForm={setEditingMetadata}
+                patchRecordingName={props.recording.name}
                 onPatchSubmit={handleSubmitLabelPatch}
+                onPatchCancel={handleCancelLabelPatch}
               />
               : rowLabels.map(l => (
                 <Text>

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -177,7 +177,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
     };
 
     const handleSubmitLabelPatch = React.useCallback(() => {
-      context.api.patchRecordingLabels(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
+      context.api.patchRecordingMetadata(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
       setEditingMetadata(false);
     }, [props.recording.name, rowLabels, context, context.api, setEditingMetadata]);
 

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -177,7 +177,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
     };
 
     const handleSubmitLabelPatch = React.useCallback(() => {
-      context.api.patchRecordingMetadata(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
+      context.api.postRecordingMetadata(props.recording.name, rowLabels).subscribe(() => {} /* do nothing */);
       setEditingMetadata(false);
     }, [props.recording.name, rowLabels, context, context.api, setEditingMetadata]);
 

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -122,7 +122,8 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
   React.useEffect(() => {
     addSubscription(
       context.notificationChannel.messages(NotificationCategory.RecordingMetadataUpdated)
-        .subscribe(v => setRecordings(old => old.map(o => o.name == v.message.recordingName ? { ...o, labels: v.message.labels } : o)))
+        .subscribe(v => setRecordings(old => old.map(
+          o => o.name == v.message.recordingName ? { ...o, metadata: { labels: v.message.labels } } : o)))
     );
   }, [addSubscription, context, context.notificationChannel, setRecordings]);
 
@@ -158,8 +159,8 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
 
   const RecordingRow = (props) => {
     const parsedLabels = React.useMemo(() => {
-      return parseLabels(props.recording.labels);
-    }, [props.recording.labels]);
+      return parseLabels(props.recording.metadata.labels);
+    }, [props.recording.metadata.labels]);
 
     const expandedRowId =`archived-table-row-${props.index}-exp`;
     const handleToggle = () => {
@@ -182,9 +183,9 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
     }, [props.recording.name, rowLabels, context, context.api, setEditingMetadata]);
 
     const handleCancelLabelPatch = React.useCallback(() => {
-      setRowLabels(parseLabels(props.recording.labels));
+      setRowLabels(parseLabels(props.recording.metadata.labels));
       setEditingMetadata(false);
-    }, [props.recording.labels, setRowLabels, setEditingMetadata]);
+    }, [props.recording.metadata.labels, setRowLabels, setEditingMetadata]);
 
     const parentRow = React.useMemo(() => {
       return(
@@ -236,7 +237,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
           />
         </Tr>
       );
-    }, [props.recording, props.recording.labels, props.recording.name, props.index, handleCheck, checkedIndices, isExpanded, handleToggle, tableColumns, context.api]);
+    }, [props.recording, props.recording.metadata.labels, props.recording.name, props.index, handleCheck, checkedIndices, isExpanded, handleToggle, tableColumns, context.api]);
 
     const childRow = React.useMemo(() => {
       return (

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -83,10 +83,6 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
     context.api.downloadRecording(props.recording);
   }, [context.api, props.recording]);
 
-  const handleEditMetadata = React.useCallback(() => {
-    props.editMetadataFn()
-  }, [context.api, props.recording]);
-
   const handleViewReport = React.useCallback(() => {
     context.api.downloadReport(props.recording);
   }, [context.api, props.recording]);
@@ -99,7 +95,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
       },
       {
         title: "Edit Metadata",
-        onClick: handleEditMetadata
+        onClick: props.editMetadataFn
       },
       {
         title: "View Report ...",

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -48,7 +48,7 @@ export interface RecordingActionsProps {
   index: number;
   recording: ActiveRecording;
   uploadFn: () => Observable<boolean>;
-  editMetadataFn: () => Observable<boolean>;
+  editMetadataFn: () => void;
 }
 
 export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = (props) => {
@@ -85,12 +85,6 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
 
   const handleEditMetadata = React.useCallback(() => {
     props.editMetadataFn()
-    .pipe(first())
-      .subscribe(success => {
-        if (success) {
-          notifications.success('Metadata Updated', `Metadata for "${props.recording.name}" updated`);
-        }
-      });
   }, [context.api, props.recording]);
 
   const handleViewReport = React.useCallback(() => {

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -48,6 +48,7 @@ export interface RecordingActionsProps {
   index: number;
   recording: ActiveRecording;
   uploadFn: () => Observable<boolean>;
+  editMetadataFn: () => Observable<boolean>;
 }
 
 export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = (props) => {
@@ -82,6 +83,16 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
     context.api.downloadRecording(props.recording);
   }, [context.api, props.recording]);
 
+  const handleEditMetadata = React.useCallback(() => {
+    props.editMetadataFn()
+    .pipe(first())
+      .subscribe(success => {
+        if (success) {
+          notifications.success('Metadata Updated', `Metadata for "${props.recording.name}" updated`);
+        }
+      });
+  }, [context.api, props.recording]);
+
   const handleViewReport = React.useCallback(() => {
     context.api.downloadReport(props.recording);
   }, [context.api, props.recording]);
@@ -91,6 +102,10 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
       {
         title: "Download Recording",
         onClick: handleDownloadRecording
+      },
+      {
+        title: "Edit Metadata",
+        onClick: handleEditMetadata
       },
       {
         title: "View Report ...",

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -503,8 +503,16 @@ export class ApiService {
 
   patchRecordingLabels(recordingName: string, labels: RecordingLabel[]): Observable<boolean> {
     const form = new window.FormData();
+    let arr = [] as Map<string, string>[];
+  
+      labels.forEach(l => { 
+        arr[l.key] = l.value;
+      });
+
+    const stringLabels = JSON.stringify(Object.entries(arr));
+
     form.append('recordingName', recordingName);
-    form.append('labels', JSON.stringify(labels));
+    form.append('labels', stringLabels);
 
     return this.target.target().pipe(concatMap(target =>
         this.sendRequest(

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -501,7 +501,7 @@ export class ApiService {
     );
   }
 
-  patchRecordingLabels(recordingName: string, labels: RecordingLabel[]): Observable<boolean> {
+  patchRecordingLabels(recordingName: string, labels: RecordingLabel[]): Observable<string> {
     const form = new window.FormData();
     let arr = [] as Map<string, string>[];
   
@@ -511,19 +511,22 @@ export class ApiService {
 
     const stringLabels = JSON.stringify(Object.entries(arr));
 
-    form.append('recordingName', recordingName);
     form.append('labels', stringLabels);
 
     return this.target.target().pipe(concatMap(target =>
         this.sendRequest(
-          'v1', `targets/${encodeURIComponent(target.connectUrl)}/recordings/${encodeURIComponent(recordingName)}`,
+          'v2.1', `targets/${encodeURIComponent(target.connectUrl)}/recordings/${encodeURIComponent(recordingName)}`,
           {
             method: 'PATCH',
             body: form,
           }
         ).pipe(
-          map(resp => resp.ok),
-          first(),
+          concatMap(resp => {
+            if (resp.ok) {
+            return from(resp.text());
+          }
+          throw resp.text();
+          })        
         )
       ));
   }

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -232,6 +232,9 @@ export class ApiService {
         form.append('maxSize', String(recordingAttributes.options.maxSize));
       }
     }
+    if (!!recordingAttributes.labels) {
+      form.append('labels', JSON.stringify(recordingAttributes.labels));
+    }
 
     return this.target.target().pipe(concatMap(target =>
       this.sendRequest('v1', `targets/${encodeURIComponent(target.connectUrl)}/recordings`, {
@@ -615,4 +618,5 @@ export interface RecordingAttributes {
   events: string;
   duration?: number;
   options?: RecordingOptions;
+  labels?: string;
 }

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -501,9 +501,9 @@ export class ApiService {
     );
   }
 
-  patchRecordingLabels(recordingName: string, labels: RecordingLabel[]): Observable<string> {
+  patchRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
     return this.sendRequest(
-      'v2.1', `recordings/${encodeURIComponent(recordingName)}/labels`,
+      'beta', `recordings/${encodeURIComponent(recordingName)}/metadata`,
       {
         method: 'PATCH',
         body: this.stringifyRecordingLabels(labels),
@@ -518,10 +518,10 @@ export class ApiService {
     );
   }
 
-  patchTargetRecordingLabels(recordingName: string, labels: RecordingLabel[]): Observable<string> {
+  patchTargetRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
     return this.target.target().pipe(concatMap(target =>
         this.sendRequest(
-          'v2.1', `targets/${encodeURIComponent(target.connectUrl)}/recordings/${encodeURIComponent(recordingName)}/labels`,
+          'beta', `targets/${encodeURIComponent(target.connectUrl)}/recordings/${encodeURIComponent(recordingName)}/metadata`,
           {
             method: 'PATCH',
             body: this.stringifyRecordingLabels(labels),
@@ -621,7 +621,7 @@ export interface ArchivedRecording {
   name: string;
   downloadUrl: string;
   reportUrl: string;
-  labels: string;
+  labels: Object;
 }
 
 export interface ActiveRecording extends ArchivedRecording {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -502,13 +502,11 @@ export class ApiService {
   }
 
   patchRecordingLabels(recordingName: string, labels: RecordingLabel[]): Observable<string> {
-    const form = this.createLabelsPatchForm(labels);
-
     return this.sendRequest(
       'v2.1', `recordings/${encodeURIComponent(recordingName)}/labels`,
       {
         method: 'PATCH',
-        body: form,
+        body: this.stringifyRecordingLabels(labels),
       }
     ).pipe(
       concatMap(resp => {
@@ -521,14 +519,12 @@ export class ApiService {
   }
 
   patchTargetRecordingLabels(recordingName: string, labels: RecordingLabel[]): Observable<string> {
-    const form = this.createLabelsPatchForm(labels);
-
     return this.target.target().pipe(concatMap(target =>
         this.sendRequest(
           'v2.1', `targets/${encodeURIComponent(target.connectUrl)}/recordings/${encodeURIComponent(recordingName)}/labels`,
           {
             method: 'PATCH',
-            body: form,
+            body: this.stringifyRecordingLabels(labels),
           }
         ).pipe(
           concatMap(resp => {
@@ -595,15 +591,12 @@ export class ApiService {
     throw error;
   }
 
-  private createLabelsPatchForm(labels: RecordingLabel[]) {
-    const form = new window.FormData();
+  private stringifyRecordingLabels(labels: RecordingLabel[]): string {
     let arr = [] as Map<string, string>[];
     labels.forEach(l => { 
       arr[l.key] = l.value;
     });
-    const stringLabels = JSON.stringify(Object.entries(arr));
-    form.append('labels', stringLabels);
-    return form;
+    return JSON.stringify(Object.entries(arr));
   }
 
 }

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -621,7 +621,7 @@ export interface ArchivedRecording {
   name: string;
   downloadUrl: string;
   reportUrl: string;
-  labels: Object;
+  metadata: Metadata;
 }
 
 export interface ActiveRecording extends ArchivedRecording {
@@ -665,4 +665,8 @@ export interface RecordingAttributes {
   duration?: number;
   options?: RecordingOptions;
   labels?: string;
+}
+
+export interface Metadata {
+  labels: Object;
 }

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -500,6 +500,11 @@ export class ApiService {
     );
   }
 
+  patchRecordingLabels(labels: RecordingLabel[]): Observable<boolean> {
+    // TODO make PUT request when backend completed
+    return of(true);
+  }
+
   private sendRequest(apiVersion: ApiVersion, path: string, config?: RequestInit): Observable<Response> {
     const req = () => this.login.getHeaders().pipe(
       concatMap(headers => {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -233,7 +233,7 @@ export class ApiService {
       }
     }
     if (!!recordingAttributes.labels) {
-      form.append('labels', JSON.stringify(recordingAttributes.labels));
+      form.append('labels', recordingAttributes.labels);
     }
 
     return this.target.target().pipe(concatMap(target =>

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -501,11 +501,11 @@ export class ApiService {
     );
   }
 
-  patchRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
+  postRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
     return this.sendRequest(
-      'beta', `recordings/${encodeURIComponent(recordingName)}/metadata`,
+      'beta', `recordings/${encodeURIComponent(recordingName)}/metadata/labels`,
       {
-        method: 'PATCH',
+        method: 'POST',
         body: this.stringifyRecordingLabels(labels),
       }
     ).pipe(
@@ -518,12 +518,12 @@ export class ApiService {
     );
   }
 
-  patchTargetRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
+  postTargetRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
     return this.target.target().pipe(concatMap(target =>
         this.sendRequest(
-          'beta', `targets/${encodeURIComponent(target.connectUrl)}/recordings/${encodeURIComponent(recordingName)}/metadata`,
+          'beta', `targets/${encodeURIComponent(target.connectUrl)}/recordings/${encodeURIComponent(recordingName)}/metadata/labels`,
           {
-            method: 'PATCH',
+            method: 'POST',
             body: this.stringifyRecordingLabels(labels),
           }
         ).pipe(

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -587,6 +587,7 @@ export interface ActiveRecording extends ArchivedRecording {
   toDisk: boolean;
   maxSize: number;
   maxAge: number;
+  labels: string;
 }
 
 export enum RecordingState {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -233,8 +233,8 @@ export class ApiService {
         form.append('maxSize', String(recordingAttributes.options.maxSize));
       }
     }
-    if (!!recordingAttributes.labels) {
-      form.append('labels', recordingAttributes.labels);
+    if (!!recordingAttributes.metadata) {
+      form.append('metadata', JSON.stringify(recordingAttributes.metadata));
     }
 
     return this.target.target().pipe(concatMap(target =>
@@ -664,7 +664,7 @@ export interface RecordingAttributes {
   events: string;
   duration?: number;
   options?: RecordingOptions;
-  labels?: string;
+  metadata?: Metadata;
 }
 
 export interface Metadata {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -621,6 +621,7 @@ export interface ArchivedRecording {
   name: string;
   downloadUrl: string;
   reportUrl: string;
+  labels: string;
 }
 
 export interface ActiveRecording extends ArchivedRecording {
@@ -632,7 +633,6 @@ export interface ActiveRecording extends ArchivedRecording {
   toDisk: boolean;
   maxSize: number;
   maxAge: number;
-  labels: string;
 }
 
 export enum RecordingState {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -42,6 +42,7 @@ import { Target, TargetService } from './Target.service';
 import { Notifications } from '@app/Notifications/Notifications';
 import { AuthMethod, LoginService, SessionState } from './Login.service';
 import {Rule} from '@app/Rules/Rules';
+import { RecordingLabel } from '@app/CreateRecording/EditRecordingLabels';
 
 type ApiVersion = 'v1' | 'v2' | 'v2.1' | 'beta';
 
@@ -500,9 +501,23 @@ export class ApiService {
     );
   }
 
-  patchRecordingLabels(labels: RecordingLabel[]): Observable<boolean> {
-    // TODO make PUT request when backend completed
-    return of(true);
+  patchRecordingLabels(recordingName: string, labels: RecordingLabel[]): Observable<boolean> {
+    const form = new window.FormData();
+    form.append('recordingName', recordingName);
+    form.append('labels', JSON.stringify(labels));
+
+    return this.target.target().pipe(concatMap(target =>
+        this.sendRequest(
+          'v1', `targets/${encodeURIComponent(target.connectUrl)}/recordings/${encodeURIComponent(recordingName)}`,
+          {
+            method: 'PATCH',
+            body: form,
+          }
+        ).pipe(
+          map(resp => resp.ok),
+          first(),
+        )
+      ));
   }
 
   private sendRequest(apiVersion: ApiVersion, path: string, config?: RequestInit): Observable<Response> {

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -57,6 +57,7 @@ export enum NotificationCategory {
   TemplateDeleted = 'TemplateDeleted',
   RuleCreated = 'RuleCreated',
   RuleDeleted = 'RuleDeleted',
+  RecordingMetadataUpdated  = 'RecordingMetadataUpdated',
 }
 
 export enum CloseStatus {
@@ -157,6 +158,13 @@ const messageKeys = new Map([
       variant: AlertVariant.success,
       title: 'Automated Rule Deleted',
       body: evt => `${evt.message.name} was deleted`
+    } as NotificationMessageMapper
+  ],
+  [
+    NotificationCategory.RecordingMetadataUpdated, {
+      variant: AlertVariant.success,
+      title: 'Recording Metadata Updated',
+      body: evt => `${evt.message.recordingName} metadata was updated`
     } as NotificationMessageMapper
   ],
 ]);


### PR DESCRIPTION
Related https://github.com/cryostatio/cryostat/issues/709

When creating recordings, users can add their own metadata with key-value label pairs. You can also edit labels for all active and archived recordings.

The labels are stored in the filesystem for now until we find a solution to manage the metadata when Cryostat is restarted (see https://github.com/cryostatio/cryostat/issues/709#issuecomment-1035314270)

![image](https://user-images.githubusercontent.com/84587295/156236583-488b8d64-0037-443f-baf3-4b2535040283.png)
