### PR TITLE
feat(credentials): Manage target JMX credentials

### DIFF
--- a/src/app/AppLayout/AuthModal.tsx
+++ b/src/app/AppLayout/AuthModal.tsx
@@ -38,6 +38,8 @@
 import * as React from 'react';
 import { Modal, ModalVariant } from '@patternfly/react-core';
 import { JmxAuthForm } from './JmxAuthForm';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { first } from 'rxjs';
 
 export interface AuthModalProps {
   visible: boolean;
@@ -46,8 +48,15 @@ export interface AuthModalProps {
 }
 
 export const AuthModal: React.FunctionComponent<AuthModalProps> = (props) => {
+  const context = React.useContext(ServiceContext);
+
   const handleDismiss = () => {
     props.onDismiss();
+  };
+
+  const onSave = (username: string, password: string) => {
+    context.api.postTargetCredentials(username, password).pipe(first()).subscribe();
+    props.onSave();
   };
 
   return (
@@ -59,7 +68,7 @@ export const AuthModal: React.FunctionComponent<AuthModalProps> = (props) => {
       title="Authentication Required"
       description="This target JVM requires authentication. The credentials you provide here will be passed from Cryostat to the target when establishing JMX connections."
     >
-      <JmxAuthForm onSave={props.onSave} onDismiss={props.onDismiss} />
+      <JmxAuthForm onSave={onSave} onDismiss={handleDismiss} />
     </Modal>
   );
 };

--- a/src/app/AppLayout/JmxAuthForm.tsx
+++ b/src/app/AppLayout/JmxAuthForm.tsx
@@ -67,6 +67,10 @@ export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) =>
         clear();
         props.onSave();
       });
+
+    context.api.postTargetCredentials(username, password)
+      .pipe(first())
+      .subscribe();
   };
 
   const handleDeleteCredentials = () => {
@@ -76,7 +80,6 @@ export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) =>
       .subscribe((target) => {
         context.target.deleteCredentials(target.connectUrl);
         clear();
-        props.onSave();
       });
   };
 

--- a/src/app/AppLayout/JmxAuthForm.tsx
+++ b/src/app/AppLayout/JmxAuthForm.tsx
@@ -73,16 +73,6 @@ export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) =>
       .subscribe();
   };
 
-  const handleDeleteCredentials = () => {
-    context.target
-      .target()
-      .pipe(first())
-      .subscribe((target) => {
-        context.target.deleteCredentials(target.connectUrl);
-        clear();
-      });
-  };
-
   const handleDismiss = () => {
     clear();
     props.onDismiss();
@@ -120,9 +110,6 @@ export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) =>
       <ActionGroup>
         <Button variant="primary" onClick={handleSave}>
           Save
-        </Button>
-        <Button variant="danger" onClick={handleDeleteCredentials}>
-          Delete
         </Button>
         <Button variant="secondary" onClick={handleDismiss}>
           Cancel

--- a/src/app/AppLayout/JmxAuthForm.tsx
+++ b/src/app/AppLayout/JmxAuthForm.tsx
@@ -42,7 +42,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface JmxAuthFormProps {
   onDismiss: () => void;
-  onSave: () => void;
+  onSave: (username: string, password: string) => void;
 }
 
 const EnterKeyCode = 13;
@@ -65,12 +65,8 @@ export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) =>
         context.target.setCredentials(target.connectUrl, `${username}:${password}`);
         context.target.setAuthRetry();
         clear();
-        props.onSave();
+        props.onSave(username, password);
       });
-
-    context.api.postTargetCredentials(username, password)
-      .pipe(first())
-      .subscribe();
   };
 
   const handleDismiss = () => {

--- a/src/app/AppLayout/JmxAuthForm.tsx
+++ b/src/app/AppLayout/JmxAuthForm.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import * as React from 'react';
+import { first } from 'rxjs/operators';
+import { ActionGroup, Button, Form, FormGroup, Modal, ModalVariant, TextInput } from '@patternfly/react-core';
+import { ServiceContext } from '@app/Shared/Services/Services';
+
+export interface JmxAuthFormProps {
+  onDismiss: () => void;
+  onSave: () => void;
+}
+
+const EnterKeyCode = 13;
+
+export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) => {
+  const context = React.useContext(ServiceContext);
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+
+  const clear = () => {
+    setUsername('');
+    setPassword('');
+  };
+
+  const handleSave = () => {
+    context.target
+      .target()
+      .pipe(first())
+      .subscribe((target) => {
+        context.target.setCredentials(target.connectUrl, `${username}:${password}`);
+        context.target.setAuthRetry();
+        clear();
+        props.onSave();
+      });
+  };
+
+  const handleDeleteCredentials = () => {
+    context.target
+      .target()
+      .pipe(first())
+      .subscribe((target) => {
+        context.target.deleteCredentials(target.connectUrl);
+        clear();
+        props.onSave();
+      });
+  };
+
+  const handleDismiss = () => {
+    clear();
+    props.onDismiss();
+  };
+
+  const handleKeyUp = (event: React.KeyboardEvent): void => {
+    if (event.keyCode === EnterKeyCode) {
+      handleSave();
+    }
+  };
+
+  return (
+    <Form>
+      <FormGroup isRequired label="Username" fieldId="username">
+        <TextInput
+          value={username}
+          isRequired
+          type="text"
+          id="username"
+          onChange={setUsername}
+          onKeyUp={handleKeyUp}
+          autoFocus
+        />
+      </FormGroup>
+      <FormGroup isRequired label="Password" fieldId="password">
+        <TextInput
+          value={password}
+          isRequired
+          type="password"
+          id="password"
+          onChange={setPassword}
+          onKeyUp={handleKeyUp}
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button variant="primary" onClick={handleSave}>
+          Save
+        </Button>
+        <Button variant="danger" onClick={handleDeleteCredentials}>
+          Delete
+        </Button>
+        <Button variant="secondary" onClick={handleDismiss}>
+          Cancel
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+};

--- a/src/app/SecurityPanel/CreateJmxCredentialModal.tsx
+++ b/src/app/SecurityPanel/CreateJmxCredentialModal.tsx
@@ -54,8 +54,8 @@ export const CreateJmxCredentialModal: React.FunctionComponent<CreateJmxCredenti
       onClose={props.onClose}
       title="Store JMX Credentials"
       description="Creates stored credentials for a given target. 
-      These are used for automated rules processing - if a Target JVM requires JMX authentication, 
-      Cryostat will use stored credentials when attempting to open JMX connections to the target."
+        If a Target JVM requires JMX authentication, Cryostat will use stored credentials 
+        when attempting to open JMX connections to the target."
     >
       <TargetSelect />
       <br />

--- a/src/app/SecurityPanel/CreateJmxCredentialModal.tsx
+++ b/src/app/SecurityPanel/CreateJmxCredentialModal.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright The Cryostat Authors
- *
+ * 
  * The Universal Permissive License (UPL), Version 1.0
- *
+ * 
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- *
+ * 
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- *
+ * 
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- *
+ * 
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,30 +36,60 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { Modal, ModalVariant } from '@patternfly/react-core';
-import { JmxAuthForm } from './JmxAuthForm';
+import { ActionGroup, Button, FileUpload, Form, FormGroup, Modal, ModalVariant } from '@patternfly/react-core';
+import { first, tap } from 'rxjs/operators';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { NotificationsContext } from '@app/Notifications/Notifications';
+import { JmxAuthForm } from '@app/AppLayout/JmxAuthForm';
+import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 
-export interface AuthModalProps {
+export interface CreateJmxCredentialModalProps {
   visible: boolean;
-  onDismiss: () => void;
-  onSave: () => void;
+  onClose: () => void;
 }
 
-export const AuthModal: React.FunctionComponent<AuthModalProps> = (props) => {
-  const handleDismiss = () => {
-    props.onDismiss();
+export const CreateJmxCredentialModal: React.FunctionComponent<CreateJmxCredentialModalProps> = props => {
+  const context = React.useContext(ServiceContext);
+  const notifications = React.useContext(NotificationsContext);
+
+  const [rejected, setRejected] = React.useState(false);
+
+  const reset = () => {
+    
+  };
+
+  const handleSaveAuthModal = () => {
+    // setShowAuthModal(false);
+  };
+
+  const handleClose = () => {
+    reset();
+    props.onClose();
+  };
+
+  const handleSubmit = () => {
+
+    // context.api.()
+    //   .pipe(
+    //     first(),
+    //     tap(() => setUploading(false)),
+    //   )
+    //   .subscribe(handleClose, reset);
   };
 
   return (
-    <Modal
+    <Modal 
       isOpen={props.visible}
       variant={ModalVariant.large}
       showClose={true}
-      onClose={handleDismiss}
-      title="Authentication Required"
-      description="This target JVM requires authentication. The credentials you provide here will be passed from Cryostat to the target when establishing JMX connections."
+      onClose={handleClose}
+      title="Store JMX Credentials"
+      description="Creates stored credentials for a given target. 
+      These are used for automated rules processing - if a Target JVM requires JMX authentication, 
+      Cryostat will use stored credentials when attempting to open JMX connections to the target." 
     >
-      <JmxAuthForm onSave={props.onSave} onDismiss={props.onDismiss} />
+      <TargetSelect />
+    <JmxAuthForm onDismiss={props.onClose} onSave={handleSaveAuthModal}/>
     </Modal>
   );
 };

--- a/src/app/SecurityPanel/CreateJmxCredentialModal.tsx
+++ b/src/app/SecurityPanel/CreateJmxCredentialModal.tsx
@@ -1,8 +1,8 @@
 /*
  * Copyright The Cryostat Authors
- * 
+ *
  * The Universal Permissive License (UPL), Version 1.0
- * 
+ *
  * Subject to the condition set forth below, permission is hereby granted to any
  * person obtaining a copy of this software, associated documentation and/or data
  * (collectively the "Software"), free of charge and under any and all copyright
@@ -10,23 +10,23 @@
  * licensable by each licensor hereunder covering either (i) the unmodified
  * Software as contributed to or provided by such licensor, or (ii) the Larger
  * Works (as defined below), to deal in both
- * 
+ *
  * (a) the Software, and
  * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
  * one is included with the Software (each a "Larger Work" to which the Software
  * is contributed by such licensors),
- * 
+ *
  * without restriction, including without limitation the rights to copy, create
  * derivative works of, display, perform, and distribute the Software and make,
  * use, sell, offer for sale, import, export, have made, and have sold the
  * Software and the Larger Work(s), and to sublicense the foregoing rights on
  * either these or other terms.
- * 
+ *
  * This license is subject to the following condition:
  * The above copyright notice and either this complete permission notice or at
  * a minimum a reference to the UPL must be included in all copies or
  * substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,10 +36,7 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { ActionGroup, Button, FileUpload, Form, FormGroup, Modal, ModalVariant } from '@patternfly/react-core';
-import { first, tap } from 'rxjs/operators';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { NotificationsContext } from '@app/Notifications/Notifications';
+import { Modal, ModalVariant } from '@patternfly/react-core';
 import { JmxAuthForm } from '@app/AppLayout/JmxAuthForm';
 import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 
@@ -48,48 +45,21 @@ export interface CreateJmxCredentialModalProps {
   onClose: () => void;
 }
 
-export const CreateJmxCredentialModal: React.FunctionComponent<CreateJmxCredentialModalProps> = props => {
-  const context = React.useContext(ServiceContext);
-  const notifications = React.useContext(NotificationsContext);
-
-  const [rejected, setRejected] = React.useState(false);
-
-  const reset = () => {
-    
-  };
-
-  const handleSaveAuthModal = () => {
-    // setShowAuthModal(false);
-  };
-
-  const handleClose = () => {
-    reset();
-    props.onClose();
-  };
-
-  const handleSubmit = () => {
-
-    // context.api.()
-    //   .pipe(
-    //     first(),
-    //     tap(() => setUploading(false)),
-    //   )
-    //   .subscribe(handleClose, reset);
-  };
-
+export const CreateJmxCredentialModal: React.FunctionComponent<CreateJmxCredentialModalProps> = (props) => {
   return (
-    <Modal 
+    <Modal
       isOpen={props.visible}
       variant={ModalVariant.large}
       showClose={true}
-      onClose={handleClose}
+      onClose={props.onClose}
       title="Store JMX Credentials"
       description="Creates stored credentials for a given target. 
       These are used for automated rules processing - if a Target JVM requires JMX authentication, 
-      Cryostat will use stored credentials when attempting to open JMX connections to the target." 
+      Cryostat will use stored credentials when attempting to open JMX connections to the target."
     >
       <TargetSelect />
-    <JmxAuthForm onDismiss={props.onClose} onSave={handleSaveAuthModal}/>
+      <br />
+      <JmxAuthForm onSave={props.onClose} onDismiss={props.onClose} />
     </Modal>
   );
 };

--- a/src/app/SecurityPanel/ImportCertificate.tsx
+++ b/src/app/SecurityPanel/ImportCertificate.tsx
@@ -35,36 +35,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { Card, CardBody, CardTitle, Text, TextVariants } from '@patternfly/react-core';
-import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
-import { StoreJmxCredentials } from './StoreJmxCredentials';
-import { ImportCertificate } from './ImportCertificate';
 
-export const SecurityPanel = () => {
-  const securityCards = [ImportCertificate, StoreJmxCredentials].map((c) => ({
-    title: c.title,
-    description: c.description,
-    element: React.createElement(c.content, null),
-  }));
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { CertificateUploadModal } from './CertificateUploadModal';
+import { SecurityCard } from './SecurityPanel';
+
+const Component = () => {
+  const [showModal, setShowModal] = React.useState(false);
+
+  const handleModalClose = () => {
+    setShowModal(false);
+  };
 
   return (
-    <BreadcrumbPage pageTitle="Security">
-      {securityCards.map((s) => (
-        <Card>
-          <CardTitle>
-            <Text component={TextVariants.h1}>{s.title}</Text>
-            <Text component={TextVariants.small}>{s.description}</Text>
-          </CardTitle>
-          <CardBody>{s.element}</CardBody>
-        </Card>
-      ))}
-    </BreadcrumbPage>
+    <>
+      <Button variant="primary" aria-label="import" onClick={() => setShowModal(true)}>
+        Upload
+      </Button>
+      <CertificateUploadModal visible={showModal} onClose={handleModalClose} />
+    </>
   );
 };
 
-export interface SecurityCard {
-  title: string;
-  description: string;
-  content: React.FunctionComponent;
-}
+export const ImportCertificate: SecurityCard = {
+  title: 'Import SSL Certificates',
+  description: 'Restart is needed to apply changes.',
+  content: Component,
+};

--- a/src/app/SecurityPanel/SecurityPanel.tsx
+++ b/src/app/SecurityPanel/SecurityPanel.tsx
@@ -45,16 +45,10 @@ import { TargetCredentialsTable } from './TargetCredentialsTable';
 
 export const SecurityPanel = () => {
     const [showModal, setShowModal] = React.useState(false);
-    const [showAuthModal, setShowAuthModal] = React.useState(false);
-
 
     const handleModalClose = () => {
         setShowModal(false);
     }
-
-    const handleDismissAuthModal = () => {
-        setShowAuthModal(false);
-      };
 
     // TODO extract like settings panel
 
@@ -82,13 +76,11 @@ export const SecurityPanel = () => {
                     </Text>
                 </CardHeader>
                 <CardBody>
-                    <TargetCredentialsTable addCredentials={() => setShowAuthModal(true)}/>
+                    <TargetCredentialsTable />
                 </CardBody>
             </Card>
         </BreadcrumbPage>
 
         <CertificateUploadModal visible={showModal} onClose={handleModalClose}/>
-        <CreateJmxCredentialModal visible={showAuthModal} onClose={handleDismissAuthModal}/>
-
     </>);
 }

--- a/src/app/SecurityPanel/SecurityPanel.tsx
+++ b/src/app/SecurityPanel/SecurityPanel.tsx
@@ -51,7 +51,7 @@ export const SecurityPanel = () => {
   return (
     <BreadcrumbPage pageTitle="Security">
       {securityCards.map((s) => (
-        <Card>
+        <Card key={s.title}>
           <CardTitle>
             <Text component={TextVariants.h1}>{s.title}</Text>
             <Text component={TextVariants.small}>{s.description}</Text>

--- a/src/app/SecurityPanel/SecurityPanel.tsx
+++ b/src/app/SecurityPanel/SecurityPanel.tsx
@@ -39,13 +39,24 @@ import * as React from 'react';
 import { Button, Card, CardBody, CardHeader, Text, TextVariants } from '@patternfly/react-core';
 import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { CertificateUploadModal } from './CertificateUploadModal';
+import { CreateJmxCredentialModal } from './CreateJmxCredentialModal';
+import { AuthModal } from '@app/AppLayout/AuthModal';
+import { TargetCredentialsTable } from './TargetCredentialsTable';
 
 export const SecurityPanel = () => {
     const [showModal, setShowModal] = React.useState(false);
+    const [showAuthModal, setShowAuthModal] = React.useState(false);
+
 
     const handleModalClose = () => {
         setShowModal(false);
     }
+
+    const handleDismissAuthModal = () => {
+        setShowAuthModal(false);
+      };
+
+    // TODO extract like settings panel
 
     return (<>
         <BreadcrumbPage pageTitle='Security'>
@@ -64,8 +75,20 @@ export const SecurityPanel = () => {
                     </Text>
                 </CardBody>
             </Card>
+            <Card>
+                <CardHeader>
+                    <Text component={TextVariants.h4}>
+                        Store JMX Credentials
+                    </Text>
+                </CardHeader>
+                <CardBody>
+                    <TargetCredentialsTable addCredentials={() => setShowAuthModal(true)}/>
+                </CardBody>
+            </Card>
         </BreadcrumbPage>
 
         <CertificateUploadModal visible={showModal} onClose={handleModalClose}/>
+        <CreateJmxCredentialModal visible={showAuthModal} onClose={handleDismissAuthModal}/>
+
     </>);
 }

--- a/src/app/SecurityPanel/StoreJmxCredentials.tsx
+++ b/src/app/SecurityPanel/StoreJmxCredentials.tsx
@@ -66,11 +66,11 @@ import { forkJoin, Observable, of } from 'rxjs';
 import _ from 'lodash';
 import { Caption, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { CreateJmxCredentialModal } from './CreateJmxCredentialModal';
+import { SecurityCard } from './SecurityPanel';
 
-export interface TargetCredentialsTableProps {
-}
+export interface TargetCredentialsTableProps {}
 
-export const TargetCredentialsTable: React.FunctionComponent<TargetCredentialsTableProps> = (props) => {
+const Component: React.FunctionComponent<TargetCredentialsTableProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
 
@@ -203,9 +203,6 @@ export const TargetCredentialsTable: React.FunctionComponent<TargetCredentialsTa
         <>
           <TargetCredentialsToolbar />
           <TableComposable aria-label={tableTitle}>
-            <Caption>Targets for which Cryostat has stored JMX credentials. 
-              These credentials are used for automated rules processing - if a Target JVM requires JMX authentication, 
-              Cryostat will use stored credentials when attempting to open JMX connections to the target.</Caption>
             <Thead>
               <Tr>
                 <Th
@@ -224,7 +221,15 @@ export const TargetCredentialsTable: React.FunctionComponent<TargetCredentialsTa
           </TableComposable>
         </>
       )}
-        <CreateJmxCredentialModal visible={showAuthModal} onClose={() => setShowAuthModal(false)}/>
+      <CreateJmxCredentialModal visible={showAuthModal} onClose={() => setShowAuthModal(false)} />
     </>
   );
+};
+
+export const StoreJmxCredentials: SecurityCard = {
+  title: 'Store JMX Credentials',
+  description: `Targets for which Cryostat has stored JMX credentials are listed here. 
+    If a Target JVM requires JMX authentication, Cryostat will use stored credentials 
+    when attempting to open JMX connections to the target.`,
+  content: Component,
 };

--- a/src/app/SecurityPanel/StoreJmxCredentials.tsx
+++ b/src/app/SecurityPanel/StoreJmxCredentials.tsx
@@ -150,10 +150,10 @@ const Component = () => {
   const TargetCredentialsToolbar = () => {
     const buttons = React.useMemo(() => {
       const arr = [
-        <Button variant="primary" aria-label="import" onClick={() => setShowAuthModal(true)}>
+        <Button variant="primary" aria-label="add-jmx-credential" onClick={() => setShowAuthModal(true)}>
           Add
         </Button>,
-        <Button key="delete" variant="danger" onClick={handleDeleteCredentials} isDisabled={!checkedIndices.length}>
+        <Button key="delete" variant="danger" aria-label="delete-selected-jmx-credential" onClick={handleDeleteCredentials} isDisabled={!checkedIndices.length}>
           Delete
         </Button>,
       ];

--- a/src/app/SecurityPanel/StoreJmxCredentials.tsx
+++ b/src/app/SecurityPanel/StoreJmxCredentials.tsx
@@ -182,18 +182,19 @@ const Component = () => {
     return (
       <Tbody key={props.index}>
         <Tr key={`${props.index}`}>
-          <Td key={`active-table-row-${props.index}_0`}>
+          <Td key={`credentials-table-row-${props.index}_0`}>
             <Checkbox
-              name={`active-table-row-${props.index}-check`}
+              name={`credentials-table-row-${props.index}-check`}
               onChange={handleCheck}
               isChecked={checkedIndices.includes(props.index)}
-              id={`active-table-row-${props.index}-check`}
+              id={`credentials-table-row-${props.index}-check`}
+              aria-label={`credentials-table-row-${props.index}-check`}
             />
           </Td>
-          <Td key={`active-table-row-${props.index}_1`} dataLabel={tableColumns[0]}>
+          <Td key={`credentials-table-row-${props.index}_1`} dataLabel={tableColumns[0]}>
             {props.target.alias}
           </Td>
-          <Td key={`active-table-row-${props.index}_2`} dataLabel={tableColumns[1]}>
+          <Td key={`credentials-table-row-${props.index}_2`} dataLabel={tableColumns[1]}>
             {props.target.connectUrl}
           </Td>
         </Tr>

--- a/src/app/SecurityPanel/TargetCredentialsTable.tsx
+++ b/src/app/SecurityPanel/TargetCredentialsTable.tsx
@@ -80,7 +80,7 @@ export const TargetCredentialsTable: React.FunctionComponent<TargetCredentialsTa
   const [isEmpty, setIsEmpty] = React.useState(false); //TODO init
   const [showAuthModal, setShowAuthModal] = React.useState(false);
 
-  const tableColumns: string[] = ['Target', 'Alias'];
+  const tableColumns: string[] = ['Target Alias', 'Connect URL'];
   const tableTitle = 'Stored Credentials';
 
   // TODO subscribe to "targets that have credentials stored" state
@@ -174,10 +174,10 @@ export const TargetCredentialsTable: React.FunctionComponent<TargetCredentialsTa
             />
           </Td>
           <Td key={`active-table-row-${props.index}_1`} dataLabel={tableColumns[0]}>
-            {props.target.connectUrl}
+            {props.target.alias}
           </Td>
           <Td key={`active-table-row-${props.index}_2`} dataLabel={tableColumns[1]}>
-            {props.target.alias}
+            {props.target.connectUrl}
           </Td>
         </Tr>
       </Tbody>

--- a/src/app/SecurityPanel/TargetCredentialsTable.tsx
+++ b/src/app/SecurityPanel/TargetCredentialsTable.tsx
@@ -1,0 +1,231 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import * as React from 'react';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { NotificationsContext } from '@app/Notifications/Notifications';
+import { NO_TARGET, Target } from '@app/Shared/Services/Target.service';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
+import {
+  Button,
+  Card,
+  CardActions,
+  CardBody,
+  CardHeader,
+  CardHeaderMain,
+  Checkbox,
+  EmptyState,
+  EmptyStateIcon,
+  Select,
+  SelectOption,
+  SelectVariant,
+  Text,
+  TextVariants,
+  Title,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { ContainerNodeIcon, PlusCircleIcon, SearchIcon, Spinner2Icon, TrashIcon } from '@patternfly/react-icons';
+import { Observable, of } from 'rxjs';
+import { catchError, first } from 'rxjs/operators';
+
+import _ from 'lodash';
+import { Caption, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+
+export interface TargetCredentialsTableProps {
+  addCredentials: () => void;
+}
+
+export const TargetCredentialsTable: React.FunctionComponent<TargetCredentialsTableProps> = (props) => {
+  const context = React.useContext(ServiceContext);
+
+  const [targets, setTargets] = React.useState([] as Target[]);
+  const [headerChecked, setHeaderChecked] = React.useState(false);
+  const [checkedIndices, setCheckedIndices] = React.useState([] as number[]);
+  const [isEmpty, setIsEmpty] = React.useState(false); //TODO init
+
+  const tableColumns: string[] = ['Connect Url', 'Alias'];
+  const tableTitle = 'Stored Credentials';
+
+  // TODO subscribe to "targets that have credentials stored" state
+  // or somehow filter targets list
+  // and setTargets()
+  React.useEffect(() => {
+    const sub = context.targets.targets().subscribe((targets) => {
+      setTargets(targets);
+    });
+    return () => sub.unsubscribe();
+  }, [context, context.targets, setTargets]);
+
+  const handleRowCheck = React.useCallback(
+    (checked, index) => {
+      if (checked) {
+        setCheckedIndices((ci) => [...ci, index]);
+      } else {
+        setHeaderChecked(false);
+        setCheckedIndices((ci) => ci.filter((v) => v !== index));
+      }
+    },
+    [setCheckedIndices, setHeaderChecked]
+  );
+
+  const handleHeaderCheck = React.useCallback(
+    (event, checked) => {
+      setHeaderChecked(checked);
+      setCheckedIndices(checked ? Array.from(new Array(targets.length), (x, i) => i) : []);
+    },
+    [setHeaderChecked, setCheckedIndices, targets]
+  );
+
+  const handleAddCredentials = React.useCallback(() => {
+    props.addCredentials(); // TODO update table. notification?
+  }, [props.addCredentials]);
+
+  const handleDeleteTargetCredentials = () => {
+    // const tasks: Observable<any>[] = [];
+    // targets.forEach((t: Target, idx) => {
+    //   if (checkedIndices.includes(idx)) {
+    //     handleRowCheck(false, idx);
+    //     tasks.push(context.target.deleteCredentials(t.connectUrl)); // TODO make call to backend
+    //   }
+    // });
+    // addSubscription(forkJoin(tasks).subscribe());
+  };
+
+  const TargetCredentialsToolbar = () => {
+    const buttons = React.useMemo(() => {
+      const arr = [
+        <Button variant="primary" aria-label="import" onClick={() => handleAddCredentials()}>
+          Add Credentials
+        </Button>,
+        <Button
+          key="delete"
+          variant="danger"
+          onClick={handleDeleteTargetCredentials}
+          isDisabled={!checkedIndices.length}
+        >
+          Delete Credentials
+        </Button>,
+      ];
+
+      return (
+        <>
+          {arr.map((btn, idx) => (
+            <ToolbarItem key={idx}>{btn}</ToolbarItem>
+          ))}
+        </>
+      );
+    }, [checkedIndices]);
+
+    return (
+      <Toolbar id="target-credentials-toolbar">
+        <ToolbarContent>{buttons}</ToolbarContent>
+      </Toolbar>
+    );
+  };
+
+  const TargetCredentialsTableRow = (props) => {
+    const handleCheck = (checked) => {
+      handleRowCheck(checked, props.index);
+    };
+
+    return (
+      <Tbody key={props.index}>
+        <Tr key={`${props.index}`}>
+          <Td key={`active-table-row-${props.index}_0`}>
+            <Checkbox
+              name={`active-table-row-${props.index}-check`}
+              onChange={handleCheck}
+              isChecked={checkedIndices.includes(props.index)}
+              id={`active-table-row-${props.index}-check`}
+            />
+          </Td>
+          <Td key={`active-table-row-${props.index}_1`} dataLabel={tableColumns[0]}>
+            {props.target.connectUrl}
+          </Td>
+          <Td key={`active-table-row-${props.index}_2`} dataLabel={tableColumns[1]}>
+            {props.target.alias}
+          </Td>
+        </Tr>
+      </Tbody>
+    );
+  };
+  const targetRows = React.useMemo(() => {
+    return targets.map((t, idx) => <TargetCredentialsTableRow key={idx} target={t} index={idx} />);
+  }, [targets, checkedIndices]);
+
+  return (
+    <>
+      {isEmpty ? (
+        <>
+          <TargetCredentialsToolbar />
+          <EmptyState>
+            <EmptyStateIcon icon={SearchIcon} />
+            <Title headingLevel="h4" size="lg">
+              No {tableTitle}
+            </Title>
+          </EmptyState>
+        </>
+      ) : (
+        <>
+          <TargetCredentialsToolbar />
+          <TableComposable aria-label={tableTitle}>
+            <Caption>Targets for which Cryostat has stored JMX credentials. 
+              These credentials are used for automated rules processing - if a Target JVM requires JMX authentication, 
+              Cryostat will use stored credentials when attempting to open JMX connections to the target.</Caption>
+            <Thead>
+              <Tr>
+                <Th
+                  key="table-header-check-all"
+                  select={{
+                    onSelect: handleHeaderCheck,
+                    isSelected: headerChecked,
+                  }}
+                />
+                {tableColumns.map((key, idx) => (
+                  <Th key={`table-header-${key}`}>{key}</Th>
+                ))}
+              </Tr>
+            </Thead>
+            {targetRows}
+          </TableComposable>
+        </>
+      )}
+    </>
+  );
+};

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -559,12 +559,13 @@ export class ApiService {
 
   getTargetsWithStoredJmxCredentials() : Observable<Target[]> {
     return this.sendRequest(
-      'beta', `credentials`,
+      'v2.1', `credentials`,
       {
         method: 'GET'        
       }
     ).pipe(
-      concatMap(resp => from(resp.json())),
+      concatMap(resp => resp.json()),
+      map((response: TargetCredentialsResponse) => response.data.result),
       first()
     );
   }
@@ -658,6 +659,12 @@ interface AssetJwtResponse extends ApiV2Response {
     result: {
       resourceUrl: string;
     }
+  }
+}
+
+interface TargetCredentialsResponse extends ApiV2Response {
+  data: {
+    result: Target[];
   }
 }
 

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -538,6 +538,37 @@ export class ApiService {
       ));
   }
 
+  postTargetCredentials(username: string, password: string): Observable<boolean> {
+    const body = new window.FormData();
+    body.append('username', username);
+    body.append('password', password);
+
+    return this.target.target().pipe(concatMap(target =>
+      this.sendRequest(
+        'v2', `targets/${encodeURIComponent(target.connectUrl)}/credentials`,
+        {
+          method: 'POST',
+          body,
+        }
+      ).pipe(
+        map(resp => resp.ok),
+        first()
+      )
+    ));
+  }
+
+  deleteTargetCredentials(t: Target): Observable<boolean> {
+    return this.sendRequest(
+      'v2', `targets/${encodeURIComponent(t.connectUrl)}/credentials`, 
+      {
+        method: 'DELETE'
+      }
+    ).pipe(
+      map(resp => resp.ok),
+      first(),
+    );
+  }
+
   private sendRequest(apiVersion: ApiVersion, path: string, config?: RequestInit): Observable<Response> {
     const req = () => this.login.getHeaders().pipe(
       concatMap(headers => {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -557,6 +557,18 @@ export class ApiService {
     ));
   }
 
+  getTargetsWithStoredJmxCredentials() : Observable<Target[]> {
+    return this.sendRequest(
+      'beta', `credentials`,
+      {
+        method: 'GET'        
+      }
+    ).pipe(
+      concatMap(resp => from(resp.json())),
+      first()
+    );
+  }
+
   deleteTargetCredentials(t: Target): Observable<boolean> {
     return this.sendRequest(
       'v2', `targets/${encodeURIComponent(t.connectUrl)}/credentials`, 

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -61,6 +61,8 @@ export enum NotificationCategory {
   RuleDeleted = 'RuleDeleted',
   RecordingMetadataUpdated  = 'RecordingMetadataUpdated',
   GrafanaConfiguration = 'GrafanaConfiguration', // generated client-side
+  TargetCredentialsStored = 'TargetCredentialsStored',
+  TargetCredentialsDeleted = 'TargetCredentialsDeleted',
 }
 
 export enum CloseStatus {
@@ -188,6 +190,20 @@ export const messageKeys = new Map([
       variant: AlertVariant.success,
       title: 'Recording Metadata Updated',
       body: evt => `${evt.message.recordingName} metadata was updated`
+    } as NotificationMessageMapper
+  ],
+  [
+    NotificationCategory.TargetCredentialsStored, {
+      variant: AlertVariant.success,
+      title: 'Target Credentials Stored',
+      body: evt => `Credentials stored for target: ${evt.message.target}`
+    } as NotificationMessageMapper
+  ],
+  [
+    NotificationCategory.TargetCredentialsDeleted, {
+      variant: AlertVariant.success,
+      title: 'Target Credentials Deleted',
+      body: evt => `Credentials deleted for target: ${evt.message.target}`
     } as NotificationMessageMapper
   ],
 ]);


### PR DESCRIPTION
Fixes #388 
Adds a table listing targets with stored credentials in the Security tab. Also refactors the Security panel to make it easier to add more cards in the future.

![image](https://user-images.githubusercontent.com/84587295/158269983-420678d4-e3db-46b7-939a-2c20ebd8e04b.png)