### PR TITLE
fix(rules): fix header concatenation

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -585,11 +585,17 @@ export class ApiService {
   private sendRequest(apiVersion: ApiVersion, path: string, config?: RequestInit): Observable<Response> {
     const req = () => this.login.getHeaders().pipe(
       concatMap(headers => {
+        if(!!config && !!config.headers) {
+          Object.entries(config.headers).forEach(([k, v]) => {
+            headers.set(k, v);
+          });
+        }
+
         return fromFetch(`${this.login.authority}/api/${apiVersion}/${path}`, {
           credentials: 'include',
           mode: 'cors',
-          headers,
           ...config,
+          headers,
         });
       }),
       map(resp => {


### PR DESCRIPTION
Fixes #390 

When two headers objects are passed to `fromFetch`, the last header object listed (`config.headers`) seems to replace the previous `headers` object (`login.getHeaders`). This appends the correct `Content-type`, but removes the `Authorization` header from the request. Appending the `config.headers` into the original `headers` object, then passing in the updated `headers` object last will preserve all the headers.