### PR TITLE
fix(labels): Prevent duplicate labels POST call

### DIFF
--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -193,9 +193,21 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
 
   React.useEffect(() => {
     addSubscription(
-      context.notificationChannel.messages(NotificationCategory.RecordingMetadataUpdated)
-        .subscribe(v => setRecordings(old => old.map(
-          o => o.name == v.message.recordingName ? { ...o, metadata: { labels: v.message.metadata.labels } } : o)))
+      combineLatest([
+      context.target.target(),
+      context.notificationChannel.messages(NotificationCategory.RecordingMetadataUpdated),
+    ])
+      .subscribe(parts => {
+        const currentTarget = parts[0];
+        const event = parts[1];
+        if (currentTarget.connectUrl != event.message.target) {
+          return;
+        }
+        setRecordings(old => old.map(
+          o => o.name == event.message.recordingName 
+            ? { ...o, metadata: { labels: event.message.metadata.labels } } 
+            : o));
+      })
     );
   }, [addSubscription, context, context.notificationChannel, setRecordings]);
 

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -536,7 +536,9 @@ export class ApiService {
   }
 
   postTargetRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
-    return this.target.target().pipe(concatMap(target =>
+    return this.target.target().pipe(
+      first(),
+      concatMap(target =>
         this.sendRequest(
           'beta', `targets/${encodeURIComponent(target.connectUrl)}/recordings/${encodeURIComponent(recordingName)}/metadata/labels`,
           {


### PR DESCRIPTION
Fixes #409 - the `target.target()` Observable in `postTargetRecordingMetadata` seemed to be firing twice.

I also noticed the metadata labels notification subscription didn't check if the notification applied to the selected target. Added a check to prevent unnecessary computation when receiving metadata label notifications.

This fix prevents an error toast from popping up but leaves the state otherwise unchanged. Up to you if you want to backport it.