### PR TITLE
Fix(webpack): Change hashing algorithm for Fedora 36 compatibility 

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -26,7 +26,7 @@ module.exports = merge(common('development'), {
   output: {
     filename: '[name].bundle.js',
     path: path.resolve(__dirname, 'dist'), 
-    hashFunction: "xxhash64"
+    hashFunction: "xxhash64",
   },
   module: {
     rules: [

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -25,7 +25,8 @@ module.exports = merge(common('development'), {
   ],
   output: {
     filename: '[name].bundle.js',
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve(__dirname, 'dist'), 
+    hashFunction: "xxhash64"
   },
   module: {
     rules: [

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -28,10 +28,11 @@ module.exports = merge(common('production'), {
       path: './.env.prod',
     }),
   ],
-  // output: {
-  //   filename: '[name].[contenthash].bundle.js',
-  //   path: path.resolve(__dirname, 'dist')
-  // },
+  output: {
+    // filename: '[name].[contenthash].bundle.js',
+    // path: path.resolve(__dirname, 'dist'),
+    hashFunction: "xxhash64",
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
Fixes #451 

Changes the hashing algorithm used by webpack from the default MD4 to [XXH64](http://cyan4973.github.io/xxHash/). The solution is taken from [here](https://stackoverflow.com/a/69394785). XXH64 is a fast, non-cryptographic hashing algorithm that doesn't rely on OpenSSL. From the webpack [docs](https://webpack.js.org/configuration/output/#outputhashfunction), it seems that this algorithm will become the default in future releases. 

However, if we would like to preserve the cryptography of MD4, while still relying on OpenSSL, there are other options:

```
[hdhillon@localhost cryostat-web]$ openssl list -digest-algorithms
...
Provided:
  { 2.16.840.1.101.3.4.2.10, SHA3-512 } @ default
  { 1.2.156.10197.1.401, SM3 } @ default
  { 1.3.6.1.4.1.1722.12.2.2.8, BLAKE2S-256, BLAKE2s256 } @ default
  { 2.16.840.1.101.3.4.2.8, SHA3-256 } @ default
  { 2.16.840.1.101.3.4.2.7, SHA3-224 } @ default
  { 2.16.840.1.101.3.4.2.2, SHA-384, SHA2-384, SHA384 } @ default
  { 2.16.840.1.101.3.4.2.3, SHA-512, SHA2-512, SHA512 } @ default
  { 2.16.840.1.101.3.4.2.5, SHA-512/224, SHA2-512/224, SHA512-224 } @ default
  { 2.16.840.1.101.3.4.2.12, SHAKE-256, SHAKE256 } @ default
  { 2.16.840.1.101.3.4.2.1, SHA-256, SHA2-256, SHA256 } @ default
  { 1.3.14.3.2.26, SHA-1, SHA1, SSL3-SHA1 } @ default
  { 2.16.840.1.101.3.4.2.9, SHA3-384 } @ default
  { 2.16.840.1.101.3.4.2.11, SHAKE-128, SHAKE128 } @ default
  MD5-SHA1 @ default
  { 1.2.840.113549.2.5, MD5, SSL3-MD5 } @ default
  { 2.16.840.1.101.3.4.2.4, SHA-224, SHA2-224, SHA224 } @ default
  { 1.3.6.1.4.1.1722.12.2.1.16, BLAKE2B-512, BLAKE2b512 } @ default
  { 2.16.840.1.101.3.4.2.6, SHA-512/256, SHA2-512/256, SHA512-256 } @ default
  { KECCAK-KMAC-128, KECCAK-KMAC128 } @ default
  { KECCAK-KMAC-256, KECCAK-KMAC256 } @ default
  NULL @ default
```