### PR TITLE
chore(navigation): remove breadcrumb href since replaced by Link

### DIFF
--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -55,7 +55,7 @@ export const BreadcrumbPage: React.FunctionComponent<BreadcrumbPageProps> = (pro
       <Breadcrumb>
         {
         (props.breadcrumbs || []).map(
-            ({ title, path }) => <BreadcrumbItem key={path} to={path} render={() => (<><Link to={path}>{title}</Link></>)}></BreadcrumbItem>)
+            ({ title, path }) => <BreadcrumbItem key={path} render={() => (<><Link to={path}>{title}</Link></>)}></BreadcrumbItem>)
         }
         <BreadcrumbHeading>{props.pageTitle}</BreadcrumbHeading>
       </Breadcrumb>


### PR DESCRIPTION
Related to #459 

Previous fix didn't remove `to` property in `BreadcrumbItem`. There seems to be no effect if not removing but it might not be clear which behaviour the breadcrumb follows as we also have  `<Link>`'s `to` property.