### PR TITLE
fix(labels): edit labels for distinct recordings with identical file names

### DIFF
--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -106,8 +106,6 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
   const updateCommonLabels = React.useCallback(
     (setLabels: (l: RecordingLabel[]) => void) => {
       let allRecordingLabels = [] as RecordingLabel[][];
-      console.log("updateCommonLabels", recordings);
-      console.log(recordings)
       recordings.forEach((r: ArchivedRecording, idx) => {
         if (props.checkedIndices.includes(idx)) {
           allRecordingLabels.push(parseLabels(r.metadata.labels));

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -41,7 +41,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { ActiveRecording, ArchivedRecording } from '@app/Shared/Services/Api.service';
 import { includesLabel, parseLabels, RecordingLabel } from './RecordingLabel';
-import { combineLatest, concatMap, filter, first, forkJoin, merge, Observable } from 'rxjs';
+import { combineLatest, concatMap, filter, first, forkJoin, map, merge, Observable } from 'rxjs';
 import { LabelCell } from '@app/RecordingMetadata/LabelCell';
 import { RecordingLabelFields } from './RecordingLabelFields';
 import { HelpIcon } from '@patternfly/react-icons';
@@ -55,7 +55,7 @@ export interface BulkEditLabelsProps {
 
 export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (props) => {
   const context = React.useContext(ServiceContext);
-  const [recordings, setRecordings] = React.useState([] as ActiveRecording[]);
+  const [recordings, setRecordings] = React.useState([] as ArchivedRecording[]);
   const [editing, setEditing] = React.useState(false);
   const [commonLabels, setCommonLabels] = React.useState([] as RecordingLabel[]);
   const [savedCommonLabels, setSavedCommonLabels] = React.useState([] as RecordingLabel[]);
@@ -128,8 +128,25 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
         .pipe(
           filter((target) => target !== NO_TARGET),
           concatMap((target) =>
-            context.api.doGet<ActiveRecording[]>(`targets/${encodeURIComponent(target.connectUrl)}/recordings`)
+            props.isTargetRecording ?
+              context.api.doGet<ActiveRecording[]>(`targets/${encodeURIComponent(target.connectUrl)}/recordings`)
+              : context.api.graphql<any>(`
+                  query {
+                    targetNodes(filter: { name: "${target.connectUrl}" }) {
+                      recordings {
+                        archived {
+                          name
+                          downloadUrl
+                          reportUrl
+                          metadata {
+                            labels
+                          }
+                        }
+                      }
+                    }
+                  }`),
           ),
+          map(v => props.isTargetRecording ? v : v.data.targetNodes[0].recordings.archived as ArchivedRecording[]),
           first()
         )
         .subscribe((value) => setRecordings(value))

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -151,7 +151,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
         )
         .subscribe((value) => setRecordings(value))
     );
-  }, [addSubscription, context, context.target, context.api, setRecordings]);
+  }, [addSubscription, props.isTargetRecording, context, context.target, context.api, setRecordings]);
 
   React.useEffect(() => {
     addSubscription(context.target.target().subscribe(refreshRecordingList));

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -106,6 +106,8 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
   const updateCommonLabels = React.useCallback(
     (setLabels: (l: RecordingLabel[]) => void) => {
       let allRecordingLabels = [] as RecordingLabel[][];
+      console.log("updateCommonLabels", recordings);
+      console.log(recordings)
       recordings.forEach((r: ArchivedRecording, idx) => {
         if (props.checkedIndices.includes(idx)) {
           allRecordingLabels.push(parseLabels(r.metadata.labels));
@@ -135,18 +137,20 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
                     targetNodes(filter: { name: "${target.connectUrl}" }) {
                       recordings {
                         archived {
-                          name
-                          downloadUrl
-                          reportUrl
-                          metadata {
-                            labels
+                          data {
+                            name
+                            downloadUrl
+                            reportUrl
+                            metadata {
+                              labels
+                            }
                           }
                         }
                       }
                     }
                   }`),
           ),
-          map(v => props.isTargetRecording ? v : v.data.targetNodes[0].recordings.archived as ArchivedRecording[]),
+          map(v => props.isTargetRecording ? v : v.data.targetNodes[0].recordings.archived.data as ArchivedRecording[]),
           first()
         )
         .subscribe((value) => setRecordings(value))

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -230,8 +230,16 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
 
   React.useEffect(() => {
     addSubscription(
+      combineLatest([
+        context.target.target(),
       context.notificationChannel.messages(NotificationCategory.RecordingMetadataUpdated)
-      .subscribe(event => {
+      ])
+      .subscribe(parts => {
+        const currentTarget = parts[0];
+        const event = parts[1];
+        if (currentTarget.connectUrl != event.message.target) {
+          return;
+        }
         setRecordings(old => old.map(
           o => o.name == event.message.recordingName 
             ? { ...o, metadata: { labels: event.message.metadata.labels } } 
@@ -414,7 +422,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
   const LabelsPanel = React.useMemo(() => (
     <RecordingLabelsPanel
       setShowPanel={setShowDetailsPanel}  
-      isTargetRecording={true}
+      isTargetRecording={false}
       checkedIndices={checkedIndices}
     />
   ), [checkedIndices]);

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -544,9 +544,11 @@ export class ApiService {
           targetNodes(filter: { name: "${target.connectUrl}" }) {
             recordings {
               archived(filter: { name: "${recordingName}" }) {
-                doPutMetadata(metadata: { labels: ${this.stringifyRecordingLabels(labels)}}) {
-                  metadata {
-                    labels
+                data {
+                  doPutMetadata(metadata: { labels: ${this.stringifyRecordingLabels(labels)}}) {
+                    metadata {
+                      labels
+                    }
                   }
                 }
               }

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -534,7 +534,7 @@ export class ApiService {
     );
   }
 
-  postRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
+  postRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<ArchivedRecording[]> {
     return this.target.target()
     .pipe(
       filter(target => target !== NO_TARGET),
@@ -554,10 +554,11 @@ export class ApiService {
           }
         }`)
       ),
+      map(v => v.data.targetNodes[0].recordings.archived as ArchivedRecording[]),
     )
   }
 
-  postTargetRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
+  postTargetRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<ActiveRecording[]> {
     return this.target.target()
     .pipe(
       filter(target => target !== NO_TARGET),
@@ -577,6 +578,7 @@ export class ApiService {
           }
         }`)
       ),
+      map(v => v.data.targetNodes[0].recordings.active as ActiveRecording[]),
     )
   }
 

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -535,20 +535,26 @@ export class ApiService {
   }
 
   postRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
-    return this.graphql<any>(`
-    query {
-      targetNodes {
-        recordings {
-          archived(filter: { name: "${recordingName}" }) {
-            doPutMetadata(metadata: { labels: ${this.stringifyRecordingLabels(labels)}}) {
-              metadata {
-                labels
+    return this.target.target()
+    .pipe(
+      filter(target => target !== NO_TARGET),
+      first(),
+      concatMap(target => this.graphql<any>(`
+        query {
+          targetNodes(filter: { name: "${target.connectUrl}" }) {
+            recordings {
+              archived(filter: { name: "${recordingName}" }) {
+                doPutMetadata(metadata: { labels: ${this.stringifyRecordingLabels(labels)}}) {
+                  metadata {
+                    labels
+                  }
+                }
               }
             }
           }
-        }
-      }
-    }`);
+        }`)
+      ),
+    )
   }
 
   postTargetRecordingMetadata(recordingName: string, labels: RecordingLabel[]): Observable<string> {
@@ -571,7 +577,7 @@ export class ApiService {
           }
         }`)
       ),
-      )
+    )
   }
 
   postCredentials(matchExpression: string, username: string, password: string): Observable<boolean> {

--- a/src/test/RecordingMetadata.tsx/BulkEditLabels.test.tsx
+++ b/src/test/RecordingMetadata.tsx/BulkEditLabels.test.tsx
@@ -43,9 +43,8 @@ import { of } from 'rxjs';
 import '@testing-library/jest-dom';
 import { BulkEditLabels } from '@app/RecordingMetadata/BulkEditLabels';
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
-import { ActiveRecording, ArchivedRecording } from '@app/Shared/Services/Api.service';
+import { ArchivedRecording } from '@app/Shared/Services/Api.service';
 import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
-import { Button, TextInput } from '@patternfly/react-core';
 
 jest.mock('@patternfly/react-core', () => ({
   ...jest.requireActual('@patternfly/react-core'),
@@ -76,7 +75,9 @@ const mockArchivedRecordingsResponse = {
     targetNodes: [
       {
         recordings: {
-          archived: [mockRecording] as ArchivedRecording[],
+          archived: {
+            data: [mockRecording] as ArchivedRecording[]
+          }
         },
       },
     ],


### PR DESCRIPTION
Fixes #442 

Uses the backend fix from https://github.com/cryostatio/cryostat/pull/971 to modify and retrieve archived recording labels saved from a specified target. 

I'll add another follow-up PR to apply the same fix to the all-archives view once Hareet merges his.