### PR TITLE
feat(rules): implement initialDelay

### DIFF
--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -392,7 +392,7 @@ const Comp = () => {
                     isRequired
                     type="number"
                     id="preservedArchives"
-                    aria-label="prserved archives"
+                    aria-label="preserved archives"
                     onChange={handleSetPreservedArchives}
                     min="0"
                   />

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -49,13 +49,13 @@ import { CreateRule } from '@app/Rules/CreateRule';
 import { EventTemplate } from '@app/CreateRecording/CreateRecording';
 import { Target } from '@app/Shared/Services/Target.service';
 
-const escapeKeyboardInput = (value: string) => { 
+const escapeKeyboardInput = (value: string) => {
   return value.replace(/[{[]/g, '$&$&');
 }
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
-const mockTarget: Target = { 
-  connectUrl: mockConnectUrl, 
+const mockTarget: Target = {
+  connectUrl: mockConnectUrl,
   alias: 'io.cryostat.Cryostat',
   annotations: {
     cryostat: new Map<string, string>(
@@ -76,6 +76,7 @@ const mockRule: Rule =  {
   matchExpression: "target.alias == 'io.cryostat.Cryostat' || target.annotations.cryostat['PORT'] == 9091",
   eventSpecifier: "template=Profiling,type=TARGET",
   archivalPeriodSeconds: 0,
+  initialDelaySeconds: 0,
   preservedArchives: 0,
   maxAgeSeconds: 0,
   maxSizeBytes: 0

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -159,6 +159,10 @@ describe('<CreateRule/>', () => {
     expect(preservedArchivesInput).toBeInTheDocument();
     expect(preservedArchivesInput).toBeVisible();
 
+    const initialDelayInput = screen.getByLabelText('Initial Delay');
+    expect(initialDelayInput).toBeInTheDocument();
+    expect(initialDelayInput).toBeVisible();
+
     const createButton = screen.getByRole('button', {name: /create/i});
     expect(createButton).toBeInTheDocument();
     expect(createButton).toBeVisible();
@@ -171,6 +175,7 @@ describe('<CreateRule/>', () => {
     userEvent.type(maxAgeInput, `${mockRule.maxAgeSeconds}`);
     userEvent.type(archivalPeriodInput, `${mockRule.archivalPeriodSeconds}`);
     userEvent.type(preservedArchivesInput, `${mockRule.preservedArchives}`);
+    userEvent.type(initialDelayInput, `${mockRule.initialDelaySeconds}`);
 
     await waitFor(() => expect(createButton).not.toBeDisabled());
 

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -55,6 +55,7 @@ const mockRule: Rule =  {
   matchExpression: "target.alias == 'io.cryostat.Cryostat' || target.annotations.cryostat['PORT'] == 9091",
   eventSpecifier: "template=Profiling,type=TARGET",
   archivalPeriodSeconds: 0,
+  initialDelaySeconds: 0,
   preservedArchives: 0,
   maxAgeSeconds: 0,
   maxSizeBytes: 0
@@ -271,7 +272,7 @@ describe('<Rules/>', () => {
     const uploadInput = modal.querySelector("input[accept='.json'][type='file']") as HTMLInputElement;
     expect(uploadInput).toBeInTheDocument();
     expect(uploadInput).not.toBeVisible();
-    
+
     userEvent.click(browseButton);
     userEvent.upload(uploadInput, mockFileUpload);
 

--- a/src/test/Rules/__snapshots__/CreateRule.test.tsx.snap
+++ b/src/test/Rules/__snapshots__/CreateRule.test.tsx.snap
@@ -626,6 +626,102 @@ exports[`<CreateRule/> renders correctly 1`] = `
                   >
                     <label
                       className="pf-c-form__label"
+                      htmlFor="initialDelay"
+                    >
+                      <span
+                        className="pf-c-form__label-text"
+                      >
+                        Initial Delay
+                      </span>
+                    </label>
+                     
+                  </div>
+                  <div
+                    className="pf-c-form__group-control"
+                  >
+                    <div
+                      className="pf-l-split pf-m-gutter"
+                    >
+                      <div
+                        className="pf-l-split__item pf-m-fill"
+                      >
+                        <input
+                          aria-invalid={false}
+                          aria-label="initial delay"
+                          className="pf-c-form-control"
+                          data-ouia-component-id="OUIA-Generated-TextInputBase-7"
+                          data-ouia-component-type="PF4/TextInput"
+                          data-ouia-safe={true}
+                          disabled={false}
+                          id="initialDelay"
+                          min="0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          readOnly={false}
+                          required={true}
+                          type="number"
+                          value={0}
+                        />
+                      </div>
+                      <div
+                        className="pf-l-split__item"
+                      >
+                        <select
+                          aria-invalid={false}
+                          aria-label="initial delay units input"
+                          className="pf-c-form-control"
+                          data-ouia-component-id="OUIA-Generated-FormSelect-default-5"
+                          data-ouia-component-type="PF4/FormSelect"
+                          data-ouia-safe={true}
+                          disabled={false}
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          required={false}
+                          value={1}
+                        >
+                          <option
+                            className=""
+                            disabled={false}
+                            value="1"
+                          >
+                            Seconds
+                          </option>
+                          <option
+                            className=""
+                            disabled={false}
+                            value={60}
+                          >
+                            Minutes
+                          </option>
+                          <option
+                            className=""
+                            disabled={false}
+                            value={3600}
+                          >
+                            Hours
+                          </option>
+                        </select>
+                      </div>
+                    </div>
+                    <div
+                      aria-live="polite"
+                      className="pf-c-form__helper-text"
+                      id="initialDelay-helper"
+                    >
+                      Initial delay before archiving starts. The first archived copy will be made this long after the recording is started. The second archived copy will occur one Archival Period later.
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="pf-c-form__group"
+                >
+                  <div
+                    className="pf-c-form__group-label"
+                  >
+                    <label
+                      className="pf-c-form__label"
                       htmlFor="preservedArchives"
                     >
                       <span
@@ -643,7 +739,7 @@ exports[`<CreateRule/> renders correctly 1`] = `
                       aria-invalid={false}
                       aria-label="prserved archives"
                       className="pf-c-form-control"
-                      data-ouia-component-id="OUIA-Generated-TextInputBase-7"
+                      data-ouia-component-id="OUIA-Generated-TextInputBase-8"
                       data-ouia-component-type="PF4/TextInput"
                       data-ouia-safe={true}
                       disabled={false}

--- a/src/test/Rules/__snapshots__/CreateRule.test.tsx.snap
+++ b/src/test/Rules/__snapshots__/CreateRule.test.tsx.snap
@@ -737,7 +737,7 @@ exports[`<CreateRule/> renders correctly 1`] = `
                   >
                     <input
                       aria-invalid={false}
-                      aria-label="prserved archives"
+                      aria-label="preserved archives"
                       className="pf-c-form-control"
                       data-ouia-component-id="OUIA-Generated-TextInputBase-8"
                       data-ouia-component-type="PF4/TextInput"


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/1014
As usual, this needs to be tested along with the corresponding backend support in https://github.com/cryostatio/cryostat/pull/1015 . For submodule/CI reasons the "depends on" relationship is inverted.

Adds support for the new "initial delay" parameter for automated rule definitions.

Previously, rules only had an "archival period". So when a rule was created with period *t* - or when a new matching target appeared - at time *x* archived recordings would be copied at time *x+t*, *x+2t*, *x+3t*, ... , *x+nt*.

Now, rules can be created with both an archival period and an initial delay. If the rule is created or a target appears at time *x*, and the rule has archival period *t* and initial delay *d*, then archived recordings are copied at *x+d*, *x+d+t*, ... , *x+d+nt*.

It is also possible to have an initial delay defined >0 but the archival period of 0. This has the effect of only copying an archived recording at time *x+d*, exactly once.

If the initial delay is left as 0 and the archival period is >0, the backend will treat this the same way that it used to, with archives being copied at *x+nt*. There will be no copy created immediately at *x*.
