### PR TITLE
fix(rules): automated rule creation now list eventTemplates based on target selector

### DIFF
--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -170,7 +170,7 @@ const Comp = () => {
     archivalPeriod, archivalPeriodUnits, initialDelay, initialDelayUnits,
     preservedArchives, maxAge, maxAgeUnits, maxSize, maxSizeUnits]);
 
-  // FIXME Error 427 JMX Authentication is handled differently than Error 502 Untrusted SSL
+  // FIXME Error 427 JMX Authentication is handled differently than Error 502 Untrusted SSL.
   const refreshTemplateList = React.useCallback(() => {
     addSubscription(
       context.target.target()
@@ -208,7 +208,6 @@ const Comp = () => {
 
   return (
     <BreadcrumbPage pageTitle='Create' breadcrumbs={breadcrumbs} >
-      <Button onClick={() => {context.api.doGet<EventTemplate[]>(`targets/localhost:0/templates`).subscribe()}}/>
       <Grid hasGutter>
         <GridItem xl={7}>
           <Card>

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -170,8 +170,7 @@ const Comp = () => {
     archivalPeriod, archivalPeriodUnits, initialDelay, initialDelayUnits,
     preservedArchives, maxAge, maxAgeUnits, maxSize, maxSizeUnits]);
 
-  // FIXME we query ourselves to populate the list of templates, since Rules can apply to any target. Is this better than making the user write the event specifier manually,
-  // or at least make them write the name manually and choose TARGET/CUSTOM from a dropdown?
+  // FIXME Error 427 JMX Authentication is handled differently than Error 502 Untrusted SSL
   const refreshTemplateList = React.useCallback(() => {
     addSubscription(
       context.target.target()
@@ -190,11 +189,7 @@ const Comp = () => {
           ),
         ),
         first(),
-      ).subscribe({
-        next: (t) => setTemplates(t),
-        error: (e) => console.log(e), 
-        complete: () => console.log("completed")
-      })
+      ).subscribe(setTemplates)
     );
   }, [addSubscription, context, context.api, context.target, setTemplates]);
 

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -38,7 +38,7 @@
 import * as React from 'react';
 import { ActionGroup, Button, Card, CardBody, CardHeader, CardHeaderMain, Form, FormGroup, FormSelect, FormSelectOption, Grid, GridItem, Split, SplitItem, Text, TextInput, TextVariants, ValidatedOptions } from '@patternfly/react-core';
 import { useHistory, withRouter } from 'react-router-dom';
-import { catchError, concatMap, filter, finalize, first, mergeMap, toArray} from 'rxjs/operators';
+import { catchError, filter, first, mergeMap, toArray} from 'rxjs/operators';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { NotificationsContext } from '@app/Notifications/Notifications';
 import { BreadcrumbPage, BreadcrumbTrail } from '@app/BreadcrumbPage/BreadcrumbPage';
@@ -47,7 +47,7 @@ import { EventTemplate } from '../CreateRecording/CreateRecording';
 import { Rule } from './Rules';
 import { MatchExpressionEvaluator } from '../Shared/MatchExpressionEvaluator';
 import { FormSelectTemplateSelector } from '../TemplateSelector/FormSelectTemplateSelector';
-import { NO_TARGET, Target } from '@app/Shared/Services/Target.service';
+import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { iif, of } from 'rxjs';
 
 // FIXME check if this is correct/matches backend name validation

--- a/src/test/Rules/__snapshots__/CreateRule.test.tsx.snap
+++ b/src/test/Rules/__snapshots__/CreateRule.test.tsx.snap
@@ -63,6 +63,22 @@ exports[`<CreateRule/> renders correctly 1`] = `
     <div
       className="pf-l-stack__item"
     >
+      <button
+        aria-disabled={false}
+        aria-label={null}
+        className="pf-c-button pf-m-primary"
+        data-ouia-component-id="OUIA-Generated-Button-primary-1"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe={true}
+        disabled={false}
+        onClick={[Function]}
+        role={null}
+        type="button"
+      />
+    </div>
+    <div
+      className="pf-l-stack__item"
+    >
       <div
         className="pf-l-grid pf-m-gutter"
       >
@@ -775,7 +791,7 @@ exports[`<CreateRule/> renders correctly 1`] = `
                         aria-disabled={true}
                         aria-label={null}
                         className="pf-c-button pf-m-primary pf-m-disabled"
-                        data-ouia-component-id="OUIA-Generated-Button-primary-1"
+                        data-ouia-component-id="OUIA-Generated-Button-primary-2"
                         data-ouia-component-type="PF4/Button"
                         data-ouia-safe={true}
                         disabled={true}

--- a/src/test/Rules/__snapshots__/CreateRule.test.tsx.snap
+++ b/src/test/Rules/__snapshots__/CreateRule.test.tsx.snap
@@ -63,22 +63,6 @@ exports[`<CreateRule/> renders correctly 1`] = `
     <div
       className="pf-l-stack__item"
     >
-      <button
-        aria-disabled={false}
-        aria-label={null}
-        className="pf-c-button pf-m-primary"
-        data-ouia-component-id="OUIA-Generated-Button-primary-1"
-        data-ouia-component-type="PF4/Button"
-        data-ouia-safe={true}
-        disabled={false}
-        onClick={[Function]}
-        role={null}
-        type="button"
-      />
-    </div>
-    <div
-      className="pf-l-stack__item"
-    >
       <div
         className="pf-l-grid pf-m-gutter"
       >
@@ -791,7 +775,7 @@ exports[`<CreateRule/> renders correctly 1`] = `
                         aria-disabled={true}
                         aria-label={null}
                         className="pf-c-button pf-m-primary pf-m-disabled"
-                        data-ouia-component-id="OUIA-Generated-Button-primary-2"
+                        data-ouia-component-id="OUIA-Generated-Button-primary-1"
                         data-ouia-component-type="PF4/Button"
                         data-ouia-safe={true}
                         disabled={true}


### PR DESCRIPTION
Fixes #433 

It works but if a user clicks on a certain target and if there's any errors with SSL authentication or JMX authentication `e.g. HTTP 427: JMX Authentication Failure`, the `ServiceApi` will stop working and get stuck on the error, and hence subsequent clicks on the dropdown targets won't do anything 

I'm not sure why I even get these errors since I'm running 
```
CRYOSTAT_DISABLE_SSL=true CRYOSTAT_DISABLE_JMX_AUTH=true CRYOSTAT_CORS_ORIGIN=http://localhost:9000 sh smoketest.sh
```
