### PR TITLE
fix(templates): delete custom event template no longer deletes default templates with similar name

### DIFF
--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -136,7 +136,7 @@ export const EventTemplates = () => {
   React.useEffect(() => {
     addSubscription(
       context.notificationChannel.messages(NotificationCategory.TemplateDeleted)
-        .subscribe(v => setTemplates(old => old.filter(o => o.name != v.message.template.name)))
+        .subscribe(v => setTemplates(old => old.filter(o => (o.name != v.message.template.name || o.type != v.message.template.type))))
     )
   }, [addSubscription, context, context.notificationChannel, setTemplates]);
 


### PR DESCRIPTION
Fixes #472

The only thing that I'm thinking is if it's better to test every field of a `Template` object instead of just filtering `name` and `type`
i.e. `if (o.name != v.message.template.name) || type != type || provider != provider || description != description ` or make some helper for that.

I'm thinking not, since users can only create `CUSTOM` templates for now and cannot create new custom event templates with the same name, because of this `Event template "Continuous" already exists caused by MutableTemplateService.InvalidEventTemplateException: Event template "Continuous" already exists`