### PR TITLE
feat(recording): include helperText for invalid recording names when creating new recordings with form

### DIFF
--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -234,8 +234,8 @@ export const CustomRecordingForm = (props) => {
         label="Duration"
         isRequired
         validated={durationValid}
-        helperText="Time before the recording is automatically stopped"
-        helperTextInvalid="A recording may only have a non-zero integer duration"
+        helperText={continuous ? "A continuous recording will never be automatically stopped" : "Time before the recording is automatically stopped"}
+        helperTextInvalid="A recording may only have a positive integer duration"
         fieldId="recording-duration"
       >
         <Checkbox

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -200,6 +200,7 @@ export const CustomRecordingForm = (props) => {
         isRequired
         fieldId="recording-name"
         helperText="Enter a recording name. This will be unique within the target JVM"
+        helperTextInvalid="A recording name may only contain letters, numbers, and underscores"
         validated={nameValid}
       >
         <TextInput


### PR DESCRIPTION
Fixes #402

Thoughts or anything I missed? 

One thing I was wondering about was that, if users put 0 in the `Duration` input, the recording will be set to `Continuous` and I'm wondering if there's any indication that that is the case on the UI somewhere, and if not, if that should be included as well.