### PR TITLE
fix(recordings): remove unnecessary recording filter queries

### DIFF
--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -531,7 +531,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
     return (
       <Toolbar id="active-recordings-toolbar" clearAllFilters={handleClearFilters}>
         <ToolbarContent>
-        <RecordingFilters filters={filters} setFilters={setFilters} />
+        <RecordingFilters recordings={recordings} filters={filters} setFilters={setFilters} />        
         { buttons }
         { deleteActiveWarningModal }
         </ToolbarContent>

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -378,7 +378,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
     return (
       <Toolbar id="archived-recordings-toolbar" clearAllFilters={handleClearFilters}>
         <ToolbarContent>
-          <RecordingFilters filters={filters} setFilters={setFilters} />
+          <RecordingFilters recordings={recordings} filters={filters} setFilters={setFilters} />
           <ToolbarGroup variant="button-group">
             <ToolbarItem>
               <Button key="edit labels" variant="secondary" onClick={handleEditLabels} isDisabled={!checkedIndices.length}>Edit Labels</Button>

--- a/src/app/Recordings/NameFilter.tsx
+++ b/src/app/Recordings/NameFilter.tsx
@@ -39,12 +39,11 @@
 import React from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { NO_TARGET } from '@app/Shared/Services/Target.service';
-import { concatMap, filter, first, map } from 'rxjs';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { ArchivedRecording } from '@app/Shared/Services/Api.service';
 
 export interface NameFilterProps {
+  recordings: ArchivedRecording[];
   onSubmit: (inputName) => void;
 }
 
@@ -69,38 +68,9 @@ export const NameFilter: React.FunctionComponent<NameFilterProps> = (props) => {
     [props.onSubmit, setIsOpen, setSelected]
   );
 
-  const refreshRecordingList = React.useCallback(() => {
-    addSubscription(
-      context.target
-        .target()
-        .pipe(
-          filter((target) => target !== NO_TARGET),
-          concatMap(target =>
-            context.api.graphql<any>(`
-              query {
-                targetNodes(filter: { name: "${target.connectUrl}" }) {
-                  recordings {
-                    active {
-                      name
-                    }
-                    archived {
-                      name
-                    }
-                  }
-                }
-              }`)
-          ),
-          map(v => [...v.data.targetNodes[0].recordings.active as ArchivedRecording[],
-          ...v.data.targetNodes[0].recordings.archived as ArchivedRecording[]]),
-          first()
-        )
-        .subscribe((recordings) => setNames(recordings.map((r) => r.name)))
-    );
-  }, [addSubscription, context, context.target, context.api]);
-
   React.useEffect(() => {
-    addSubscription(context.target.target().subscribe(refreshRecordingList));
-  }, [addSubscription, context, context.target, refreshRecordingList]);
+    setNames(props.recordings.map((r) => r.name));
+  }, [setNames, props.recordings]);
 
   return (
     <Select

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 
-import { RecordingState } from '@app/Shared/Services/Api.service';
+import { ArchivedRecording, RecordingState } from '@app/Shared/Services/Api.service';
 import {
   Checkbox,
   Dropdown,
@@ -63,6 +63,7 @@ import { LabelFilter } from './LabelFilter';
 import { NameFilter } from './NameFilter';
 
 export interface RecordingFiltersProps {
+  recordings: ArchivedRecording[];
   filters: RecordingFiltersCategories;
   setFilters: Dispatch<SetStateAction<RecordingFiltersCategories>>;
 }
@@ -226,10 +227,10 @@ export const RecordingFilters: React.FunctionComponent<RecordingFiltersProps> = 
   const filterDropdownItems = React.useMemo(
     () => [
       <InputGroup>
-        <NameFilter onSubmit={onNameInput} />
+        <NameFilter recordings={props.recordings} onSubmit={onNameInput} />
       </InputGroup>,
       <InputGroup>
-        <LabelFilter onSubmit={onLabelInput} />
+        <LabelFilter recordings={props.recordings} onSubmit={onLabelInput} />
       </InputGroup>,
       <Select
         variant={SelectVariant.checkbox}


### PR DESCRIPTION
Related #486
Related #488

Thanks @hareetd for noticing that the search filters PR causes repeated graphql queries triggered by the `NameFilter` and `LabelFilter` components re-rendering excessively. I removed the graphql recording queries and pass the list of recordings as a prop for the filter components instead.