### PR TITLE
fix(targets): select TargetSelect to none when TargetJvmNotification LOST if that target is currently selected

### DIFF
--- a/src/app/Shared/MatchExpressionEvaluator.tsx
+++ b/src/app/Shared/MatchExpressionEvaluator.tsx
@@ -60,7 +60,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
     addSubscription(
       context.target.target().subscribe(setTarget)
     );
-  }, [context, context.target]);
+  }, [addSubscription, context, context.target]);
 
   React.useEffect(() => {
     if (!props.matchExpression || !target?.connectUrl) {

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -148,7 +148,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
       }
     }
     setExpanded(false);
-  }, [context, context.target, selected, notifications, setExpanded, setCachedTargetSelection, removeCachedTargetSelection]);
+  }, [context, context.target, selected, notifications, setExpanded]);
 
   const selectNone = React.useCallback(() => {
     onSelect(undefined, undefined, true);

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -82,8 +82,8 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
               connectUrl: evt.serviceRef.connectUrl,
               alias: evt.serviceRef.alias,
             }
-            context.target.target().subscribe((currentTarget) => {
-              if (currentTarget.connectUrl == target.connectUrl && currentTarget.alias == target.alias) {
+            context.target.target().pipe(first()).subscribe((currentTarget) => {
+              if (currentTarget.connectUrl === target.connectUrl && currentTarget.alias === target.alias) {
                 selectNone();
               }
             })

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -48,6 +48,7 @@ import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { CreateRule } from '@app/Rules/CreateRule';
 import { EventTemplate } from '@app/CreateRecording/CreateRecording';
 import { Target } from '@app/Shared/Services/Target.service';
+import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
 
 const escapeKeyboardInput = (value: string) => {
   return value.replace(/[{[]/g, '$&$&');
@@ -82,6 +83,18 @@ const mockRule: Rule =  {
   maxSizeBytes: 0
 };
 
+const mockNewTarget: Target = {
+  connectUrl: 'service:jmx:rmi://someUrl1',
+  alias: 'someAlias',
+}
+
+const mockTargetFoundNotification = {
+  message: {
+    event: { kind: 'FOUND', serviceRef: mockNewTarget }
+  }
+} as NotificationMessage;
+
+
 const history = createMemoryHistory();
 
 jest.mock('react-router-dom', () => ({
@@ -91,6 +104,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const createSpy = jest.spyOn(defaultServices.api, 'createRule').mockReturnValue(of(true));
+jest.spyOn(defaultServices.notificationChannel, 'messages').mockReturnValue(of(mockTargetFoundNotification));
 jest.spyOn(defaultServices.api, 'doGet').mockReturnValue(of([mockEventTemplate]));
 jest.spyOn(defaultServices.target, 'target').mockReturnValue(of(mockTarget));
 jest.spyOn(defaultServices.targets, 'targets').mockReturnValue(of([mockTarget]));


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat-web/issues/294#issuecomment-1204281360
Depends on https://github.com/cryostatio/cryostat/pull/1037
Fixes #294

The fix stops the `TargetSelect` from selecting a target if it was selected when a `TargetJvmDiscovery` LOST notification is emitted. So it is entirely dependent on LOST notifications getting through somewhat quickly.