### PR TITLE
fix(about): correct logo height using \!important override

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -58,7 +58,7 @@ html, body, #root {
   padding-right: 10rem;
 }
 .cryostat-logo {
-  height: 2em;
+  height: 2em !important;
 }
 
 .recordings-table-drawer-content {


### PR DESCRIPTION
override some Patternfly styling update that broke this view

Fixes #514
