### PR TITLE
chore(deps): update to React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "npm-run-all -l -p format eslint",
     "format": "npm-run-all format:check",
     "format:check": "npm-run-all -l license:check prettier:check",
-    "format:apply": "npm-run-all -l -p license:apply prettier:apply",
+    "format:apply": "npm-run-all -l -p license:apply eslint:apply prettier:apply",
     "prettier:check": "prettier --check './src/**/*.{tsx,ts}'",
     "prettier:apply": "prettier --write './src/**/*.{tsx,ts}'",
     "build:bundle-profile": "webpack --config webpack.prod.js --profile --json > stats.json",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "yarn:frzinstall": "yarn install --frozen-lockfile"
   },
   "devDependencies": {
-    "@testing-library/dom": "^8.11.3",
-    "@testing-library/jest-dom": "^5.16.2",
-    "@testing-library/react": "^12.1.4",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/dom": "^8.18.1",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/enzyme": "^3.10.9",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^27.0.2",
@@ -71,6 +71,7 @@
     "react-axe": "^3.4.1",
     "react-docgen-typescript-loader": "^3.7.2",
     "react-router-dom": "^5.3.0",
+    "react-test-renderer": "^18.2.0",
     "regenerator-runtime": "^0.13.9",
     "rimraf": "^3.0.2",
     "rxjs": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^27.0.2",
     "@types/js-base64": "3.0.0",
+    "@types/react": "^18.0.21",
+    "@types/react-dom": "^18.0.6",
     "@types/react-test-renderer": "^17.0.1",
     "@types/victory": "^33.1.5",
     "@typescript-eslint/eslint-plugin": "^4.32.0",

--- a/package.json
+++ b/package.json
@@ -96,8 +96,8 @@
     "@reduxjs/toolkit": "^1.8.5",
     "@types/lodash": "^4.14.175",
     "express": "^4.17.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
     "react-router-last-location": "^2.0.1"
   }

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -326,7 +326,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
               actionClose={<AlertActionCloseButton onClose={() => handleMarkNotificationRead(key)} />}
               timeout={true}
             >
-              {message}
+              {message as string}
             </Alert>
           ))}
       </AlertGroup>

--- a/src/app/AppLayout/JmxAuthForm.tsx
+++ b/src/app/AppLayout/JmxAuthForm.tsx
@@ -43,6 +43,7 @@ export interface JmxAuthFormProps {
   onDismiss: () => void;
   onSave: (username: string, password: string) => Promise<void>;
   focus?: boolean;
+  children?: React.ReactNode;
 }
 
 export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) => {

--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -85,7 +85,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<AllTarge
         for (let i = 0; i < targets.length; i++) {
           if (targets[i].connectUrl === connectUrl) {
             setCounts((old) => {
-              let updated = [...old];
+              const updated = [...old];
               updated[i] += delta;
               return updated;
             });
@@ -98,8 +98,8 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<AllTarge
 
     const handleTargetsAndCounts = React.useCallback(
       (targetNodes) => {
-        let updatedTargets: Target[] = [];
-        let updatedCounts: number[] = [];
+        const updatedTargets: Target[] = [];
+        const updatedCounts: number[] = [];
         for (const node of targetNodes) {
           const target: Target = {
             connectUrl: node.target.serviceUri,
@@ -179,7 +179,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<AllTarge
         });
         setExpandedTargets((old) => old.filter((o) => !_.isEqual(o, target)));
         setCounts((old) => {
-          let updated = [...old];
+          const updated = [...old];
           updated.splice(idx, 1);
           return updated;
         });
@@ -276,7 +276,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<AllTarge
     );
 
     const isHidden = React.useMemo(() => {
-      let isHidden: boolean[] = [];
+      const isHidden: boolean[] = [];
       targets.map((target, idx) => {
         isHidden.push(!searchedTargets.includes(target) || (hideEmptyTargets && counts[idx] === 0));
       });
@@ -285,7 +285,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<AllTarge
 
     const targetRows = React.useMemo(() => {
       return targets.map((target, idx) => {
-        let isExpanded: boolean = expandedTargets.includes(target);
+        const isExpanded: boolean = expandedTargets.includes(target);
 
         const handleToggle = () => {
           if (counts[idx] !== 0 || isExpanded) {
@@ -320,7 +320,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<AllTarge
 
     const recordingRows = React.useMemo(() => {
       return targets.map((target, idx) => {
-        let isExpanded: boolean = expandedTargets.includes(target);
+        const isExpanded: boolean = expandedTargets.includes(target);
 
         return (
           <Tr key={`${idx}_child`} isExpanded={isExpanded} isHidden={isHidden[idx]}>
@@ -337,7 +337,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<AllTarge
     }, [targets, expandedTargets, isHidden]);
 
     const rowPairs = React.useMemo(() => {
-      let rowPairs: JSX.Element[] = [];
+      const rowPairs: JSX.Element[] = [];
       for (let i = 0; i < targetRows.length; i++) {
         rowPairs.push(targetRows[i]);
         rowPairs.push(recordingRows[i]);

--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -42,6 +42,7 @@ import { Breadcrumb, BreadcrumbHeading, BreadcrumbItem, PageSection, Stack, Stac
 interface BreadcrumbPageProps {
   pageTitle: string;
   breadcrumbs?: BreadcrumbTrail[];
+  children?: React.ReactNode;
 }
 
 export interface BreadcrumbTrail {

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -134,18 +134,18 @@ export const CustomRecordingForm = (props) => {
   );
 
   const getEventString = React.useCallback(() => {
-    var str = '';
-    if (!!template) {
+    let str = '';
+    if (template) {
       str += `template=${template}`;
     }
-    if (!!templateType) {
+    if (templateType) {
       str += `,type=${templateType}`;
     }
     return str;
   }, [template, templateType]);
 
   const getFormattedLabels = React.useCallback(() => {
-    let obj = {};
+    const obj = {};
 
     labels.forEach((l) => {
       if (!!l.key && !!l.value) {
@@ -346,11 +346,7 @@ export const CustomRecordingForm = (props) => {
           isRequired
           fieldId="recording-template"
           validated={
-            template === null
-              ? ValidatedOptions.default
-              : !!template
-              ? ValidatedOptions.success
-              : ValidatedOptions.error
+            template === null ? ValidatedOptions.default : template ? ValidatedOptions.success : ValidatedOptions.error
           }
           helperTextInvalid="A Template must be selected"
         >

--- a/src/app/Login/BasicAuthForm.tsx
+++ b/src/app/Login/BasicAuthForm.tsx
@@ -58,7 +58,7 @@ export const BasicAuthForm: React.FunctionComponent<FormProps> = (props) => {
           setUsername(creds);
           return;
         }
-        let parts: string[] = creds.split(':');
+        const parts: string[] = creds.split(':');
         setUsername(parts[0]);
         setPassword(parts[1]);
       });

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -196,7 +196,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
                     <NotificationDrawerListItem key={key} variant={variant} onClick={() => markRead(key)} isRead={read}>
                       <NotificationDrawerListItemHeader title={title} variant={variant} />
                       <NotificationDrawerListItemBody timestamp={timestampToDateTimeString(timestamp)}>
-                        <Text component={TextVariants.p}>{message}</Text>
+                        <Text component={TextVariants.p}>{message as String}</Text>
                       </NotificationDrawerListItemBody>
                     </NotificationDrawerListItem>
                   ))}

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -196,7 +196,7 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
                     <NotificationDrawerListItem key={key} variant={variant} onClick={() => markRead(key)} isRead={read}>
                       <NotificationDrawerListItemHeader title={title} variant={variant} />
                       <NotificationDrawerListItemBody timestamp={timestampToDateTimeString(timestamp)}>
-                        <Text component={TextVariants.p}>{message as String}</Text>
+                        <Text component={TextVariants.p}>{message as string}</Text>
                       </NotificationDrawerListItemBody>
                     </NotificationDrawerListItem>
                   ))}

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -115,11 +115,11 @@ export class Notifications {
     return this.notifications().pipe(map((a) => a.filter(Notifications.isProblemNotification)));
   }
 
-  setRead(key?: string, read: boolean = true): void {
+  setRead(key?: string, read = true): void {
     if (!key) {
       return;
     }
-    for (let n of this._notifications) {
+    for (const n of this._notifications) {
       if (n.key === key) {
         n.read = read;
       }
@@ -128,7 +128,7 @@ export class Notifications {
   }
 
   markAllRead(): void {
-    for (let n of this._notifications) {
+    for (const n of this._notifications) {
       n.read = true;
     }
     this._notifications$.next(this._notifications);

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -118,7 +118,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
 
   const updateCommonLabels = React.useCallback(
     (setLabels: (l: RecordingLabel[]) => void) => {
-      let allRecordingLabels = [] as RecordingLabel[][];
+      const allRecordingLabels = [] as RecordingLabel[][];
 
       recordings.forEach((r: ArchivedRecording) => {
         const idx = getIdxFromRecording(r);

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -75,7 +75,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
   );
 
   const handleUpdateLabels = React.useCallback(() => {
-    const tasks: Observable<any>[] = [];
+    const tasks: Observable<ActiveRecording[] | ArchivedRecording[]>[] = [];
     const toDelete = savedCommonLabels.filter((label) => !includesLabel(commonLabels, label));
 
     recordings.forEach((r: ArchivedRecording) => {
@@ -88,8 +88,8 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
 
         tasks.push(
           props.isTargetRecording
-            ? context.api.postTargetRecordingMetadata(r.name, updatedLabels).pipe(first())
-            : context.api.postRecordingMetadata(r.name, updatedLabels).pipe(first())
+            ? context.api.postTargetRecordingMetadata(r.name, updatedLabels)
+            : context.api.postRecordingMetadata(r.name, updatedLabels)
         );
       }
     });

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -61,20 +61,20 @@ export const LabelPattern = /^\S+$/;
 
 export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsProps> = (props) => {
   const [validKeys, setValidKeys] = React.useState(
-    Array(!!props.labels ? props.labels.length : 0).fill(ValidatedOptions.default)
+    Array(props.labels ? props.labels.length : 0).fill(ValidatedOptions.default)
   );
   const [validValues, setValidVals] = React.useState(
-    Array(!!props.labels ? props.labels.length : 0).fill(ValidatedOptions.default)
+    Array(props.labels ? props.labels.length : 0).fill(ValidatedOptions.default)
   );
-  const [keys, setKeys] = React.useState(!!props.labels ? props.labels.map((l) => l.key) : []);
+  const [keys, setKeys] = React.useState(props.labels ? props.labels.map((l) => l.key) : []);
 
   const handleKeyChange = React.useCallback(
     (idx, key) => {
-      let updatedLabels = [...props.labels];
+      const updatedLabels = [...props.labels];
       updatedLabels[idx].key = key;
       props.setLabels(updatedLabels);
 
-      let updatedKeys = [...keys];
+      const updatedKeys = [...keys];
       updatedKeys[idx] = key;
       setKeys(updatedKeys);
 
@@ -85,7 +85,7 @@ export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsP
 
   const handleValueChange = React.useCallback(
     (idx, value) => {
-      let updatedLabels = [...props.labels];
+      const updatedLabels = [...props.labels];
       updatedLabels[idx].value = value;
       props.setLabels(updatedLabels);
 
@@ -113,13 +113,13 @@ export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsP
   );
 
   const removeAtIndex = (idx, arr, setArr) => {
-    let updated = [...arr];
+    const updated = [...arr];
     updated.splice(idx, 1);
     setArr(updated);
   };
 
   const updateValidState = (idx, isValid, arr, setArr) => {
-    let updated = [...arr];
+    const updated = [...arr];
     updated[idx] = getValidatedOption(isValid);
     setArr(updated);
   };

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -350,7 +350,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
   }, [dispatch, deleteAllFiltersIntent, targetConnectURL]);
 
   const updateFilters = React.useCallback(
-    (target, { filterValue, filterKey, deleted = false, deleteOptions }) => {
+    (target, { filterValue, filterKey, deleted = false, deleteOptions } : UpdateFilterOptions ) => {
       if (deleted) {
         if (deleteOptions && deleteOptions.all) {
           dispatch(deleteCategoryFiltersIntent(target, filterKey, false));

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -350,7 +350,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
   }, [dispatch, deleteAllFiltersIntent, targetConnectURL]);
 
   const updateFilters = React.useCallback(
-    (target, { filterValue, filterKey, deleted = false, deleteOptions } : UpdateFilterOptions ) => {
+    (target, { filterValue, filterKey, deleted = false, deleteOptions }: UpdateFilterOptions) => {
       if (deleted) {
         if (deleteOptions && deleteOptions.all) {
           dispatch(deleteCategoryFiltersIntent(target, filterKey, false));

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -203,7 +203,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
   }, [dispatch, deleteAllFiltersIntent, targetConnectURL]);
 
   const updateFilters = React.useCallback(
-    (target, { filterValue, filterKey, deleted = false, deleteOptions }) => {
+    (target, { filterValue, filterKey, deleted = false, deleteOptions } : UpdateFilterOptions) => {
       if (deleted) {
         if (deleteOptions && deleteOptions.all) {
           dispatch(deleteCategoryFiltersIntent(target, filterKey, true));

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -203,7 +203,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
   }, [dispatch, deleteAllFiltersIntent, targetConnectURL]);
 
   const updateFilters = React.useCallback(
-    (target, { filterValue, filterKey, deleted = false, deleteOptions } : UpdateFilterOptions) => {
+    (target, { filterValue, filterKey, deleted = false, deleteOptions }: UpdateFilterOptions) => {
       if (deleted) {
         if (deleteOptions && deleteOptions.all) {
           dispatch(deleteCategoryFiltersIntent(target, filterKey, true));

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -72,13 +72,11 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
     addSubscription(
       props
         .uploadFn()
-        .pipe(first())
         .subscribe((success) => {
           if (success) {
             notifications.success('Upload Success', `Recording "${props.recording.name}" uploaded`);
             context.api
               .grafanaDashboardUrl()
-              .pipe(first())
               .subscribe((url) => window.open(url, '_blank'));
           }
         })

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -70,16 +70,12 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
   const grafanaUpload = React.useCallback(() => {
     notifications.info('Upload Started', `Recording "${props.recording.name}" uploading...`);
     addSubscription(
-      props
-        .uploadFn()
-        .subscribe((success) => {
-          if (success) {
-            notifications.success('Upload Success', `Recording "${props.recording.name}" uploaded`);
-            context.api
-              .grafanaDashboardUrl()
-              .subscribe((url) => window.open(url, '_blank'));
-          }
-        })
+      props.uploadFn().subscribe((success) => {
+        if (success) {
+          notifications.success('Upload Success', `Recording "${props.recording.name}" uploaded`);
+          context.api.grafanaDashboardUrl().subscribe((url) => window.open(url, '_blank'));
+        }
+      })
     );
   }, [addSubscription, notifications, props.uploadFn, context.api]);
 

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -279,7 +279,7 @@ export const filterRecordings = (recordings: any[], filters: RecordingFiltersCat
 
   let filtered = recordings;
 
-  if (!!filters.Name.length) {
+  if (filters.Name.length) {
     filtered = filtered.filter((r) => filters.Name.includes(r.name));
   }
   if (!!filters.State && !!filters.State.length) {
@@ -314,7 +314,7 @@ export const filterRecordings = (recordings: any[], filters: RecordingFiltersCat
       }).length;
     });
   }
-  if (!!filters.Label.length) {
+  if (filters.Label.length) {
     filtered = filtered.filter(
       (r) => Object.entries(r.metadata.labels).filter(([k, v]) => filters.Label.includes(`${k}:${v}`)).length
     );

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -61,6 +61,7 @@ export interface RecordingsTableProps {
   errorMessage: string;
   onHeaderCheck: (event, checked: boolean) => void;
   clearFilters?: (filterType) => void;
+  children?: React.ReactNode;
 }
 
 export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (props) => {

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -105,11 +105,11 @@ const Comp = () => {
   );
 
   const eventSpecifierString = React.useMemo(() => {
-    var str = '';
-    if (!!template) {
+    let str = '';
+    if (template) {
       str += `template=${template}`;
     }
-    if (!!templateType) {
+    if (templateType) {
       str += `,type=${templateType}`;
     }
     return str;
@@ -349,7 +349,7 @@ const Comp = () => {
                   validated={
                     template === null
                       ? ValidatedOptions.default
-                      : !!template
+                      : template
                       ? ValidatedOptions.success
                       : ValidatedOptions.error
                   }

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -254,7 +254,7 @@ export const Rules = () => {
   }, [rules, sortBy]);
 
   const handleDelete = React.useCallback(
-    (rowData: IRowData, clean: boolean = true) => {
+    (rowData: IRowData, clean = true) => {
       addSubscription(
         context.api
           .deleteRule(rowData[0], clean)

--- a/src/app/SecurityPanel/CertificateUploadModal.tsx
+++ b/src/app/SecurityPanel/CertificateUploadModal.tsx
@@ -85,7 +85,7 @@ export const CertificateUploadModal: React.FunctionComponent<CertificateUploadMo
       notifications.warning('Attempted to submit certificate upload without a file selected');
       return;
     }
-    let type = uploadFile.type;
+    const type = uploadFile.type;
     if (type != 'application/x-x509-ca-cert' && type != 'application/pkix-cert') {
       notifications.warning('File format is not compatible');
       return;

--- a/src/app/SecurityPanel/Credentials/StoreJmxCredentials.tsx
+++ b/src/app/SecurityPanel/Credentials/StoreJmxCredentials.tsx
@@ -80,7 +80,7 @@ const reducer = (state, action) => {
   switch (action.type) {
     case Actions.HANDLE_REFRESH: {
       const credentials: StoredCredential[] = action.payload.credentials;
-      let counts: number[] = [];
+      const counts: number[] = [];
       for (const c of credentials) {
         counts.push(c.numMatchingTargets);
       }
@@ -92,9 +92,9 @@ const reducer = (state, action) => {
     }
     case Actions.HANDLE_TARGET_NOTIFICATION: {
       const target: Target = action.payload.target;
-      let updated = [...state.counts];
+      const updated = [...state.counts];
       for (let i = 0; i < state.credentials.length; i++) {
-        let match: boolean = eval(state.credentials[i].matchExpression);
+        const match: boolean = eval(state.credentials[i].matchExpression);
         if (match) {
           updated[i] += action.payload.kind === 'FOUND' ? 1 : -1;
         }
@@ -331,8 +331,8 @@ export const StoreJmxCredentials = () => {
 
   const matchExpressionRows = React.useMemo(() => {
     return state.credentials.map((credential, idx) => {
-      let isExpanded: boolean = state.expandedCredentials.includes(credential);
-      let isChecked: boolean = state.checkedCredentials.includes(credential);
+      const isExpanded: boolean = state.expandedCredentials.includes(credential);
+      const isChecked: boolean = state.checkedCredentials.includes(credential);
 
       const handleToggleExpanded = () => {
         if (state.counts[idx] !== 0 || isExpanded) {
@@ -378,7 +378,7 @@ export const StoreJmxCredentials = () => {
 
   const targetRows = React.useMemo(() => {
     return state.credentials.map((credential, idx) => {
-      let isExpanded: boolean = state.expandedCredentials.includes(credential);
+      const isExpanded: boolean = state.expandedCredentials.includes(credential);
 
       return (
         <Tr key={`${idx}_child`} isExpanded={isExpanded}>
@@ -395,7 +395,7 @@ export const StoreJmxCredentials = () => {
   }, [state.credentials, state.expandedCredentials]);
 
   const rowPairs = React.useMemo(() => {
-    let rowPairs: JSX.Element[] = [];
+    const rowPairs: JSX.Element[] = [];
     for (let i = 0; i < matchExpressionRows.length; i++) {
       rowPairs.push(matchExpressionRows[i]);
       rowPairs.push(targetRows[i]);

--- a/src/app/Settings/CredentialsStorage.tsx
+++ b/src/app/Settings/CredentialsStorage.tsx
@@ -64,7 +64,7 @@ export class Locations {
 const locations = [Locations.BROWSER_SESSION, Locations.BACKEND];
 
 const getLocation = (key: string): Location => {
-  for (let l of locations) {
+  for (const l of locations) {
     if (l.key === key) {
       return l;
     }
@@ -78,7 +78,7 @@ const Component = () => {
 
   const handleSelect = React.useCallback(
     (_, selection) => {
-      let location = getLocation(selection);
+      const location = getLocation(selection);
       setSelection(location.key);
       setExpanded(false);
       saveToLocalStorage('JMX_CREDENTIAL_LOCATION', selection);

--- a/src/app/Shared/MatchExpressionEvaluator.tsx
+++ b/src/app/Shared/MatchExpressionEvaluator.tsx
@@ -98,7 +98,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
   }, [target, props.matchExpression]);
 
   React.useEffect(() => {
-    if (!!props.onChange) {
+    if (props.onChange) {
       props.onChange(valid);
     }
   }, [props.onChange, valid]);

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -217,7 +217,7 @@ export class ApiService {
     );
   }
 
-  deleteRule(name: string, clean: boolean = true): Observable<boolean> {
+  deleteRule(name: string, clean = true): Observable<boolean> {
     return this.sendRequest('v2', `rules/${name}?clean=${clean}`, {
       method: 'DELETE',
     }).pipe(
@@ -233,7 +233,7 @@ export class ApiService {
     if (!!recordingAttributes.duration && recordingAttributes.duration > 0) {
       form.append('duration', String(recordingAttributes.duration));
     }
-    if (!!recordingAttributes.options) {
+    if (recordingAttributes.options) {
       if (recordingAttributes.options.toDisk != null) {
         form.append('toDisk', String(recordingAttributes.options.toDisk));
       }
@@ -244,7 +244,7 @@ export class ApiService {
         form.append('maxSize', String(recordingAttributes.options.maxSize));
       }
     }
-    if (!!recordingAttributes.metadata) {
+    if (recordingAttributes.metadata) {
       form.append('metadata', JSON.stringify(recordingAttributes.metadata));
     }
 
@@ -846,4 +846,4 @@ export interface MatchedCredential {
 
 // New target specific archived recording apis now enforce a non-empty target field
 // The placeholder targetId for uploaded (non-target) recordings is "uploads"
-export const UPLOADS_SUBDIRECTORY: string = 'uploads';
+export const UPLOADS_SUBDIRECTORY = 'uploads';

--- a/src/app/Shared/Services/JmxCredentials.service.tsx
+++ b/src/app/Shared/Services/JmxCredentials.service.tsx
@@ -52,7 +52,7 @@ export class JmxCredentials {
   constructor(private readonly api: () => ApiService) {}
 
   setCredential(targetId: string, username: string, password: string): Observable<boolean> {
-    let location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BROWSER_SESSION.key);
+    const location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BROWSER_SESSION.key);
     switch (location) {
       case Locations.BACKEND.key:
         return this.api().postCredentials(`target.connectUrl == "${targetId}"`, username, password);
@@ -66,7 +66,7 @@ export class JmxCredentials {
   }
 
   getCredential(targetId: string): Observable<Credential | undefined> {
-    let location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BROWSER_SESSION.key);
+    const location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BROWSER_SESSION.key);
     switch (location) {
       case Locations.BACKEND.key:
         // if this is stored on the backend then Cryostat should be using those and not prompting us to request from the user

--- a/src/app/Shared/Services/Login.service.tsx
+++ b/src/app/Shared/Services/Login.service.tsx
@@ -151,7 +151,7 @@ export class LoginService {
       headers.set('Authorization', AuthMethod.NONE);
     }
     if (jmxCredential) {
-      let basic = `${jmxCredential.username}:${jmxCredential.password}`;
+      const basic = `${jmxCredential.username}:${jmxCredential.password}`;
       headers.set('X-JMX-Authorization', `Basic ${Base64.encode(basic)}`);
     }
     return headers;
@@ -257,12 +257,12 @@ export class LoginService {
   }
 
   private getTokenFromUrlFragment(): string {
-    var matches = location.hash.match(new RegExp('access_token' + '=([^&]*)'));
+    const matches = location.hash.match(new RegExp('access_token' + '=([^&]*)'));
     return matches ? matches[1] : '';
   }
 
   private hasBearerTokenUrlHash(): boolean {
-    var matches = location.hash.match('token_type=Bearer');
+    const matches = location.hash.match('token_type=Bearer');
     return !!matches;
   }
 
@@ -297,7 +297,7 @@ export class LoginService {
 
   private getCacheItem(key: string): string {
     const item = sessionStorage.getItem(key);
-    return !!item ? item : '';
+    return item ? item : '';
   }
 
   private setCacheItem(key: string, token: string): void {

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -301,10 +301,10 @@ export class NotificationChannel {
     const notificationsUrl = fromFetch(`${this.login.authority}/api/v1/notifications_url`).pipe(
       concatMap(async (resp) => {
         if (resp.ok) {
-          let body: any = await resp.json();
+          const body: any = await resp.json();
           return body.notificationsUrl;
         } else {
-          let body: string = await resp.text();
+          const body: string = await resp.text();
           throw new Error(resp.status + ' ' + body);
         }
       })
@@ -336,7 +336,7 @@ export class NotificationChannel {
             subprotocol = `basic.authorization.cryostat.${token}`;
           }
 
-          if (!!this.ws) {
+          if (this.ws) {
             this.ws.complete();
           }
 
@@ -418,7 +418,7 @@ export class NotificationChannel {
     window.console.error(err?.message);
     window.console.error(err?.stack);
 
-    if (!!err?.message) {
+    if (err?.message) {
       this.notifications.danger(title, JSON.stringify(err?.message));
     }
   }

--- a/src/app/Shared/Services/Report.service.tsx
+++ b/src/app/Shared/Services/Report.service.tsx
@@ -50,8 +50,8 @@ export class ReportService {
     if (!recording?.reportUrl) {
       return throwError(() => new Error('No recording report URL'));
     }
-    let stored = sessionStorage.getItem(this.key(recording));
-    if (!!stored) {
+    const stored = sessionStorage.getItem(this.key(recording));
+    if (stored) {
       return of(stored);
     }
     return this.login.getHeaders().pipe(

--- a/src/app/Shared/Services/Settings.service.tsx
+++ b/src/app/Shared/Services/Settings.service.tsx
@@ -89,7 +89,7 @@ export class SettingsService {
 
   deletionDialogsEnabled(): Map<DeleteWarningType, boolean> {
     const raw = window.localStorage.getItem(StorageKeys.DeletionDialogsEnabled);
-    if (!!raw) {
+    if (raw) {
       try {
         const map = JSON.parse(raw);
         if (typeof map === 'object') {
@@ -138,7 +138,7 @@ export class SettingsService {
 
   notificationsEnabled(): Map<NotificationCategory, boolean> {
     const raw = window.localStorage.getItem(StorageKeys.NotificationsEnabled);
-    if (!!raw) {
+    if (raw) {
       try {
         const map = JSON.parse(raw);
         if (typeof map === 'object') {

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -46,6 +46,7 @@ interface TargetViewProps {
   pageTitle: string;
   compactSelect?: boolean;
   breadcrumbs?: BreadcrumbTrail[];
+  children?: React.ReactNode;
 }
 
 export const TargetView: React.FunctionComponent<TargetViewProps> = (props) => {

--- a/src/app/TemplateSelector/TemplateSelector.tsx
+++ b/src/app/TemplateSelector/TemplateSelector.tsx
@@ -44,6 +44,7 @@ export interface TemplateSelectorProps {
   placeholder: JSX.Element;
   customGroup: (el: JSX.Element[]) => JSX.Element;
   targetGroup: (el: JSX.Element[]) => JSX.Element;
+  children?: React.ReactNode;
 }
 
 export const TemplateSelector: React.FunctionComponent<TemplateSelectorProps> = (props) => {

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 
-export const createBlobURL = (content: any, contentType: string, timeout: number = 1000) => {
+export const createBlobURL = (content: any, contentType: string, timeout = 1000) => {
   const blob = new Blob([content], { type: contentType });
   const url = window.URL.createObjectURL(blob);
   setTimeout(() => window.URL.revokeObjectURL(url), timeout);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,6 +37,7 @@
  */
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { App } from '@app/index';
 
 if (process.env.NODE_ENV !== 'production') {
@@ -53,4 +54,5 @@ if (process.env.NODE_ENV !== 'production') {
   axe(React, ReactDOM, 1000, config);
 }
 
-ReactDOM.render(<App />, document.getElementById('root') as HTMLElement);
+const root = createRoot(document.getElementById('root') as HTMLElement);
+root.render(<App />);

--- a/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
@@ -273,7 +273,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     expect(screen.getByText(`${mockCount3}`)).toBeInTheDocument();
   });
 
-  it('hides targets with zero recordings', () => {
+  it('hides targets with zero recordings', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <AllTargetsArchivedRecordingsTable />
@@ -293,7 +293,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     expect(within(secondTarget).getByText(`${mockCount2}`)).toBeTruthy();
 
     const checkbox = screen.getByLabelText('all-archives-hide-check');
-    userEvent.click(checkbox);
+    await userEvent.click(checkbox);
 
     tableBody = screen.getAllByRole('rowgroup')[1];
     rows = within(tableBody).getAllByRole('row');
@@ -303,7 +303,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     expect(within(thirdTarget).getByText(`${mockCount3}`)).toBeTruthy();
   });
 
-  it('correctly handles the search function', () => {
+  it('correctly handles the search function', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <AllTargetsArchivedRecordingsTable />
@@ -316,7 +316,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     let rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(2);
 
-    userEvent.type(search, '1');
+    await userEvent.type(search, '1');
     tableBody = screen.getAllByRole('rowgroup')[1];
     rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(1);
@@ -324,17 +324,17 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     expect(within(firstTarget).getByText(`${mockAlias1} (${mockConnectUrl1})`)).toBeTruthy();
     expect(within(firstTarget).getByText(`${mockCount1}`)).toBeTruthy();
 
-    userEvent.type(search, 'asdasdjhj');
+    await userEvent.type(search, 'asdasdjhj');
     expect(screen.getByText('No Targets')).toBeInTheDocument();
     expect(screen.queryByLabelText('all-archives-table')).not.toBeInTheDocument();
 
-    userEvent.clear(search);
+    await userEvent.clear(search);
     tableBody = screen.getAllByRole('rowgroup')[1];
     rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(2);
   });
 
-  it('expands targets to show their <ArchivedRecordingsTable />', () => {
+  it('expands targets to show their <ArchivedRecordingsTable />', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <AllTargetsArchivedRecordingsTable />
@@ -349,7 +349,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
 
     let firstTarget = rows[0];
     const expand = within(firstTarget).getByLabelText('Details');
-    userEvent.click(expand);
+    await userEvent.click(expand);
 
     tableBody = screen.getAllByRole('rowgroup')[1];
     rows = within(tableBody).getAllByRole('row');
@@ -358,14 +358,14 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     let expandedTable = rows[1];
     expect(within(expandedTable).getByText('Archived Recordings Table')).toBeTruthy();
 
-    userEvent.click(expand);
+    await userEvent.click(expand);
     tableBody = screen.getAllByRole('rowgroup')[1];
     rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(2);
     expect(screen.queryByText('Archived Recordings Table')).not.toBeInTheDocument();
   });
 
-  it('does not expand targets with zero recordings', () => {
+  it('does not expand targets with zero recordings', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <AllTargetsArchivedRecordingsTable />
@@ -373,7 +373,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     );
 
     const checkbox = screen.getByLabelText('all-archives-hide-check');
-    userEvent.click(checkbox);
+    await userEvent.click(checkbox);
 
     let tableBody = screen.getAllByRole('rowgroup')[1];
     let rows = within(tableBody).getAllByRole('row');
@@ -384,7 +384,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     expect(within(thirdTarget).getByText(`${mockCount3}`)).toBeTruthy();
 
     const expand = within(thirdTarget).getByLabelText('Details');
-    userEvent.click(expand);
+    await userEvent.click(expand);
 
     tableBody = screen.getAllByRole('rowgroup')[1];
     rows = within(tableBody).getAllByRole('row');
@@ -429,7 +429,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     expect(within(thirdTarget).getByText(`${mockCount3 + 1}`)).toBeTruthy();
   });
 
-  it('decrements the count when an archived recording is deleted', () => {
+  it('decrements the count when an archived recording is deleted', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <AllTargetsArchivedRecordingsTable />
@@ -437,7 +437,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     );
 
     const checkbox = screen.getByLabelText('all-archives-hide-check');
-    userEvent.click(checkbox);
+    await userEvent.click(checkbox);
 
     let tableBody = screen.getAllByRole('rowgroup')[1];
     let rows = within(tableBody).getAllByRole('row');

--- a/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
@@ -347,7 +347,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     let rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(2);
 
-    let firstTarget = rows[0];
+    const firstTarget = rows[0];
     const expand = within(firstTarget).getByLabelText('Details');
     await userEvent.click(expand);
 
@@ -355,7 +355,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(3);
 
-    let expandedTable = rows[1];
+    const expandedTable = rows[1];
     expect(within(expandedTable).getByText('Archived Recordings Table')).toBeTruthy();
 
     await userEvent.click(expand);
@@ -421,8 +421,8 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
       </ServiceContext.Provider>
     );
 
-    let tableBody = screen.getAllByRole('rowgroup')[1];
-    let rows = within(tableBody).getAllByRole('row');
+    const tableBody = screen.getAllByRole('rowgroup')[1];
+    const rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(3);
 
     const thirdTarget = rows[2];
@@ -439,8 +439,8 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     const checkbox = screen.getByLabelText('all-archives-hide-check');
     await userEvent.click(checkbox);
 
-    let tableBody = screen.getAllByRole('rowgroup')[1];
-    let rows = within(tableBody).getAllByRole('row');
+    const tableBody = screen.getAllByRole('rowgroup')[1];
+    const rows = within(tableBody).getAllByRole('row');
 
     const firstTarget = rows[0];
     expect(within(firstTarget).getByText(`${mockAlias1} (${mockConnectUrl1})`)).toBeTruthy();

--- a/src/test/Archives/Archives.test.tsx
+++ b/src/test/Archives/Archives.test.tsx
@@ -117,7 +117,7 @@ describe('<Archives />', () => {
     expect(screen.getByText('Archives Unavailable')).toBeInTheDocument();
   });
 
-  it('handles changing tabs', () => {
+  it('handles changing tabs', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <Archives />
@@ -136,7 +136,7 @@ describe('<Archives />', () => {
     expect(within(secondTab).getByText('Uploads')).toBeTruthy();
 
     // Click the Uploads tab
-    userEvent.click(screen.getByText('Uploads'));
+    await userEvent.click(screen.getByText('Uploads'));
 
     // Assert that the Uploads tab is now selected
     tabsList = screen.getAllByRole('tab');

--- a/src/test/Archives/__snapshots__/AllTargetsArchivedRecordingsTable.test.tsx.snap
+++ b/src/test/Archives/__snapshots__/AllTargetsArchivedRecordingsTable.test.tsx.snap
@@ -64,7 +64,6 @@ Array [
                   />
                 </span>
               </div>
-              
             </div>
           </div>
         </div>

--- a/src/test/Events/EventTemplates.test.tsx
+++ b/src/test/Events/EventTemplates.test.tsx
@@ -159,7 +159,7 @@ describe('<EventTemplates />', () => {
     expect(screen.getByText('Type')).toBeInTheDocument();
   });
 
-  it('shows a popup when uploading', () => {
+  it('shows a popup when uploading', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <EventTemplates />
@@ -169,20 +169,20 @@ describe('<EventTemplates />', () => {
 
     const buttons = screen.getAllByRole('button');
     const uploadButton = buttons[0];
-    userEvent.click(uploadButton);
+    await userEvent.click(uploadButton);
 
     expect(screen.getByLabelText('Create Custom Event Template'));
   });
 
-  it('downloads an event template when Download is clicked on template action bar', () => {
+  it('downloads an event template when Download is clicked on template action bar', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <EventTemplates />
       </ServiceContext.Provider>
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
-    userEvent.click(screen.getByText('Download'));
+    await userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByText('Download'));
 
     const downloadRequestSpy = jest.spyOn(defaultServices.api, 'downloadTemplate');
 
@@ -190,28 +190,28 @@ describe('<EventTemplates />', () => {
     expect(downloadRequestSpy).toBeCalledWith(mockCustomEventTemplate);
   });
 
-  it('shows a popup when Delete is clicked and then deletes the template after clicking confirmation Delete', () => {
+  it('shows a popup when Delete is clicked and then deletes the template after clicking confirmation Delete', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <EventTemplates />
       </ServiceContext.Provider>
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByLabelText('Actions'));
 
     expect(screen.getByText('Create Recording...'));
     expect(screen.getByText('Download'));
     expect(screen.getByText('Delete'));
 
     const deleteAction = screen.getByText('Delete');
-    userEvent.click(deleteAction);
+    await userEvent.click(deleteAction);
 
     expect(screen.getByLabelText('Event template delete warning'));
 
     const deleteRequestSpy = jest.spyOn(defaultServices.api, 'deleteCustomEventTemplate');
     const dialogWarningSpy = jest.spyOn(defaultServices.settings, 'setDeletionDialogsEnabledFor');
-    userEvent.click(screen.getByLabelText("Don't ask me again"));
-    userEvent.click(within(screen.getByLabelText('Event template delete warning')).getByText('Delete'));
+    await userEvent.click(screen.getByLabelText("Don't ask me again"));
+    await userEvent.click(within(screen.getByLabelText('Event template delete warning')).getByText('Delete'));
 
     expect(deleteRequestSpy).toHaveBeenCalledTimes(1);
     expect(deleteRequestSpy).toBeCalledWith('someEventTemplate');
@@ -219,14 +219,14 @@ describe('<EventTemplates />', () => {
     expect(dialogWarningSpy).toBeCalledWith(DeleteWarningType.DeleteEventTemplates, false);
   });
 
-  it('deletes the template when Delete is clicked w/o popup warning', () => {
+  it('deletes the template when Delete is clicked w/o popup warning', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <EventTemplates />
       </ServiceContext.Provider>
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByLabelText('Actions'));
 
     expect(screen.getByText('Create Recording...'));
     expect(screen.getByText('Download'));
@@ -234,7 +234,7 @@ describe('<EventTemplates />', () => {
 
     const deleteRequestSpy = jest.spyOn(defaultServices.api, 'deleteCustomEventTemplate');
     const deleteAction = screen.getByText('Delete');
-    userEvent.click(deleteAction);
+    await userEvent.click(deleteAction);
 
     expect(deleteRequestSpy).toHaveBeenCalledTimes(1);
     expect(screen.queryByLabelText('Event template delete warning')).not.toBeInTheDocument();

--- a/src/test/Events/__snapshots__/EventTemplates.test.tsx.snap
+++ b/src/test/Events/__snapshots__/EventTemplates.test.tsx.snap
@@ -273,9 +273,7 @@ Array [
           data-label=""
           onMouseEnter={[Function]}
           scope={null}
-        >
-          
-        </td>
+        />
       </tr>
     </thead>
     <tbody

--- a/src/test/RecordingMetadata.tsx/BulkEditLabels.test.tsx
+++ b/src/test/RecordingMetadata.tsx/BulkEditLabels.test.tsx
@@ -186,7 +186,7 @@ describe('<BulkEditLabels />', () => {
     expect(placeHolder).toBeVisible();
   });
 
-  it('should display editable labels form when in edit mode', () => {
+  it('should display editable labels form when in edit mode', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <BulkEditLabels checkedIndices={activeCheckedIndices} isTargetRecording={true} />
@@ -197,7 +197,7 @@ describe('<BulkEditLabels />', () => {
     expect(editButton).toBeInTheDocument();
     expect(editButton).toBeVisible();
 
-    userEvent.click(editButton);
+    await userEvent.click(editButton);
 
     const addLabelButton = screen.getByRole('button', { name: 'Add Label' });
     expect(addLabelButton).toBeInTheDocument();
@@ -267,7 +267,7 @@ describe('<BulkEditLabels />', () => {
     expect(editButton).toBeInTheDocument();
     expect(editButton).toBeVisible();
 
-    userEvent.click(editButton);
+    await userEvent.click(editButton);
 
     let addLabelButton = screen.getByRole('button', { name: 'Add Label' });
     expect(addLabelButton).toBeInTheDocument();
@@ -293,7 +293,7 @@ describe('<BulkEditLabels />', () => {
     expect(cancelButton).toBeInTheDocument();
     expect(cancelButton).toBeVisible();
 
-    userEvent.click(cancelButton);
+    await userEvent.click(cancelButton);
 
     editButton = screen.getByRole('button', { name: 'Edit Labels' });
     expect(editButton).toBeInTheDocument();
@@ -313,7 +313,7 @@ describe('<BulkEditLabels />', () => {
     expect(editButton).toBeInTheDocument();
     expect(editButton).toBeVisible();
 
-    userEvent.click(editButton);
+    await userEvent.click(editButton);
 
     let addLabelButton = screen.getByRole('button', { name: 'Add Label' });
     expect(addLabelButton).toBeInTheDocument();
@@ -339,7 +339,7 @@ describe('<BulkEditLabels />', () => {
     expect(cancelButton).toBeInTheDocument();
     expect(cancelButton).toBeVisible();
 
-    userEvent.click(saveButton);
+    await userEvent.click(saveButton);
 
     expect(saveRequestSpy).toHaveBeenCalledTimes(1);
   });
@@ -356,7 +356,7 @@ describe('<BulkEditLabels />', () => {
     expect(editButton).toBeInTheDocument();
     expect(editButton).toBeVisible();
 
-    userEvent.click(editButton);
+    await userEvent.click(editButton);
 
     let addLabelButton = screen.getByRole('button', { name: 'Add Label' });
     expect(addLabelButton).toBeInTheDocument();
@@ -382,7 +382,7 @@ describe('<BulkEditLabels />', () => {
     expect(cancelButton).toBeInTheDocument();
     expect(cancelButton).toBeVisible();
 
-    userEvent.click(saveButton);
+    await userEvent.click(saveButton);
 
     expect(saveRequestSpy).toHaveBeenCalledTimes(1);
   });

--- a/src/test/RecordingMetadata.tsx/BulkEditLabels.test.tsx
+++ b/src/test/RecordingMetadata.tsx/BulkEditLabels.test.tsx
@@ -269,7 +269,7 @@ describe('<BulkEditLabels />', () => {
 
     await userEvent.click(editButton);
 
-    let addLabelButton = screen.getByRole('button', { name: 'Add Label' });
+    const addLabelButton = screen.getByRole('button', { name: 'Add Label' });
     expect(addLabelButton).toBeInTheDocument();
     expect(addLabelButton).toBeVisible();
 
@@ -309,13 +309,13 @@ describe('<BulkEditLabels />', () => {
       </ServiceContext.Provider>
     );
 
-    let editButton = screen.getByRole('button', { name: 'Edit Labels' });
+    const editButton = screen.getByRole('button', { name: 'Edit Labels' });
     expect(editButton).toBeInTheDocument();
     expect(editButton).toBeVisible();
 
     await userEvent.click(editButton);
 
-    let addLabelButton = screen.getByRole('button', { name: 'Add Label' });
+    const addLabelButton = screen.getByRole('button', { name: 'Add Label' });
     expect(addLabelButton).toBeInTheDocument();
     expect(addLabelButton).toBeVisible();
 
@@ -352,13 +352,13 @@ describe('<BulkEditLabels />', () => {
       </ServiceContext.Provider>
     );
 
-    let editButton = screen.getByRole('button', { name: 'Edit Labels' });
+    const editButton = screen.getByRole('button', { name: 'Edit Labels' });
     expect(editButton).toBeInTheDocument();
     expect(editButton).toBeVisible();
 
     await userEvent.click(editButton);
 
-    let addLabelButton = screen.getByRole('button', { name: 'Add Label' });
+    const addLabelButton = screen.getByRole('button', { name: 'Add Label' });
     expect(addLabelButton).toBeInTheDocument();
     expect(addLabelButton).toBeVisible();
 

--- a/src/test/RecordingMetadata.tsx/ClickableLabel.test.tsx
+++ b/src/test/RecordingMetadata.tsx/ClickableLabel.test.tsx
@@ -128,7 +128,7 @@ describe('<ClickableLabel />', () => {
     expect(label.classList.contains('pf-m-blue')).toBe(false);
   });
 
-  it('should display hover effect when hovered and is selected', () => {
+  it('should display hover effect when hovered and is selected', async () => {
     render(<ClickableLabel label={mockLabel} isSelected={true} onLabelClick={onLabelClick}></ClickableLabel>);
 
     const label = screen.getByLabelText(mockLabelAsString);
@@ -137,7 +137,7 @@ describe('<ClickableLabel />', () => {
 
     expect(label.classList.contains('pf-m-blue')).toBe(true);
 
-    userEvent.hover(label);
+    await userEvent.hover(label);
 
     const labelStyle = label.style;
     expect(labelStyle.cursor).toBe('pointer');
@@ -145,7 +145,7 @@ describe('<ClickableLabel />', () => {
     expect(labelStyle.getPropertyValue('--pf-c-label__content--before--BorderColor')).toBe(blueLabelBorderColor);
   });
 
-  it('should display hover effect when hovered and is not selected', () => {
+  it('should display hover effect when hovered and is not selected', async () => {
     render(<ClickableLabel label={mockLabel} isSelected={false} onLabelClick={onLabelClick}></ClickableLabel>);
 
     const label = screen.getByLabelText(mockLabelAsString);
@@ -154,7 +154,7 @@ describe('<ClickableLabel />', () => {
 
     expect(label.classList.contains('pf-m-blue')).toBe(false);
 
-    userEvent.hover(label);
+    await userEvent.hover(label);
 
     const labelStyle = label.style;
     expect(labelStyle.cursor).toBe('pointer');
@@ -162,7 +162,7 @@ describe('<ClickableLabel />', () => {
     expect(labelStyle.getPropertyValue('--pf-c-label__content--before--BorderColor')).toBe(greyLabelBorderColor);
   });
 
-  it('should update label filters when clicked', () => {
+  it('should update label filters when clicked', async () => {
     render(<ClickableLabel label={mockLabel} isSelected={true} onLabelClick={onLabelClick}></ClickableLabel>);
 
     const label = screen.getByLabelText(mockLabelAsString);
@@ -171,7 +171,7 @@ describe('<ClickableLabel />', () => {
 
     expect(label.classList.contains('pf-m-blue')).toBe(true);
 
-    userEvent.click(label);
+    await userEvent.click(label);
 
     expect(onLabelClick).toHaveBeenCalledTimes(1);
     expect(onLabelClick).toHaveBeenCalledWith(mockLabel);

--- a/src/test/RecordingMetadata.tsx/LabelCell.test.tsx
+++ b/src/test/RecordingMetadata.tsx/LabelCell.test.tsx
@@ -92,7 +92,7 @@ describe('<LabelCell />', () => {
   it('should display read-only labels', () => {
     render(<LabelCell target={mockFooTarget.connectUrl} labels={mockLabelList} />);
 
-    mockLabelStringDisplayList.forEach((labelAsString) => {
+    mockLabelStringDisplayList.forEach(async (labelAsString) => {
       const displayedLabel = screen.getByLabelText(labelAsString);
 
       expect(displayedLabel).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe('<LabelCell />', () => {
 
       expect(displayedLabel.onclick).toBeNull();
 
-      userEvent.click(displayedLabel);
+      await userEvent.click(displayedLabel);
       expect(onUpdateLabels).not.toHaveBeenCalled();
     });
   });
@@ -115,13 +115,13 @@ describe('<LabelCell />', () => {
     );
 
     let count = 0;
-    mockLabelStringDisplayList.forEach((labelAsString, index) => {
+    mockLabelStringDisplayList.forEach(async (labelAsString, index) => {
       const displayedLabel = screen.getByLabelText(labelAsString);
 
       expect(displayedLabel).toBeInTheDocument();
       expect(displayedLabel).toBeVisible();
 
-      userEvent.click(displayedLabel);
+      await userEvent.click(displayedLabel);
 
       expect(onUpdateLabels).toHaveBeenCalledTimes(++count);
       expect(onUpdateLabels).toHaveBeenCalledWith(mockFooTarget.connectUrl, {

--- a/src/test/RecordingMetadata.tsx/RecordingLabelFields.test.tsx
+++ b/src/test/RecordingMetadata.tsx/RecordingLabelFields.test.tsx
@@ -105,47 +105,47 @@ describe('<RecordingLabelFields />', () => {
     expect(screen.getByText('Add Label')).toBeInTheDocument();
   });
 
-  it('updates the label key when entering text into the Key input', () => {
+  it('updates the label key when entering text into the Key input', async () => {
     render(<RecordingLabelFields {...mockProps} />);
 
     const labelKeyInput = screen.getAllByLabelText('label key')[0];
-    userEvent.clear(labelKeyInput);
+    await userEvent.clear(labelKeyInput);
 
-    userEvent.type(labelKeyInput, 'someEditedKey');
+    await userEvent.type(labelKeyInput, 'someEditedKey');
     expect(mockProps.labels[0].key).toBe('someEditedKey');
   });
 
-  it('updates the label value when entering text into the Value input', () => {
+  it('updates the label value when entering text into the Value input', async () => {
     render(<RecordingLabelFields {...mockProps} />);
 
     const labelValueInput = screen.getAllByLabelText('label value')[0];
 
-    userEvent.clear(labelValueInput);
+    await userEvent.clear(labelValueInput);
 
-    userEvent.type(labelValueInput, 'someEditedValue');
+    await userEvent.type(labelValueInput, 'someEditedValue');
 
     expect(mockProps.labels[0].value).toBe('someEditedValue');
   });
 
-  it('adds a label when Add Label is clicked', () => {
+  it('adds a label when Add Label is clicked', async () => {
     render(<RecordingLabelFields {...mockProps} />);
 
     expect(screen.getAllByLabelText('label key').length).toBe(2);
     expect(screen.getAllByLabelText('label value').length).toBe(2);
 
-    userEvent.click(screen.getByText('Add Label'));
+    await userEvent.click(screen.getByText('Add Label'));
 
     expect(mockProps.setLabels).toHaveBeenCalledTimes(1);
     expect(mockProps.setLabels).toHaveBeenCalledWith([mockLabel1, mockLabel2, mockEmptyLabel]);
   });
 
-  it('removes the correct label when Delete button is clicked', () => {
+  it('removes the correct label when Delete button is clicked', async () => {
     render(<RecordingLabelFields {...mockProps} />);
 
     expect(screen.getAllByLabelText('label key').length).toBe(2);
     expect(screen.getAllByLabelText('label value').length).toBe(2);
 
-    userEvent.click(screen.getAllByTestId('remove-label-button')[0]);
+    await userEvent.click(screen.getAllByTestId('remove-label-button')[0]);
 
     expect(mockProps.setLabels).toHaveBeenCalledTimes(1);
     expect(mockProps.setLabels).toHaveBeenCalledWith([mockLabel2]);
@@ -157,26 +157,26 @@ describe('<RecordingLabelFields />', () => {
     expect(mockValid).toBe(ValidatedOptions.success);
   });
 
-  it('validates the label key when leaving the input field', () => {
+  it('validates the label key when leaving the input field', async () => {
     render(<RecordingLabelFields {...mockProps} />);
 
     const labelKeyInput = screen.getAllByLabelText('label key')[0];
-    userEvent.click(labelKeyInput);
+    await userEvent.click(labelKeyInput);
 
     // click somewhere else to leave the input field and trigger validation
-    userEvent.click(screen.getAllByLabelText('label value')[0]);
+    await userEvent.click(screen.getAllByLabelText('label value')[0]);
 
     expect(mockValid).toBe(ValidatedOptions.success);
   });
 
-  it('validates the label value when leaving the input field', () => {
+  it('validates the label value when leaving the input field', async () => {
     render(<RecordingLabelFields {...mockProps} />);
 
     const labelValueInput = screen.getAllByLabelText('label value')[0];
-    userEvent.click(labelValueInput);
+    await userEvent.click(labelValueInput);
 
     // click somewhere else to leave the input field and trigger validation
-    userEvent.click(screen.getAllByLabelText('label key')[0]);
+    await userEvent.click(screen.getAllByLabelText('label key')[0]);
 
     expect(mockValid).toBe(ValidatedOptions.success);
   });

--- a/src/test/RecordingMetadata.tsx/RecordingLabelFields.test.tsx
+++ b/src/test/RecordingMetadata.tsx/RecordingLabelFields.test.tsx
@@ -70,7 +70,7 @@ describe('<RecordingLabelFields />', () => {
     mockValid = ValidatedOptions.default;
   });
 
-  let mockProps = {
+  const mockProps = {
     labels: mockLabels,
     setLabels: jest.fn(() => (l: RecordingLabel[]) => {
       mockLabels = l.slice();

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -116,6 +116,7 @@ jest.spyOn(defaultServices.api, 'doGet').mockReturnValue(of([mockRecording]));
 jest.spyOn(defaultServices.api, 'downloadRecording').mockReturnValue();
 jest.spyOn(defaultServices.api, 'downloadReport').mockReturnValue();
 jest.spyOn(defaultServices.api, 'grafanaDatasourceUrl').mockReturnValue(of('/grafanaUrl'));
+jest.spyOn(defaultServices.api, 'grafanaDashboardUrl').mockReturnValue(of('/grafanaUrl'));
 jest.spyOn(defaultServices.api, 'stopRecording').mockReturnValue(of(true));
 jest.spyOn(defaultServices.api, 'uploadActiveRecordingToGrafana').mockReturnValue(of(true));
 
@@ -267,18 +268,18 @@ describe('<ActiveRecordingsTable />', () => {
     expect(screen.getByText('Delete')).toBeInTheDocument();
   });
 
-  it('routes to the Create Flight Recording form when Create is clicked', () => {
+  it('routes to the Create Flight Recording form when Create is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
       preloadState: preloadedState,
       history: history,
     });
 
-    userEvent.click(screen.getByText('Create'));
+    await userEvent.click(screen.getByText('Create'));
 
     expect(history.entries.map((entry) => entry.pathname)).toStrictEqual(['/recordings', '/recordings/create']);
   });
 
-  it('archives the selected recording when Archive is clicked', () => {
+  it('archives the selected recording when Archive is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
       preloadState: preloadedState,
       history: history,
@@ -286,8 +287,8 @@ describe('<ActiveRecordingsTable />', () => {
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
-    userEvent.click(selectAllCheck);
-    userEvent.click(screen.getByText('Archive'));
+    await userEvent.click(selectAllCheck);
+    await userEvent.click(screen.getByText('Archive'));
 
     const archiveRequestSpy = jest.spyOn(defaultServices.api, 'archiveRecording');
 
@@ -295,7 +296,7 @@ describe('<ActiveRecordingsTable />', () => {
     expect(archiveRequestSpy).toBeCalledWith('someRecording');
   });
 
-  it('stops the selected recording when Stop is clicked', () => {
+  it('stops the selected recording when Stop is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
       preloadState: preloadedState,
       history: history,
@@ -303,8 +304,8 @@ describe('<ActiveRecordingsTable />', () => {
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
-    userEvent.click(selectAllCheck);
-    userEvent.click(screen.getByText('Stop'));
+    await userEvent.click(selectAllCheck);
+    await userEvent.click(screen.getByText('Stop'));
 
     const stopRequestSpy = jest.spyOn(defaultServices.api, 'stopRecording');
 
@@ -312,7 +313,7 @@ describe('<ActiveRecordingsTable />', () => {
     expect(stopRequestSpy).toBeCalledWith('someRecording');
   });
 
-  it('opens the labels drawer when Edit Labels is clicked', () => {
+  it('opens the labels drawer when Edit Labels is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
       preloadState: preloadedState,
       history: history,
@@ -320,8 +321,8 @@ describe('<ActiveRecordingsTable />', () => {
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
-    userEvent.click(selectAllCheck);
-    userEvent.click(screen.getByText('Edit Labels'));
+    await userEvent.click(selectAllCheck);
+    await userEvent.click(screen.getByText('Edit Labels'));
     expect(screen.getByText('Edit Recording Labels')).toBeInTheDocument();
   });
 
@@ -333,9 +334,9 @@ describe('<ActiveRecordingsTable />', () => {
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
-    userEvent.click(selectAllCheck);
+    await userEvent.click(selectAllCheck);
 
-    userEvent.click(screen.getByText('Delete'));
+    await userEvent.click(screen.getByText('Delete'));
 
     const deleteModal = await screen.findByLabelText(DeleteActiveRecordings.ariaLabel);
     expect(deleteModal).toBeInTheDocument();
@@ -343,8 +344,8 @@ describe('<ActiveRecordingsTable />', () => {
 
     const deleteRequestSpy = jest.spyOn(defaultServices.api, 'deleteRecording');
     const dialogWarningSpy = jest.spyOn(defaultServices.settings, 'setDeletionDialogsEnabledFor');
-    userEvent.click(screen.getByLabelText("Don't ask me again"));
-    userEvent.click(within(screen.getByLabelText(DeleteActiveRecordings.ariaLabel)).getByText('Delete'));
+    await userEvent.click(screen.getByLabelText("Don't ask me again"));
+    await userEvent.click(within(screen.getByLabelText(DeleteActiveRecordings.ariaLabel)).getByText('Delete'));
 
     expect(deleteRequestSpy).toBeCalledTimes(1);
     expect(deleteRequestSpy).toBeCalledWith('someRecording');
@@ -352,7 +353,7 @@ describe('<ActiveRecordingsTable />', () => {
     expect(dialogWarningSpy).toBeCalledWith(DeleteWarningType.DeleteActiveRecordings, false);
   });
 
-  it('deletes the recording when Delete is clicked w/o popup warning', () => {
+  it('deletes the recording when Delete is clicked w/o popup warning', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
       preloadState: preloadedState,
       history: history,
@@ -360,8 +361,8 @@ describe('<ActiveRecordingsTable />', () => {
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
-    userEvent.click(selectAllCheck);
-    userEvent.click(screen.getByText('Delete'));
+    await userEvent.click(selectAllCheck);
+    await userEvent.click(screen.getByText('Delete'));
 
     const deleteRequestSpy = jest.spyOn(defaultServices.api, 'deleteRecording');
 
@@ -370,14 +371,14 @@ describe('<ActiveRecordingsTable />', () => {
     expect(deleteRequestSpy).toBeCalledWith('someRecording');
   });
 
-  it('downloads a recording when Download Recording is clicked', () => {
+  it('downloads a recording when Download Recording is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
       preloadState: preloadedState,
       history: history,
     });
 
-    userEvent.click(screen.getByLabelText('Actions'));
-    userEvent.click(screen.getByText('Download Recording'));
+    await userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByText('Download Recording'));
 
     const downloadRequestSpy = jest.spyOn(defaultServices.api, 'downloadRecording');
 
@@ -385,28 +386,28 @@ describe('<ActiveRecordingsTable />', () => {
     expect(downloadRequestSpy).toBeCalledWith(mockRecording);
   });
 
-  it('displays the automated analysis report when View Report is clicked', () => {
+  it('displays the automated analysis report when View Report is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
       preloadState: preloadedState,
       history: history,
     });
 
-    userEvent.click(screen.getByLabelText('Actions'));
-    userEvent.click(screen.getByText('View Report ...'));
+    await userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByText('View Report ...'));
 
     const reportRequestSpy = jest.spyOn(defaultServices.api, 'downloadReport');
 
     expect(reportRequestSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('uploads a recording to Grafana when View in Grafana is clicked', () => {
+  it('uploads a recording to Grafana when View in Grafana is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
       preloadState: preloadedState,
       history: history,
     });
 
-    userEvent.click(screen.getByLabelText('Actions'));
-    userEvent.click(screen.getByText('View in Grafana ...'));
+    await userEvent.click(await screen.getByLabelText('Actions'));
+    await userEvent.click(await screen.getByText('View in Grafana ...'));
 
     const grafanaUploadSpy = jest.spyOn(defaultServices.api, 'uploadActiveRecordingToGrafana');
 

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -176,6 +176,8 @@ jest
   .mockReturnValueOnce(of(mockDeleteNotification))
   .mockReturnValue(of()); // all other tests
 
+jest.spyOn(window, 'open').mockReturnValue(null);
+
 describe('<ActiveRecordingsTable />', () => {
   let preloadedState: RootState;
 
@@ -220,45 +222,55 @@ describe('<ActiveRecordingsTable />', () => {
     expect(tree.toJSON()).toMatchSnapshot();
   });
 
-  it('adds a recording after receiving a notification', () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+  it('adds a recording after receiving a notification', async () => {
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
     expect(screen.getByText('someRecording')).toBeInTheDocument();
     expect(screen.getByText('anotherRecording')).toBeInTheDocument();
   });
 
-  it('updates the recording labels after receiving a notification', () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+  it('updates the recording labels after receiving a notification', async () => {
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
     expect(screen.getByText('someLabel: someUpdatedValue')).toBeInTheDocument();
     expect(screen.queryByText('someLabel: someValue')).not.toBeInTheDocument();
   });
 
-  it('stops a recording after receiving a notification', () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+  it('stops a recording after receiving a notification', async () => {
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
     expect(screen.getByText('STOPPED')).toBeInTheDocument();
     expect(screen.queryByText('RUNNING')).not.toBeInTheDocument();
   });
 
-  it('removes a recording after receiving a notification', () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+  it('removes a recording after receiving a notification', async () => {
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
     expect(screen.queryByText('someRecording')).not.toBeInTheDocument();
   });
 
-  it('displays the toolbar buttons', () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+  it('displays the toolbar buttons', async () => {
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
 
     expect(screen.getByText('Create')).toBeInTheDocument();
@@ -269,9 +281,11 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('routes to the Create Flight Recording form when Create is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
 
     await userEvent.click(screen.getByText('Create'));
@@ -280,9 +294,11 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('archives the selected recording when Archive is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -297,9 +313,11 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('stops the selected recording when Stop is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -314,9 +332,11 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('opens the labels drawer when Edit Labels is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -327,9 +347,11 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('shows a popup when Delete is clicked and then deletes the recording after clicking confirmation Delete', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -354,9 +376,11 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('deletes the recording when Delete is clicked w/o popup warning', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -372,9 +396,11 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('downloads a recording when Download Recording is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
 
     await userEvent.click(screen.getByLabelText('Actions'));
@@ -387,9 +413,11 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('displays the automated analysis report when View Report is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
 
     await userEvent.click(screen.getByLabelText('Actions'));
@@ -401,9 +429,11 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('uploads a recording to Grafana when View in Grafana is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
+        preloadState: preloadedState,
+        history: history,
+      })
     });
 
     await userEvent.click(await screen.getByLabelText('Actions'));
@@ -415,3 +445,4 @@ describe('<ActiveRecordingsTable />', () => {
     expect(grafanaUploadSpy).toBeCalledWith('someRecording');
   });
 });
+

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -227,7 +227,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
     expect(screen.getByText('someRecording')).toBeInTheDocument();
     expect(screen.getByText('anotherRecording')).toBeInTheDocument();
@@ -238,7 +238,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
     expect(screen.getByText('someLabel: someUpdatedValue')).toBeInTheDocument();
     expect(screen.queryByText('someLabel: someValue')).not.toBeInTheDocument();
@@ -249,7 +249,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
     expect(screen.getByText('STOPPED')).toBeInTheDocument();
     expect(screen.queryByText('RUNNING')).not.toBeInTheDocument();
@@ -260,7 +260,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
     expect(screen.queryByText('someRecording')).not.toBeInTheDocument();
   });
@@ -270,7 +270,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
 
     expect(screen.getByText('Create')).toBeInTheDocument();
@@ -285,7 +285,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
 
     await userEvent.click(screen.getByText('Create'));
@@ -298,7 +298,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -317,7 +317,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -336,7 +336,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -351,7 +351,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -380,7 +380,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
 
     const checkboxes = screen.getAllByRole('checkbox');
@@ -400,7 +400,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
 
     await userEvent.click(screen.getByLabelText('Actions'));
@@ -417,7 +417,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
 
     await userEvent.click(screen.getByLabelText('Actions'));
@@ -433,7 +433,7 @@ describe('<ActiveRecordingsTable />', () => {
       renderWithServiceContextAndReduxStoreWithRoute(<ActiveRecordingsTable archiveEnabled={true} />, {
         preloadState: preloadedState,
         history: history,
-      })
+      });
     });
 
     await userEvent.click(await screen.getByLabelText('Actions'));
@@ -445,4 +445,3 @@ describe('<ActiveRecordingsTable />', () => {
     expect(grafanaUploadSpy).toBeCalledWith('someRecording');
   });
 });
-

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -199,62 +199,75 @@ describe('<ArchivedRecordingsTable />', () => {
     expect(tree.toJSON()).toMatchSnapshot();
   });
 
-  it('adds a recording after receiving a notification', () => {
-    renderWithServiceContextAndReduxStoreWithRoute(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
-      {
-        preloadState: preloadedState,
-        history: history,
-      }
-    );
+  it('adds a recording after receiving a notification', async () => {
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(
+        <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+        {
+          preloadState: preloadedState,
+          history: history,
+        }
+      );
+    });
+
     expect(screen.getByText('someRecording')).toBeInTheDocument();
     expect(screen.getByText('anotherRecording')).toBeInTheDocument();
   });
 
-  it('updates the recording labels after receiving a notification', () => {
-    renderWithServiceContextAndReduxStoreWithRoute(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
-      {
-        preloadState: preloadedState,
-        history: history,
-      }
-    );
+  it('updates the recording labels after receiving a notification', async () => {
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(
+        <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+        {
+          preloadState: preloadedState,
+          history: history,
+        }
+      );
+    });
+    
     expect(screen.getByText('someLabel: someUpdatedValue')).toBeInTheDocument();
     expect(screen.queryByText('someLabel: someValue')).not.toBeInTheDocument();
   });
 
-  it('removes a recording after receiving a notification', () => {
-    renderWithServiceContextAndReduxStoreWithRoute(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
-      {
-        preloadState: preloadedState,
-        history: history,
-      }
-    );
+  it('removes a recording after receiving a notification', async () => {
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(
+        <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+        {
+          preloadState: preloadedState,
+          history: history,
+        }
+      );
+    });
+
     expect(screen.queryByText('someRecording')).not.toBeInTheDocument();
   });
 
-  it('displays the toolbar buttons', () => {
-    renderWithServiceContextAndReduxStoreWithRoute(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
-      {
-        preloadState: preloadedState,
-        history: history,
-      }
-    );
+  it('displays the toolbar buttons', async () => {
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(
+        <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+        {
+          preloadState: preloadedState,
+          history: history,
+        }
+      );
+    });
 
     expect(screen.getByText('Delete')).toBeInTheDocument();
     expect(screen.getByText('Edit Labels')).toBeInTheDocument();
   });
 
   it('opens the labels drawer when Edit Labels is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
-      {
-        preloadState: preloadedState,
-        history: history,
-      }
-    );
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(
+        <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+        {
+          preloadState: preloadedState,
+          history: history,
+        }
+      );
+    });
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -264,13 +277,15 @@ describe('<ArchivedRecordingsTable />', () => {
   });
 
   it('shows a popup when Delete is clicked and then deletes the recording after clicking confirmation Delete', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
-      {
-        preloadState: preloadedState,
-        history: history,
-      }
-    );
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(
+        <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+        {
+          preloadState: preloadedState,
+          history: history,
+        }
+      );
+    });
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -293,13 +308,15 @@ describe('<ArchivedRecordingsTable />', () => {
   });
 
   it('deletes the recording when Delete is clicked w/o popup warning', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
-      {
-        preloadState: preloadedState,
-        history: history,
-      }
-    );
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(
+        <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+        {
+          preloadState: preloadedState,
+          history: history,
+        }
+      );
+    });
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -314,13 +331,15 @@ describe('<ArchivedRecordingsTable />', () => {
   });
 
   it('downloads a recording when Download Recording is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
-      {
-        preloadState: preloadedState,
-        history: history,
-      }
-    );
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(
+        <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+        {
+          preloadState: preloadedState,
+          history: history,
+        }
+      );
+    });
 
     await userEvent.click(screen.getByLabelText('Actions'));
     await userEvent.click(screen.getByText('Download Recording'));
@@ -332,13 +351,15 @@ describe('<ArchivedRecordingsTable />', () => {
   });
 
   it('displays the automated analysis report when View Report is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
-      {
-        preloadState: preloadedState,
-        history: history,
-      }
-    );
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(
+        <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+        {
+          preloadState: preloadedState,
+          history: history,
+        }
+      );
+    });
 
     await userEvent.click(screen.getByLabelText('Actions'));
     await userEvent.click(screen.getByText('View Report ...'));
@@ -349,13 +370,15 @@ describe('<ArchivedRecordingsTable />', () => {
   });
 
   it('uploads a recording to Grafana when View in Grafana is clicked', async () => {
-    renderWithServiceContextAndReduxStoreWithRoute(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
-      {
-        preloadState: preloadedState,
-        history: history,
-      }
-    );
+    await act(async () => {
+      renderWithServiceContextAndReduxStoreWithRoute(
+        <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+        {
+          preloadState: preloadedState,
+          history: history,
+        }
+      );
+    });
 
     await userEvent.click(screen.getByLabelText('Actions'));
     await userEvent.click(screen.getByText('View in Grafana ...'));
@@ -433,9 +456,7 @@ describe('<ArchivedRecordingsTable />', () => {
     expect(uploadInput.files![0]).toStrictEqual(mockFileUpload);
 
     await waitFor(() => expect(submitButton).not.toBeDisabled());
-    await tlr.act(async () => {
-      await userEvent.click(submitButton);
-    });
+    await userEvent.click(submitButton);
 
     expect(uploadSpy).toHaveBeenCalled();
     expect(uploadSpy).toHaveBeenCalledWith(mockFileUpload, expect.anything());

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -247,7 +247,7 @@ describe('<ArchivedRecordingsTable />', () => {
     expect(screen.getByText('Edit Labels')).toBeInTheDocument();
   });
 
-  it('opens the labels drawer when Edit Labels is clicked', () => {
+  it('opens the labels drawer when Edit Labels is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(
       <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
       {
@@ -258,8 +258,8 @@ describe('<ArchivedRecordingsTable />', () => {
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
-    userEvent.click(selectAllCheck);
-    userEvent.click(screen.getByText('Edit Labels'));
+    await userEvent.click(selectAllCheck);
+    await userEvent.click(screen.getByText('Edit Labels'));
     expect(screen.getByText('Edit Recording Labels')).toBeInTheDocument();
   });
 
@@ -274,8 +274,8 @@ describe('<ArchivedRecordingsTable />', () => {
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
-    userEvent.click(selectAllCheck);
-    userEvent.click(screen.getByText('Delete'));
+    await userEvent.click(selectAllCheck);
+    await userEvent.click(screen.getByText('Delete'));
 
     const deleteModal = await screen.findByLabelText(DeleteArchivedRecordings.ariaLabel);
     expect(deleteModal).toBeInTheDocument();
@@ -283,8 +283,8 @@ describe('<ArchivedRecordingsTable />', () => {
 
     const deleteRequestSpy = jest.spyOn(defaultServices.api, 'deleteArchivedRecording');
     const dialogWarningSpy = jest.spyOn(defaultServices.settings, 'setDeletionDialogsEnabledFor');
-    userEvent.click(screen.getByLabelText("Don't ask me again"));
-    userEvent.click(within(screen.getByLabelText(DeleteArchivedRecordings.ariaLabel)).getByText('Delete'));
+    await userEvent.click(screen.getByLabelText("Don't ask me again"));
+    await userEvent.click(within(screen.getByLabelText(DeleteArchivedRecordings.ariaLabel)).getByText('Delete'));
 
     expect(deleteRequestSpy).toHaveBeenCalledTimes(1);
     expect(deleteRequestSpy).toBeCalledWith(mockTarget.connectUrl, 'someRecording');
@@ -292,7 +292,7 @@ describe('<ArchivedRecordingsTable />', () => {
     expect(dialogWarningSpy).toBeCalledWith(DeleteWarningType.DeleteArchivedRecordings, false);
   });
 
-  it('deletes the recording when Delete is clicked w/o popup warning', () => {
+  it('deletes the recording when Delete is clicked w/o popup warning', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(
       <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
       {
@@ -303,8 +303,8 @@ describe('<ArchivedRecordingsTable />', () => {
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
-    userEvent.click(selectAllCheck);
-    userEvent.click(screen.getByText('Delete'));
+    await userEvent.click(selectAllCheck);
+    await userEvent.click(screen.getByText('Delete'));
 
     const deleteRequestSpy = jest.spyOn(defaultServices.api, 'deleteArchivedRecording');
 
@@ -313,7 +313,7 @@ describe('<ArchivedRecordingsTable />', () => {
     expect(deleteRequestSpy).toBeCalledWith(mockTarget.connectUrl, 'someRecording');
   });
 
-  it('downloads a recording when Download Recording is clicked', () => {
+  it('downloads a recording when Download Recording is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(
       <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
       {
@@ -322,8 +322,8 @@ describe('<ArchivedRecordingsTable />', () => {
       }
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
-    userEvent.click(screen.getByText('Download Recording'));
+    await userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByText('Download Recording'));
 
     const downloadRequestSpy = jest.spyOn(defaultServices.api, 'downloadRecording');
 
@@ -331,7 +331,7 @@ describe('<ArchivedRecordingsTable />', () => {
     expect(downloadRequestSpy).toBeCalledWith(mockRecording);
   });
 
-  it('displays the automated analysis report when View Report is clicked', () => {
+  it('displays the automated analysis report when View Report is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(
       <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
       {
@@ -340,15 +340,15 @@ describe('<ArchivedRecordingsTable />', () => {
       }
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
-    userEvent.click(screen.getByText('View Report ...'));
+    await userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByText('View Report ...'));
 
     const reportRequestSpy = jest.spyOn(defaultServices.api, 'downloadReport');
 
     expect(reportRequestSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('uploads a recording to Grafana when View in Grafana is clicked', () => {
+  it('uploads a recording to Grafana when View in Grafana is clicked', async () => {
     renderWithServiceContextAndReduxStoreWithRoute(
       <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
       {
@@ -357,8 +357,8 @@ describe('<ArchivedRecordingsTable />', () => {
       }
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
-    userEvent.click(screen.getByText('View in Grafana ...'));
+    await userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByText('View in Grafana ...'));
 
     const grafanaUploadSpy = jest.spyOn(defaultServices.api, 'uploadArchivedRecordingToGrafana');
 
@@ -381,7 +381,7 @@ describe('<ArchivedRecordingsTable />', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
-    userEvent.click(uploadButton);
+    await userEvent.click(uploadButton);
 
     const uploadModal = await screen.findByRole('dialog');
     expect(uploadModal).toBeInTheDocument();
@@ -397,7 +397,7 @@ describe('<ArchivedRecordingsTable />', () => {
       }
     );
 
-    userEvent.click(screen.getByLabelText('add'));
+    await userEvent.click(screen.getByLabelText('add'));
 
     const modal = await screen.findByRole('dialog');
 
@@ -420,21 +420,21 @@ describe('<ArchivedRecordingsTable />', () => {
     expect(browseButton).toBeVisible();
 
     const submitButton = screen.getByRole('button', { name: 'Submit' }) as HTMLButtonElement;
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
 
     const uploadInput = modal.querySelector("input[accept='.jfr'][type='file']") as HTMLInputElement;
     expect(uploadInput).toBeInTheDocument();
     expect(uploadInput).not.toBeVisible();
 
-    userEvent.click(browseButton);
-    userEvent.upload(uploadInput, mockFileUpload);
+    await userEvent.click(browseButton);
+    await userEvent.upload(uploadInput, mockFileUpload);
 
     expect(uploadInput.files).not.toBe(null);
     expect(uploadInput.files![0]).toStrictEqual(mockFileUpload);
 
     await waitFor(() => expect(submitButton).not.toBeDisabled());
     await tlr.act(async () => {
-      userEvent.click(submitButton);
+      await userEvent.click(submitButton);
     });
 
     expect(uploadSpy).toHaveBeenCalled();

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -224,7 +224,7 @@ describe('<ArchivedRecordingsTable />', () => {
         }
       );
     });
-    
+
     expect(screen.getByText('someLabel: someUpdatedValue')).toBeInTheDocument();
     expect(screen.queryByText('someLabel: someValue')).not.toBeInTheDocument();
   });

--- a/src/test/Recordings/Filters/DateTimePicker.test.tsx
+++ b/src/test/Recordings/Filters/DateTimePicker.test.tsx
@@ -48,7 +48,7 @@ const currentDate = new Date('14 Sep 2022 00:00:00 UTC');
 
 // See https://github.com/testing-library/user-event/issues/833 with new testing-library versions
 const user = userEvent.setup({
-  delay:null
+  delay: null,
 });
 
 describe('<DateTimePicker />', () => {

--- a/src/test/Recordings/Filters/DateTimePicker.test.tsx
+++ b/src/test/Recordings/Filters/DateTimePicker.test.tsx
@@ -46,6 +46,11 @@ const onDateTimeSelect = jest.fn((date) => {
 });
 const currentDate = new Date('14 Sep 2022 00:00:00 UTC');
 
+// See https://github.com/testing-library/user-event/issues/833 with new testing-library versions
+const user = userEvent.setup({
+  delay:null
+});
+
 describe('<DateTimePicker />', () => {
   beforeEach(() => {
     // Mock system time
@@ -61,11 +66,11 @@ describe('<DateTimePicker />', () => {
   it('should open calendar when calendar icon is clicked', async () => {
     render(<DateTimePicker onSubmit={onDateTimeSelect} />);
 
-    const calendarIcon = screen.getByRole('button', { name: 'Toggle date picker' });
+    const calendarIcon = await screen.getByRole('button', { name: 'Toggle date picker' });
     expect(calendarIcon).toBeInTheDocument();
     expect(calendarIcon).toBeVisible();
 
-    userEvent.click(calendarIcon);
+    await user.click(calendarIcon);
 
     const calendar = await screen.findByRole('dialog');
     expect(calendar).toBeInTheDocument();
@@ -75,17 +80,17 @@ describe('<DateTimePicker />', () => {
   it('should close calendar when calendar icon is clicked', async () => {
     render(<DateTimePicker onSubmit={onDateTimeSelect} />);
 
-    const calendarIcon = screen.getByRole('button', { name: 'Toggle date picker' });
+    const calendarIcon = await screen.getByRole('button', { name: 'Toggle date picker' });
     expect(calendarIcon).toBeInTheDocument();
     expect(calendarIcon).toBeVisible();
 
-    userEvent.click(calendarIcon);
+    await user.click(calendarIcon);
 
     const calendar = await screen.findByRole('dialog');
     expect(calendar).toBeInTheDocument();
     expect(calendar).toBeVisible();
 
-    userEvent.click(calendarIcon);
+    await user.click(calendarIcon);
 
     await waitFor(() => {
       expect(calendar).not.toBeInTheDocument();
@@ -100,7 +105,7 @@ describe('<DateTimePicker />', () => {
     expect(calendarIcon).toBeInTheDocument();
     expect(calendarIcon).toBeVisible();
 
-    userEvent.click(calendarIcon);
+    await user.click(calendarIcon);
 
     const calendar = await screen.findByRole('dialog');
     expect(calendar).toBeInTheDocument();
@@ -110,7 +115,7 @@ describe('<DateTimePicker />', () => {
     expect(dateOption).toBeInTheDocument();
     expect(dateOption).toBeVisible();
 
-    userEvent.click(dateOption);
+    await user.click(dateOption);
 
     await waitFor(() => {
       expect(calendar).not.toBeInTheDocument();
@@ -130,7 +135,7 @@ describe('<DateTimePicker />', () => {
     expect(calendarIcon).toBeInTheDocument();
     expect(calendarIcon).toBeVisible();
 
-    userEvent.click(calendarIcon);
+    await user.click(calendarIcon);
 
     const calendar = await screen.findByRole('dialog');
     expect(calendar).toBeInTheDocument();
@@ -140,7 +145,7 @@ describe('<DateTimePicker />', () => {
     expect(dateOption).toBeInTheDocument();
     expect(dateOption).toBeVisible();
 
-    userEvent.click(dateOption);
+    await user.click(dateOption);
 
     await waitFor(() => {
       expect(calendar).not.toBeInTheDocument();
@@ -152,7 +157,7 @@ describe('<DateTimePicker />', () => {
     expect(searchIcon).toBeVisible();
     expect(searchIcon).not.toBeDisabled();
 
-    userEvent.click(searchIcon);
+    await user.click(searchIcon);
 
     expect(onDateTimeSelect).toHaveBeenCalledTimes(1);
     expect(onDateTimeSelect).toHaveBeenCalledWith(currentDate.toISOString());
@@ -166,7 +171,7 @@ describe('<DateTimePicker />', () => {
     expect(calendarIcon).toBeInTheDocument();
     expect(calendarIcon).toBeVisible();
 
-    userEvent.click(calendarIcon);
+    await user.click(calendarIcon);
 
     const calendar = await screen.findByRole('dialog');
     expect(calendar).toBeInTheDocument();
@@ -176,7 +181,7 @@ describe('<DateTimePicker />', () => {
     expect(dateOption).toBeInTheDocument();
     expect(dateOption).toBeVisible();
 
-    userEvent.click(dateOption);
+    await user.click(dateOption);
 
     await waitFor(() => {
       expect(calendar).not.toBeInTheDocument();
@@ -188,7 +193,7 @@ describe('<DateTimePicker />', () => {
     expect(timeInput).toBeInTheDocument();
     expect(timeInput).toBeVisible();
 
-    userEvent.click(timeInput);
+    await user.click(timeInput);
 
     const timeMenu = await screen.findByRole('menu', { name: 'Time Picker' });
     expect(timeMenu).toBeInTheDocument();
@@ -198,7 +203,7 @@ describe('<DateTimePicker />', () => {
     expect(noonOption).toBeInTheDocument();
     expect(noonOption).toBeVisible();
 
-    userEvent.click(noonOption);
+    await user.click(noonOption);
 
     expect(timeMenu).not.toBeInTheDocument();
     expect(timeMenu).not.toBeVisible();
@@ -209,7 +214,7 @@ describe('<DateTimePicker />', () => {
     expect(searchIcon).toBeVisible();
     expect(searchIcon).not.toBeDisabled();
 
-    userEvent.click(searchIcon);
+    await user.click(searchIcon);
 
     expect(onDateTimeSelect).toHaveBeenCalledTimes(1);
     const expectedDate = new Date(currentDate);
@@ -224,8 +229,8 @@ describe('<DateTimePicker />', () => {
     expect(dateInput).toBeInTheDocument();
     expect(dateInput).toBeVisible();
 
-    userEvent.type(dateInput, '2022-09-14');
-    userEvent.type(dateInput, '{enter}');
+    await user.type(dateInput, '2022-09-14');
+    await user.type(dateInput, '{enter}');
 
     const searchIcon = screen.getByRole('button', { name: 'Search For Date' });
     expect(searchIcon).toBeInTheDocument();
@@ -240,8 +245,8 @@ describe('<DateTimePicker />', () => {
     expect(dateInput).toBeInTheDocument();
     expect(dateInput).toBeVisible();
 
-    userEvent.type(dateInput, 'invalid_date');
-    userEvent.type(dateInput, '{enter}');
+    await user.type(dateInput, 'invalid_date');
+    await user.type(dateInput, '{enter}');
 
     const searchIcon = screen.getByRole('button', { name: 'Search For Date' });
     expect(searchIcon).toBeInTheDocument();
@@ -260,7 +265,7 @@ describe('<DateTimePicker />', () => {
     expect(timeInput).toBeInTheDocument();
     expect(timeInput).toBeVisible();
 
-    userEvent.click(timeInput);
+    await user.click(timeInput);
 
     const timeMenu = await screen.findByRole('menu', { name: 'Time Picker' });
     expect(timeMenu).toBeInTheDocument();
@@ -274,13 +279,13 @@ describe('<DateTimePicker />', () => {
     expect(timeInput).toBeInTheDocument();
     expect(timeInput).toBeVisible();
 
-    userEvent.click(timeInput);
+    await user.click(timeInput);
 
     const timeMenu = await screen.findByRole('menu', { name: 'Time Picker' });
     expect(timeMenu).toBeInTheDocument();
     expect(timeMenu).toBeVisible();
 
-    userEvent.click(document.body); // Click elsewhere
+    await user.click(document.body); // Click elsewhere
 
     expect(timeMenu).not.toBeInTheDocument();
     expect(timeMenu).not.toBeVisible();
@@ -302,7 +307,7 @@ describe('<DateTimePicker />', () => {
     expect(timeInput).toBeInTheDocument();
     expect(timeInput).toBeVisible();
 
-    userEvent.click(timeInput);
+    await user.click(timeInput);
 
     const timeMenu = await screen.findByRole('menu', { name: 'Time Picker' });
     expect(timeMenu).toBeInTheDocument();
@@ -312,7 +317,7 @@ describe('<DateTimePicker />', () => {
     expect(noonOption).toBeInTheDocument();
     expect(noonOption).toBeVisible();
 
-    userEvent.click(noonOption);
+    await user.click(noonOption);
 
     expect(timeMenu).not.toBeInTheDocument();
     expect(timeMenu).not.toBeVisible();
@@ -330,8 +335,8 @@ describe('<DateTimePicker />', () => {
     expect(timeInput).toBeInTheDocument();
     expect(timeInput).toBeVisible();
 
-    userEvent.type(timeInput, 'invalid_time');
-    userEvent.type(timeInput, '{enter}');
+    await user.type(timeInput, 'invalid_time');
+    await user.type(timeInput, '{enter}');
 
     const searchIcon = screen.getByRole('button', { name: 'Search For Date' });
     expect(searchIcon).toBeInTheDocument();

--- a/src/test/Recordings/Filters/DateTimePicker.test.tsx
+++ b/src/test/Recordings/Filters/DateTimePicker.test.tsx
@@ -48,7 +48,7 @@ const currentDate = new Date('14 Sep 2022 00:00:00 UTC');
 
 // See https://github.com/testing-library/user-event/issues/833 with new testing-library versions
 const user = userEvent.setup({
-  delay: null,
+  advanceTimers: jest.advanceTimersByTime
 });
 
 describe('<DateTimePicker />', () => {

--- a/src/test/Recordings/Filters/DateTimePicker.test.tsx
+++ b/src/test/Recordings/Filters/DateTimePicker.test.tsx
@@ -46,7 +46,6 @@ const onDateTimeSelect = jest.fn((date) => {
 });
 const currentDate = new Date('14 Sep 2022 00:00:00 UTC');
 
-// See https://github.com/testing-library/user-event/issues/833 with new testing-library versions
 const user = userEvent.setup({
   advanceTimers: jest.advanceTimersByTime,
 });

--- a/src/test/Recordings/Filters/DateTimePicker.test.tsx
+++ b/src/test/Recordings/Filters/DateTimePicker.test.tsx
@@ -48,7 +48,7 @@ const currentDate = new Date('14 Sep 2022 00:00:00 UTC');
 
 // See https://github.com/testing-library/user-event/issues/833 with new testing-library versions
 const user = userEvent.setup({
-  advanceTimers: jest.advanceTimersByTime
+  advanceTimers: jest.advanceTimersByTime,
 });
 
 describe('<DateTimePicker />', () => {

--- a/src/test/Recordings/Filters/DurationFilter.test.tsx
+++ b/src/test/Recordings/Filters/DurationFilter.test.tsx
@@ -125,7 +125,7 @@ describe('<DurationFilter />', () => {
     expect(checkBox).not.toHaveAttribute('checked');
   });
 
-  it('should select continous when clicking unchecked continuous box', () => {
+  it('should select continous when clicking unchecked continuous box', async () => {
     const submitContinous = jest.fn((continous) => {
       filteredDurationsWithoutCont.push('continuous');
     });
@@ -143,7 +143,7 @@ describe('<DurationFilter />', () => {
     expect(checkBox).toBeVisible();
     expect(checkBox).not.toHaveAttribute('checked');
 
-    userEvent.click(checkBox);
+    await userEvent.click(checkBox);
 
     expect(submitContinous).toHaveBeenCalledTimes(1);
     expect(submitContinous).toHaveBeenCalledWith(true);
@@ -151,7 +151,7 @@ describe('<DurationFilter />', () => {
     expect(filteredDurationsWithoutCont).toStrictEqual([`${mockRecording.duration}`, 'continuous']);
   });
 
-  it('should unselect continous when clicking checked continuous box', () => {
+  it('should unselect continous when clicking checked continuous box', async () => {
     const submitContinous = jest.fn((continous) => {
       filteredDurationsWithCont = filteredDurationsWithCont.filter((v) => v !== 'continuous');
     });
@@ -169,7 +169,7 @@ describe('<DurationFilter />', () => {
     expect(checkBox).toBeVisible();
     expect(checkBox).toHaveAttribute('checked');
 
-    userEvent.click(checkBox);
+    await userEvent.click(checkBox);
 
     expect(submitContinous).toHaveBeenCalledTimes(1);
     expect(submitContinous).toHaveBeenCalledWith(false);
@@ -193,11 +193,11 @@ describe('<DurationFilter />', () => {
     expect(durationInput).toBeInTheDocument();
     expect(durationInput).toBeVisible();
 
-    userEvent.clear(durationInput);
-    userEvent.type(durationInput, '50');
+    await userEvent.clear(durationInput);
+    await userEvent.type(durationInput, '50');
 
     // Press enter
-    userEvent.type(durationInput, '{enter}');
+    await userEvent.type(durationInput, '{enter}');
 
     expect(submitDuration).toHaveBeenCalledTimes(1);
     expect(submitDuration).toHaveBeenCalledWith(Number('50'));
@@ -221,11 +221,11 @@ describe('<DurationFilter />', () => {
     expect(durationInput).toBeInTheDocument();
     expect(durationInput).toBeVisible();
 
-    userEvent.clear(durationInput);
-    userEvent.type(durationInput, '50');
+    await userEvent.clear(durationInput);
+    await userEvent.type(durationInput, '50');
 
     // Press shift
-    userEvent.type(durationInput, '{shift}');
+    await userEvent.type(durationInput, '{shift}');
 
     expect(submitDuration).toHaveBeenCalledTimes(0);
     expect(emptyFilteredDuration).toStrictEqual([]);

--- a/src/test/Recordings/Filters/LabelFilter.test.tsx
+++ b/src/test/Recordings/Filters/LabelFilter.test.tsx
@@ -108,7 +108,7 @@ describe('<LabelFilter />', () => {
     expect(labelInput).toBeInTheDocument();
     expect(labelInput).toBeVisible();
 
-    userEvent.click(labelInput);
+    await userEvent.click(labelInput);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by label' });
     expect(selectMenu).toBeInTheDocument();
@@ -128,7 +128,7 @@ describe('<LabelFilter />', () => {
     expect(dropDownArrow).toBeInTheDocument();
     expect(dropDownArrow).toBeVisible();
 
-    userEvent.click(dropDownArrow);
+    await userEvent.click(dropDownArrow);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by label' });
     expect(selectMenu).toBeInTheDocument();
@@ -148,7 +148,7 @@ describe('<LabelFilter />', () => {
     expect(dropDownArrow).toBeInTheDocument();
     expect(dropDownArrow).toBeVisible();
 
-    userEvent.click(dropDownArrow);
+    await userEvent.click(dropDownArrow);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by label' });
     expect(selectMenu).toBeInTheDocument();
@@ -160,7 +160,7 @@ describe('<LabelFilter />', () => {
       expect(option).toBeVisible();
     });
 
-    userEvent.click(dropDownArrow);
+    await userEvent.click(dropDownArrow);
     expect(selectMenu).not.toBeInTheDocument();
     expect(selectMenu).not.toBeVisible();
   });
@@ -171,7 +171,7 @@ describe('<LabelFilter />', () => {
     expect(labelInput).toBeInTheDocument();
     expect(labelInput).toBeVisible();
 
-    userEvent.click(labelInput);
+    await userEvent.click(labelInput);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by label' });
     expect(selectMenu).toBeInTheDocument();
@@ -183,7 +183,7 @@ describe('<LabelFilter />', () => {
       expect(option).toBeVisible();
     });
 
-    userEvent.click(labelInput);
+    await userEvent.click(labelInput);
     expect(selectMenu).not.toBeInTheDocument();
     expect(selectMenu).not.toBeVisible();
   });
@@ -194,7 +194,7 @@ describe('<LabelFilter />', () => {
     expect(labelInput).toBeInTheDocument();
     expect(labelInput).toBeVisible();
 
-    userEvent.click(labelInput);
+    await userEvent.click(labelInput);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by label' });
     expect(selectMenu).toBeInTheDocument();
@@ -214,7 +214,7 @@ describe('<LabelFilter />', () => {
     expect(labelInput).toBeInTheDocument();
     expect(labelInput).toBeVisible();
 
-    userEvent.click(labelInput);
+    await userEvent.click(labelInput);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by label' });
     expect(selectMenu).toBeInTheDocument();
@@ -226,7 +226,7 @@ describe('<LabelFilter />', () => {
       expect(option).toBeVisible();
     });
 
-    userEvent.click(screen.getByText('someLabel:someValue'));
+    await userEvent.click(screen.getByText('someLabel:someValue'));
 
     // NameFilter's parent rebuilds to close menu by default.
 

--- a/src/test/Recordings/Filters/NameFilter.test.tsx
+++ b/src/test/Recordings/Filters/NameFilter.test.tsx
@@ -94,7 +94,7 @@ describe('<NameFilter />', () => {
     expect(nameInput).toBeInTheDocument();
     expect(nameInput).toBeVisible();
 
-    userEvent.click(nameInput);
+    await userEvent.click(nameInput);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by name' });
     expect(selectMenu).toBeInTheDocument();
@@ -113,7 +113,7 @@ describe('<NameFilter />', () => {
     expect(dropDownArrow).toBeInTheDocument();
     expect(dropDownArrow).toBeVisible();
 
-    userEvent.click(dropDownArrow);
+    await userEvent.click(dropDownArrow);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by name' });
     expect(selectMenu).toBeInTheDocument();
@@ -133,7 +133,7 @@ describe('<NameFilter />', () => {
     expect(dropDownArrow).toBeInTheDocument();
     expect(dropDownArrow).toBeVisible();
 
-    userEvent.click(dropDownArrow);
+    await userEvent.click(dropDownArrow);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by name' });
     expect(selectMenu).toBeInTheDocument();
@@ -145,7 +145,7 @@ describe('<NameFilter />', () => {
       expect(option).toBeVisible();
     });
 
-    userEvent.click(dropDownArrow);
+    await userEvent.click(dropDownArrow);
     expect(selectMenu).not.toBeInTheDocument();
     expect(selectMenu).not.toBeVisible();
   });
@@ -157,7 +157,7 @@ describe('<NameFilter />', () => {
     expect(nameInput).toBeInTheDocument();
     expect(nameInput).toBeVisible();
 
-    userEvent.click(nameInput);
+    await userEvent.click(nameInput);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by name' });
     expect(selectMenu).toBeInTheDocument();
@@ -169,7 +169,7 @@ describe('<NameFilter />', () => {
       expect(option).toBeVisible();
     });
 
-    userEvent.click(nameInput);
+    await userEvent.click(nameInput);
     expect(selectMenu).not.toBeInTheDocument();
     expect(selectMenu).not.toBeVisible();
   });
@@ -180,7 +180,7 @@ describe('<NameFilter />', () => {
     expect(nameInput).toBeInTheDocument();
     expect(nameInput).toBeVisible();
 
-    userEvent.click(nameInput);
+    await userEvent.click(nameInput);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by name' });
     expect(selectMenu).toBeInTheDocument();
@@ -199,7 +199,7 @@ describe('<NameFilter />', () => {
     expect(nameInput).toBeInTheDocument();
     expect(nameInput).toBeVisible();
 
-    userEvent.click(nameInput);
+    await userEvent.click(nameInput);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by name' });
     expect(selectMenu).toBeInTheDocument();
@@ -211,7 +211,7 @@ describe('<NameFilter />', () => {
       expect(option).toBeVisible();
     });
 
-    userEvent.click(screen.getByText('someRecording'));
+    await userEvent.click(screen.getByText('someRecording'));
 
     // NameFilter's parent rebuilds to close menu by default.
 

--- a/src/test/Recordings/Filters/RecordingStateFilter.test.tsx
+++ b/src/test/Recordings/Filters/RecordingStateFilter.test.tsx
@@ -98,7 +98,7 @@ describe('<RecordingStateFilter />', () => {
     expect(stateDropDown).toBeInTheDocument();
     expect(stateDropDown).toBeVisible();
 
-    userEvent.click(stateDropDown);
+    await userEvent.click(stateDropDown);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by state' });
     expect(selectMenu).toBeInTheDocument();
@@ -118,7 +118,7 @@ describe('<RecordingStateFilter />', () => {
     expect(stateDropDown).toBeInTheDocument();
     expect(stateDropDown).toBeVisible();
 
-    userEvent.click(stateDropDown);
+    await userEvent.click(stateDropDown);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by state' });
     expect(selectMenu).toBeInTheDocument();
@@ -130,7 +130,7 @@ describe('<RecordingStateFilter />', () => {
       expect(selectOption).toBeVisible();
     });
 
-    userEvent.click(stateDropDown);
+    await userEvent.click(stateDropDown);
     expect(selectMenu).not.toBeInTheDocument();
     expect(selectMenu).not.toBeVisible();
   });
@@ -142,7 +142,7 @@ describe('<RecordingStateFilter />', () => {
     expect(stateDropDown).toBeInTheDocument();
     expect(stateDropDown).toBeVisible();
 
-    userEvent.click(stateDropDown);
+    await userEvent.click(stateDropDown);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by state' });
     expect(selectMenu).toBeInTheDocument();
@@ -175,7 +175,7 @@ describe('<RecordingStateFilter />', () => {
     expect(stateDropDown).toBeInTheDocument();
     expect(stateDropDown).toBeVisible();
 
-    userEvent.click(stateDropDown);
+    await userEvent.click(stateDropDown);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by state' });
     expect(selectMenu).toBeInTheDocument();
@@ -196,7 +196,7 @@ describe('<RecordingStateFilter />', () => {
     expect(uncheckedBox).toBeVisible();
     expect(uncheckedBox).not.toHaveAttribute('checked');
 
-    userEvent.click(uncheckedBox);
+    await userEvent.click(uncheckedBox);
 
     expect(onRecordingStateToggle).toHaveBeenCalledTimes(1);
     expect(onRecordingStateToggle).toHaveBeenCalledWith(mockAnotherRecording.state);
@@ -214,7 +214,7 @@ describe('<RecordingStateFilter />', () => {
     expect(stateDropDown).toBeInTheDocument();
     expect(stateDropDown).toBeVisible();
 
-    userEvent.click(stateDropDown);
+    await userEvent.click(stateDropDown);
 
     const selectMenu = await screen.findByRole('listbox', { name: 'Filter by state' });
     expect(selectMenu).toBeInTheDocument();
@@ -235,7 +235,7 @@ describe('<RecordingStateFilter />', () => {
     expect(uncheckedBox).toBeVisible();
     expect(uncheckedBox).toHaveAttribute('checked');
 
-    userEvent.click(uncheckedBox);
+    await userEvent.click(uncheckedBox);
 
     expect(onRecordingStateToggle).toHaveBeenCalledTimes(1);
     expect(onRecordingStateToggle).toHaveBeenCalledWith(mockRecording.state);

--- a/src/test/Recordings/RecordingFilters.test.tsx
+++ b/src/test/Recordings/RecordingFilters.test.tsx
@@ -313,7 +313,7 @@ describe('<RecordingFilters />', () => {
 
     await userEvent.click(selectedItem);
 
-    let categoryMenu = await screen.findByRole('menu');
+    const categoryMenu = await screen.findByRole('menu');
     expect(categoryMenu).toBeInTheDocument();
     expect(categoryMenu).toBeVisible();
 
@@ -455,7 +455,7 @@ describe('<RecordingFilters />', () => {
     );
 
     activeCategoryOptions.forEach((category) => {
-      let chipGroup = screen.queryByRole('group', { name: category });
+      const chipGroup = screen.queryByRole('group', { name: category });
       expect(chipGroup).not.toBeInTheDocument();
     });
   });

--- a/src/test/Recordings/RecordingFilters.test.tsx
+++ b/src/test/Recordings/RecordingFilters.test.tsx
@@ -225,7 +225,7 @@ describe('<RecordingFilters />', () => {
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
 
-    userEvent.click(selectedItem);
+    await userEvent.click(selectedItem);
 
     const categoryMenu = await screen.findByRole('menu');
     expect(categoryMenu).toBeInTheDocument();
@@ -264,7 +264,7 @@ describe('<RecordingFilters />', () => {
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
 
-    userEvent.click(selectedItem);
+    await userEvent.click(selectedItem);
 
     const categoryMenu = await screen.findByRole('menu');
     expect(categoryMenu).toBeInTheDocument();
@@ -311,13 +311,13 @@ describe('<RecordingFilters />', () => {
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
 
-    userEvent.click(selectedItem);
+    await userEvent.click(selectedItem);
 
     let categoryMenu = await screen.findByRole('menu');
     expect(categoryMenu).toBeInTheDocument();
     expect(categoryMenu).toBeVisible();
 
-    userEvent.click(selectedItem); // Click again
+    await userEvent.click(selectedItem); // Click again
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
@@ -348,7 +348,7 @@ describe('<RecordingFilters />', () => {
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
 
-    userEvent.click(selectedItem);
+    await userEvent.click(selectedItem);
 
     const categoryMenu = await screen.findByRole('menu');
     expect(categoryMenu).toBeInTheDocument();
@@ -360,7 +360,7 @@ describe('<RecordingFilters />', () => {
       expect(option).toBeVisible();
     });
 
-    userEvent.click(within(categoryMenu).getByRole('menuitem', { name: 'Name' }));
+    await userEvent.click(within(categoryMenu).getByRole('menuitem', { name: 'Name' }));
 
     selectedItem = screen.getByRole('button', { name: 'Name' });
     expect(selectedItem).toBeInTheDocument();

--- a/src/test/Recordings/RecordingLabelsPanel.test.tsx
+++ b/src/test/Recordings/RecordingLabelsPanel.test.tsx
@@ -72,9 +72,9 @@ const mockRecording: ArchivedRecording = {
 };
 
 describe('<RecordingLabelsPanel />', () => {
-  let isTargetRecording = true;
-  let checkedIndices = [];
-  let recordings = [mockRecording];
+  const isTargetRecording = true;
+  const checkedIndices = [];
+  const recordings = [mockRecording];
 
   const props = {
     setShowPanel: jest.fn(() => (showPanel: boolean) => {}),

--- a/src/test/Recordings/Recordings.test.tsx
+++ b/src/test/Recordings/Recordings.test.tsx
@@ -134,7 +134,7 @@ describe('<Recordings />', () => {
     expect(screen.queryByText('Archived Recordings')).not.toBeInTheDocument();
   });
 
-  it('handles updating the activeTab state', () => {
+  it('handles updating the activeTab state', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <Recordings />
@@ -153,7 +153,7 @@ describe('<Recordings />', () => {
     expect(within(secondTab).getByText('Archived Recordings')).toBeTruthy();
 
     // Click the archived recordings tab
-    userEvent.click(screen.getByText('Archived Recordings'));
+    await userEvent.click(screen.getByText('Archived Recordings'));
 
     // Assert that the archived recordings tab is now selected
     tabsList = screen.getAllByRole('tab');

--- a/src/test/Recordings/RecordingsTable.test.tsx
+++ b/src/test/Recordings/RecordingsTable.test.tsx
@@ -211,7 +211,7 @@ describe('<RecordingsTable />', () => {
     expect(screen.getByText(`No ${fakeTableTitle}`)).toBeInTheDocument();
   });
 
-  it('handles the header checkbox callback correctly', () => {
+  it('handles the header checkbox callback correctly', async () => {
     render(
       <RecordingsTable
         toolbar={<FakeToolbar />}
@@ -230,7 +230,7 @@ describe('<RecordingsTable />', () => {
 
     let headerCheckAll = screen.getByLabelText('Select all rows');
     expect(headerCheckAll).not.toHaveAttribute('checked');
-    userEvent.click(headerCheckAll);
+    await userEvent.click(headerCheckAll);
     expect(mockHeaderCheckCallback).toHaveBeenCalledTimes(1);
   });
 

--- a/src/test/Recordings/RecordingsTable.test.tsx
+++ b/src/test/Recordings/RecordingsTable.test.tsx
@@ -228,7 +228,7 @@ describe('<RecordingsTable />', () => {
       </RecordingsTable>
     );
 
-    let headerCheckAll = screen.getByLabelText('Select all rows');
+    const headerCheckAll = screen.getByLabelText('Select all rows');
     expect(headerCheckAll).not.toHaveAttribute('checked');
     await userEvent.click(headerCheckAll);
     expect(mockHeaderCheckCallback).toHaveBeenCalledTimes(1);
@@ -251,7 +251,7 @@ describe('<RecordingsTable />', () => {
       </RecordingsTable>
     );
 
-    let headerCheckAll = screen.getByLabelText('Select all rows');
+    const headerCheckAll = screen.getByLabelText('Select all rows');
     expect(headerCheckAll).toHaveAttribute('checked');
   });
 });

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -177,19 +177,19 @@ describe('<CreateRule/>', () => {
     expect(createButton).toBeInTheDocument();
     expect(createButton).toBeVisible();
 
-    userEvent.type(nameInput, mockRule.name);
-    userEvent.type(descriptionInput, mockRule.description);
-    userEvent.type(matchExpressionInput, escapeKeyboardInput(mockRule.matchExpression));
-    userEvent.selectOptions(templateSelect, [screen.getByText('Profiling')]);
-    userEvent.type(maxSizeInput, `${mockRule.maxSizeBytes}`);
-    userEvent.type(maxAgeInput, `${mockRule.maxAgeSeconds}`);
-    userEvent.type(archivalPeriodInput, `${mockRule.archivalPeriodSeconds}`);
-    userEvent.type(preservedArchivesInput, `${mockRule.preservedArchives}`);
-    userEvent.type(initialDelayInput, `${mockRule.initialDelaySeconds}`);
+    await userEvent.type(nameInput, mockRule.name);
+    await userEvent.type(descriptionInput, mockRule.description);
+    await userEvent.type(matchExpressionInput, escapeKeyboardInput(mockRule.matchExpression));
+    await userEvent.selectOptions(templateSelect, [screen.getByText('Profiling')]);
+    await userEvent.type(maxSizeInput, `${mockRule.maxSizeBytes}`);
+    await userEvent.type(maxAgeInput, `${mockRule.maxAgeSeconds}`);
+    await userEvent.type(archivalPeriodInput, `${mockRule.archivalPeriodSeconds}`);
+    await userEvent.type(preservedArchivesInput, `${mockRule.preservedArchives}`);
+    await userEvent.type(initialDelayInput, `${mockRule.initialDelaySeconds}`);
 
     await waitFor(() => expect(createButton).not.toBeDisabled());
 
-    userEvent.click(createButton);
+    await userEvent.click(createButton);
 
     expect(createSpy).toHaveBeenCalledTimes(1);
     expect(createSpy).toHaveBeenCalledWith(mockRule);

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -137,7 +137,7 @@ describe('<Rules/>', () => {
       </ServiceContext.Provider>
     );
 
-    userEvent.click(screen.getByRole('button', { name: /Create/ }));
+    await userEvent.click(screen.getByRole('button', { name: /Create/ }));
 
     expect(history.entries.map((entry) => entry.pathname)).toStrictEqual(['/rules', '/rules/create']);
   });
@@ -151,7 +151,7 @@ describe('<Rules/>', () => {
       </ServiceContext.Provider>
     );
 
-    userEvent.click(screen.getByRole('button', { name: 'Upload' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Upload' }));
 
     const modal = await screen.findByRole('dialog');
     expect(modal).toBeInTheDocument();
@@ -178,13 +178,13 @@ describe('<Rules/>', () => {
     const deleteRequestSpy = jest.spyOn(defaultServices.api, 'deleteRule').mockReturnValue(of(true));
     const dialogWarningSpy = jest.spyOn(defaultServices.settings, 'setDeletionDialogsEnabledFor');
 
-    userEvent.click(screen.getByLabelText('Actions'));
-    userEvent.click(await screen.findByText('Delete'));
+    await userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(await screen.findByText('Delete'));
 
     expect(screen.getByLabelText(DeleteAutomatedRules.ariaLabel));
 
-    userEvent.click(screen.getByLabelText("Don't ask me again"));
-    userEvent.click(within(screen.getByLabelText(DeleteAutomatedRules.ariaLabel)).getByText('Delete'));
+    await userEvent.click(screen.getByLabelText("Don't ask me again"));
+    await userEvent.click(within(screen.getByLabelText(DeleteAutomatedRules.ariaLabel)).getByText('Delete'));
 
     expect(deleteRequestSpy).toHaveBeenCalledTimes(1);
     expect(deleteRequestSpy).toBeCalledWith(mockRule.name, true);
@@ -203,8 +203,8 @@ describe('<Rules/>', () => {
 
     const deleteRequestSpy = jest.spyOn(defaultServices.api, 'deleteRule').mockReturnValue(of(true));
 
-    userEvent.click(screen.getByLabelText('Actions'));
-    userEvent.click(await screen.findByText('Delete'));
+    await userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(await screen.findByText('Delete'));
 
     expect(screen.queryByLabelText(DeleteAutomatedRules.ariaLabel)).not.toBeInTheDocument();
     expect(deleteRequestSpy).toHaveBeenCalledTimes(1);
@@ -232,8 +232,8 @@ describe('<Rules/>', () => {
       </ServiceContext.Provider>
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
-    userEvent.click(await screen.findByText('Download'));
+    await userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(await screen.findByText('Download'));
 
     expect(downloadSpy).toHaveBeenCalledTimes(1);
     expect(downloadSpy).toBeCalledWith(mockRule.name);
@@ -248,7 +248,7 @@ describe('<Rules/>', () => {
       </ServiceContext.Provider>
     );
 
-    userEvent.click(screen.getByRole('button', { name: 'Upload' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Upload' }));
 
     const modal = await screen.findByRole('dialog');
     expect(modal).toBeInTheDocument();
@@ -269,21 +269,21 @@ describe('<Rules/>', () => {
     expect(browseButton).toBeVisible();
 
     const submitButton = screen.getByRole('button', { name: 'Submit' }) as HTMLButtonElement;
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
 
     const uploadInput = modal.querySelector("input[accept='.json'][type='file']") as HTMLInputElement;
     expect(uploadInput).toBeInTheDocument();
     expect(uploadInput).not.toBeVisible();
 
-    userEvent.click(browseButton);
-    userEvent.upload(uploadInput, mockFileUpload);
+    await userEvent.click(browseButton);
+    await userEvent.upload(uploadInput, mockFileUpload);
 
     expect(uploadInput.files).not.toBe(null);
     expect(uploadInput.files![0]).toStrictEqual(mockFileUpload);
 
     await waitFor(() => expect(submitButton).not.toBeDisabled());
     await tlr.act(async () => {
-      userEvent.click(submitButton);
+      await userEvent.click(submitButton);
     });
 
     expect(createSpy).toHaveBeenCalled();

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -282,9 +282,7 @@ describe('<Rules/>', () => {
     expect(uploadInput.files![0]).toStrictEqual(mockFileUpload);
 
     await waitFor(() => expect(submitButton).not.toBeDisabled());
-    await tlr.act(async () => {
-      await userEvent.click(submitButton);
-    });
+    await userEvent.click(submitButton);
 
     expect(createSpy).toHaveBeenCalled();
     expect(createSpy).toHaveBeenCalledWith(mockRule);

--- a/src/test/SecurityPanel/Credentials/StoreJmxCredentials.test.tsx
+++ b/src/test/SecurityPanel/Credentials/StoreJmxCredentials.test.tsx
@@ -265,7 +265,7 @@ describe('<StoreJmxCredentials />', () => {
     expect(apiRequestSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('expands to show the correct nested targets', () => {
+  it('expands to show the correct nested targets', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <StoreJmxCredentials />
@@ -281,7 +281,7 @@ describe('<StoreJmxCredentials />', () => {
 
     const expandButtons = screen.getAllByLabelText('Details');
 
-    userEvent.click(expandButtons[0]);
+    await userEvent.click(expandButtons[0]);
 
     expect(screen.getByText('Target')).toBeInTheDocument();
     expect(screen.getByText(`${mockTarget.alias} (${mockTarget.connectUrl})`)).toBeInTheDocument();
@@ -290,7 +290,7 @@ describe('<StoreJmxCredentials />', () => {
       screen.queryByText(`${mockAnotherMatchingTarget.alias} (${mockAnotherMatchingTarget.connectUrl})`)
     ).not.toBeInTheDocument();
 
-    userEvent.click(expandButtons[1]);
+    await userEvent.click(expandButtons[1]);
 
     expect(screen.getByText(`${mockAnotherTarget.alias} (${mockAnotherTarget.connectUrl})`)).toBeInTheDocument();
     expect(
@@ -312,11 +312,11 @@ describe('<StoreJmxCredentials />', () => {
 
     const expandButtons = screen.getAllByLabelText('Details');
 
-    userEvent.click(expandButtons[0]);
+    await userEvent.click(expandButtons[0]);
 
     expect(screen.getByText(`${mockTarget.alias} (${mockTarget.connectUrl})`)).toBeInTheDocument();
 
-    userEvent.click(expandButtons[1]);
+    await userEvent.click(expandButtons[1]);
 
     expect(screen.queryByText(`${mockAnotherTarget.alias} (${mockAnotherTarget.connectUrl})`)).not.toBeInTheDocument();
     expect(
@@ -324,7 +324,7 @@ describe('<StoreJmxCredentials />', () => {
     ).toBeInTheDocument();
   });
 
-  it('increments the correct count and updates the correct nested table when a found target notification is received', () => {
+  it('increments the correct count and updates the correct nested table when a found target notification is received', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <StoreJmxCredentials />
@@ -336,14 +336,14 @@ describe('<StoreJmxCredentials />', () => {
 
     const expandButtons = screen.getAllByLabelText('Details');
 
-    userEvent.click(expandButtons[0]);
+    await userEvent.click(expandButtons[0]);
 
     expect(screen.getByText(`${mockTarget.alias} (${mockTarget.connectUrl})`)).toBeInTheDocument();
     expect(
       screen.queryByText(`${mockYetAnotherMatchingTarget.alias} (${mockYetAnotherMatchingTarget.connectUrl})`)
     ).not.toBeInTheDocument();
 
-    userEvent.click(expandButtons[1]);
+    await userEvent.click(expandButtons[1]);
 
     expect(screen.getByText(`${mockAnotherTarget.alias} (${mockAnotherTarget.connectUrl})`)).toBeInTheDocument();
     expect(
@@ -354,20 +354,20 @@ describe('<StoreJmxCredentials />', () => {
     ).toBeInTheDocument();
   });
 
-  it('opens the JMX auth modal when Add is clicked', () => {
+  it('opens the JMX auth modal when Add is clicked', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <StoreJmxCredentials />
       </ServiceContext.Provider>
     );
-    userEvent.click(screen.getByText('Add'));
+    await userEvent.click(screen.getByText('Add'));
     expect(screen.getByText('CreateJmxCredentialModal')).toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText('Close'));
+    await userEvent.click(screen.getByLabelText('Close'));
     expect(screen.queryByText('CreateJmxCredentialModal')).not.toBeInTheDocument();
   });
 
-  it('shows a popup when Delete is clicked and makes a delete request when deleting one credential after confirming Delete', () => {
+  it('shows a popup when Delete is clicked and makes a delete request when deleting one credential after confirming Delete', async () => {
     const queryRequestSpy = jest.spyOn(defaultServices.api, 'getCredentials');
     const deleteRequestSpy = jest.spyOn(defaultServices.api, 'deleteCredentials');
     render(
@@ -379,14 +379,14 @@ describe('<StoreJmxCredentials />', () => {
     expect(screen.getByText(mockCredential.matchExpression)).toBeInTheDocument();
     expect(screen.getByText(mockAnotherCredential.matchExpression)).toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText('credentials-table-row-0-check'));
-    userEvent.click(screen.getByText('Delete'));
+    await userEvent.click(screen.getByLabelText('credentials-table-row-0-check'));
+    await userEvent.click(screen.getByText('Delete'));
 
     expect(screen.getByLabelText(DeleteJMXCredentials.ariaLabel)).toBeInTheDocument();
 
     const dialogWarningSpy = jest.spyOn(defaultServices.settings, 'setDeletionDialogsEnabledFor');
-    userEvent.click(screen.getByLabelText("Don't ask me again"));
-    userEvent.click(within(screen.getByLabelText(DeleteJMXCredentials.ariaLabel)).getByText('Delete'));
+    await userEvent.click(screen.getByLabelText("Don't ask me again"));
+    await userEvent.click(within(screen.getByLabelText(DeleteJMXCredentials.ariaLabel)).getByText('Delete'));
 
     expect(dialogWarningSpy).toBeCalledTimes(1);
     expect(dialogWarningSpy).toBeCalledWith(DeleteWarningType.DeleteJMXCredentials, false);
@@ -394,7 +394,7 @@ describe('<StoreJmxCredentials />', () => {
     expect(deleteRequestSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('makes multiple delete requests when all credentials are deleted at once w/o popup warning', () => {
+  it('makes multiple delete requests when all credentials are deleted at once w/o popup warning', async () => {
     const queryRequestSpy = jest.spyOn(defaultServices.api, 'getCredentials');
     const deleteRequestSpy = jest.spyOn(defaultServices.api, 'deleteCredentials');
     render(
@@ -410,8 +410,8 @@ describe('<StoreJmxCredentials />', () => {
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
-    userEvent.click(selectAllCheck);
-    userEvent.click(screen.getByText('Delete'));
+    await userEvent.click(selectAllCheck);
+    await userEvent.click(screen.getByText('Delete'));
     expect(queryRequestSpy).toHaveBeenCalledTimes(1);
     expect(deleteRequestSpy).toHaveBeenCalledTimes(2);
   });

--- a/src/test/Targets/TargetSelect.test.tsx
+++ b/src/test/Targets/TargetSelect.test.tsx
@@ -124,7 +124,7 @@ describe('<TargetSelect />', () => {
     expect(screen.getByLabelText('Options menu')).toBeInTheDocument();
   });
 
-  it('renders dropdown of multiple discovered targets', () => {
+  it('renders dropdown of multiple discovered targets', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <TargetSelect />
@@ -133,7 +133,7 @@ describe('<TargetSelect />', () => {
 
     expect(screen.getByText(`fooTarget`)).toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText('Options menu'));
+    await userEvent.click(screen.getByLabelText('Options menu'));
     expect(screen.getByLabelText('Select Input')).toBeInTheDocument();
     expect(screen.getByText(`Select Target...`)).toBeInTheDocument();
     expect(screen.getByText(`fooTarget (service:jmx:rmi://someFooUrl)`)).toBeInTheDocument();
@@ -141,22 +141,22 @@ describe('<TargetSelect />', () => {
     expect(screen.getByText('2')).toBeInTheDocument(); // Number of discoverable targets
   });
 
-  it('creates a target if user completes modal', () => {
+  it('creates a target if user completes modal', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <TargetSelect />
       </ServiceContext.Provider>
     );
     const createButton = screen.getByLabelText('Create target');
-    userEvent.click(createButton);
+    await userEvent.click(createButton);
 
     const textBoxes = screen.getAllByRole('textbox');
 
-    userEvent.type(textBoxes[0], 'service:jmx:rmi://someBazUrl');
-    userEvent.type(textBoxes[1], 'bazTarget');
+    await userEvent.type(textBoxes[0], 'service:jmx:rmi://someBazUrl');
+    await userEvent.type(textBoxes[1], 'bazTarget');
 
     const createTargetRequestSpy = jest.spyOn(defaultServices.api, 'createTarget');
-    userEvent.click(screen.getByText('Create'));
+    await userEvent.click(screen.getByText('Create'));
 
     expect(createTargetRequestSpy).toBeCalledTimes(1);
     expect(createTargetRequestSpy).toBeCalledWith(mockBazTarget);
@@ -172,21 +172,21 @@ describe('<TargetSelect />', () => {
     const deleteButton = screen.getByLabelText('Delete target');
     await waitFor(() => expect(deleteButton).not.toBeDisabled());
 
-    userEvent.click(deleteButton);
+    await userEvent.click(deleteButton);
 
     const deleteTargetRequestSpy = jest.spyOn(defaultServices.api, 'deleteTarget');
     expect(deleteTargetRequestSpy).toBeCalledTimes(1);
     expect(deleteTargetRequestSpy).toBeCalledWith(mockFooTarget);
   });
 
-  it('does nothing when trying to delete non-custom targets', () => {
+  it('does nothing when trying to delete non-custom targets', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <TargetSelect />
       </ServiceContext.Provider>
     );
     const deleteButton = screen.getByLabelText('Delete target');
-    userEvent.click(deleteButton);
+    await userEvent.click(deleteButton);
 
     const deleteTargetRequestSpy = jest.spyOn(defaultServices.api, 'deleteTarget');
 
@@ -194,14 +194,14 @@ describe('<TargetSelect />', () => {
     expect(deleteButton).toBeDisabled();
   });
 
-  it('refreshes targets when button clicked', () => {
+  it('refreshes targets when button clicked', async () => {
     render(
       <ServiceContext.Provider value={defaultServices}>
         <TargetSelect />
       </ServiceContext.Provider>
     );
     const refreshButton = screen.getByLabelText('Refresh targets');
-    userEvent.click(refreshButton);
+    await userEvent.click(refreshButton);
 
     const refreshTargetsRequestSpy = jest.spyOn(defaultServices.targets, 'queryForTargets');
     expect(refreshTargetsRequestSpy).toBeCalledTimes(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,6 +1255,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@^18.0.6":
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
+  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@^17.0.1":
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz"
@@ -1266,6 +1273,15 @@
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz"
   integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^18.0.21":
+  version "18.0.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.21.tgz#b8209e9626bb00a34c76f55482697edd2b43cc67"
+  integrity sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6307,14 +6307,13 @@ react-docgen-typescript@^1.15.0:
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.22.0.tgz"
   integrity sha512-MPLbF8vzRwAG3GcjdL+OHQlhgtWsLTXs+7uJiHfEeT3Ur7IsZaNYqRTLQ9sj2nB6M6jylcPCeCmH7qbszJmecg==
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.0"
 
 react-dropzone@9.0.0:
   version "9.0.0"
@@ -6397,13 +6396,12 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg@^3.0.0:
   version "3.0.0"
@@ -6686,13 +6684,12 @@ scheduler@^0.19.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adobe/css-tools@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.0.1.tgz#b38b444ad3aa5fedbb15f2f746dcd934226a12dd"
+  integrity sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz"
@@ -909,10 +914,10 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@testing-library/dom@^8.0.0", "@testing-library/dom@^8.11.3":
-  version "8.11.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.3.tgz"
-  integrity sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==
+"@testing-library/dom@^8.18.1", "@testing-library/dom@^8.5.0":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.18.1.tgz#80f91be02bc171fe5a3a7003f88207be31ac2cf3"
+  integrity sha512-oEvsm2B/WtcHKE+IcEeeCqNU/ltFGaVyGbpcm4g/2ytuT49jrlH9x5qRKL/H3A6yfM4YAbSbC0ceT5+9CEXnLg==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
@@ -923,36 +928,34 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
-"@testing-library/jest-dom@^5.16.2":
-  version "5.16.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz"
-  integrity sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==
+"@testing-library/jest-dom@^5.16.5":
+  version "5.16.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz#3912846af19a29b2dbf32a6ae9c31ef52580074e"
+  integrity sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==
   dependencies:
+    "@adobe/css-tools" "^4.0.1"
     "@babel/runtime" "^7.9.2"
     "@types/testing-library__jest-dom" "^5.9.1"
     aria-query "^5.0.0"
     chalk "^3.0.0"
-    css "^3.0.0"
     css.escape "^1.5.1"
     dom-accessibility-api "^0.5.6"
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@^12.1.4":
-  version "12.1.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.4.tgz"
-  integrity sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==
+"@testing-library/react@^13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.4.0.tgz#6a31e3bf5951615593ad984e96b9e5e2d9380966"
+  integrity sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^8.0.0"
-    "@types/react-dom" "*"
+    "@testing-library/dom" "^8.5.0"
+    "@types/react-dom" "^18.0.0"
 
-"@testing-library/user-event@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz"
-  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
@@ -1248,14 +1251,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@*":
-  version "17.0.13"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.13.tgz"
-  integrity sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@^18.0.6":
+"@types/react-dom@^18.0.0", "@types/react-dom@^18.0.6":
   version "18.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
   integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
@@ -1862,11 +1858,6 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
-
-atob@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz"
-  integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
 attr-accept@^1.1.3:
   version "1.1.3"
@@ -2501,15 +2492,6 @@ css.escape@^1.5.1:
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
-css@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz"
-  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
-  dependencies:
-    inherits "^2.0.4"
-    source-map "^0.6.1"
-    source-map-resolve "^0.6.0"
-
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz"
@@ -2640,11 +2622,6 @@ decimal.js@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz"
   integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
-
-decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
 dedent@^0.7.0:
   version "0.7.0"
@@ -4123,7 +4100,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -6346,15 +6323,15 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.6.0, react-
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0, react-is@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
-
-react-is@^18.0.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
-  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react-redux@^8.0.2:
   version "8.0.2"
@@ -6402,6 +6379,14 @@ react-router@5.2.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-shallow-renderer@^16.15.0:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
 react-test-renderer@^16.0.0-0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz"
@@ -6411,6 +6396,15 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.19.1"
+
+react-test-renderer@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.2.0.tgz#1dd912bd908ff26da5b9fca4fd1c489b9523d37e"
+  integrity sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==
+  dependencies:
+    react-is "^18.2.0"
+    react-shallow-renderer "^16.15.0"
+    scheduler "^0.23.0"
 
 react@^18.2.0:
   version "18.2.0"
@@ -6929,14 +6923,6 @@ source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
-
-source-map-resolve@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz"
-  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
-  dependencies:
-    atob "^2.1.2"
-    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.20:
   version "0.5.21"


### PR DESCRIPTION
Fixes #482 
Depends on https://github.com/patternfly/patternfly-react/issues/7142

What's been updated:
``` 
"react": "^17.0.2" => "^18.2.0",
"react-dom": "^17.0.2" => "react-dom": "^18.2.0",

@testing-library/dom: 8.11.3 => 8.18.1
@testing-library/jest-dom: 5.16.2 => 5.16.5
@testing-library/react: 12.1.4 => 13.4.0
@testing-library/user-event: 13.5.0 => 14.4.3
```

What's been added:
```
"@types/react": "^18.0.21", // typescript react types
"@types/react-dom": "^18.0.6",

"react-test-renderer": "^18.2.0",
```

Noteworthy: the update of `@testing-library/user-event` has made all their api calls to return promises, await and async should be used for those calls in our tests now. https://github.com/testing-library/user-event/releases/tag/v14.0.0
