### PR TITLE
fix(warning-modal): correct rule display name in warning modal

### DIFF
--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -404,7 +404,7 @@ export const Rules = () => {
                 </ToolbarGroup>
                 <RuleDeleteWarningModal
                   warningType={DeleteWarningType.DeleteAutomatedRules}
-                  rule={rowDeleteData[0]}
+                  rule={rowDeleteData[1]}
                   visible={warningModalOpen}
                   onAccept={handleWarningModalAccept}
                   onClose={handleWarningModalClose}

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -108,7 +108,7 @@ jest.spyOn(defaultServices.target, 'target').mockReturnValue(of(mockTarget));
 jest.spyOn(defaultServices.targets, 'targets').mockReturnValue(of([mockTarget]));
 jest.spyOn(defaultServices.targets, 'queryForTargets').mockReturnValue(of());
 
-describe('<CreateRule/>', () => {
+describe('<CreateRule />', () => {
   beforeEach(() => {
     history.go(-history.length);
   });

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -125,7 +125,7 @@ jest
 
   .mockReturnValue(of()); // other tests
 
-describe('<Rules/>', () => {
+describe('<Rules />', () => {
   beforeEach(() => {
     history.go(-history.length);
   });


### PR DESCRIPTION
Fixes #535 
Related to #533 

Correct display for rule-deletion warning modal. We just need to change the column index as first column is the `Switch`.