### PR TITLE
fix(target): reword helper texts

### DIFF
--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -284,7 +284,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   const selectOptions = React.useMemo(
     () =>
       [
-        <SelectOption key="placeholder" value="Select Target..." isPlaceholder={true} itemCount={targets.length} />,
+        <SelectOption key="placeholder" value="Select target..." isPlaceholder={true} itemCount={targets.length} />,
       ].concat(
         targets.map((t: Target) =>
           t.alias == t.connectUrl || !t.alias ? (

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -41,6 +41,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 import { NoTargetSelected } from './NoTargetSelected';
 import { Grid, GridItem } from '@patternfly/react-core';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 
 interface TargetViewProps {
   pageTitle: string;
@@ -51,13 +52,15 @@ interface TargetViewProps {
 export const TargetView: React.FunctionComponent<TargetViewProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const [connected, setConnected] = React.useState(false);
+  const addSubscription = useSubscriptions();
 
-  React.useLayoutEffect(() => {
-    const sub = context.target.target().subscribe((target) => {
-      setConnected(!!target && !!target.connectUrl);
-    });
-    return () => sub.unsubscribe();
-  }, [context.target]);
+  React.useEffect(() => {
+    addSubscription(
+      context.target.target().subscribe((target) => {
+        setConnected(!!target && !!target.connectUrl);
+      })
+    );
+  }, [context.target, addSubscription]);
 
   const compact = props.compactSelect == null ? true : props.compactSelect;
 

--- a/src/test/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/test/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Dashboard /> renders correctly 1`] = `
+<section
+  className="pf-c-page__main-section"
+>
+  <nav
+    aria-label="Breadcrumb"
+    className="pf-c-breadcrumb"
+    data-ouia-component-id="OUIA-Generated-Breadcrumb-1"
+    data-ouia-component-type="PF4/Breadcrumb"
+    data-ouia-safe={true}
+  >
+    <ol
+      className="pf-c-breadcrumb__list"
+    >
+      <li
+        className="pf-c-breadcrumb__item"
+      >
+        <h1
+          className="pf-c-breadcrumb__heading"
+        >
+          Dashboard
+        </h1>
+      </li>
+    </ol>
+  </nav>
+  <div
+    className="pf-l-stack pf-m-gutter"
+  >
+    <div
+      className="pf-l-stack__item"
+    >
+      <div
+        className="pf-l-grid pf-m-gutter"
+      >
+        <div
+          className="pf-l-grid__item pf-m-4-col"
+        >
+          <div>
+            Target Select
+          </div>
+        </div>
+        <div
+          className="pf-l-grid__item"
+        />
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/src/test/Targets/TargetSelect.test.tsx
+++ b/src/test/Targets/TargetSelect.test.tsx
@@ -128,7 +128,7 @@ describe('<TargetSelect />', () => {
     );
 
     expect(screen.getByText('Target JVM')).toBeInTheDocument();
-    expect(screen.getByText(`Select Target...`)).toBeInTheDocument();
+    expect(screen.getByText(`Select target...`)).toBeInTheDocument();
 
     expect(screen.getByLabelText('Create target')).toBeInTheDocument();
     expect(screen.getByLabelText('Delete target')).toBeInTheDocument();
@@ -147,7 +147,7 @@ describe('<TargetSelect />', () => {
 
     userEvent.click(screen.getByLabelText('Options menu'));
     expect(screen.getByLabelText('Select Input')).toBeInTheDocument();
-    expect(screen.getByText(`Select Target...`)).toBeInTheDocument();
+    expect(screen.getByText(`Select target...`)).toBeInTheDocument();
     expect(screen.getByText(`fooTarget (service:jmx:rmi://someFooUrl)`)).toBeInTheDocument();
     expect(screen.getByText(`barTarget (service:jmx:rmi://someBarUrl)`)).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument(); // Number of discoverable targets

--- a/src/test/Targets/__snapshots__/TargetSelect.test.tsx.snap
+++ b/src/test/Targets/__snapshots__/TargetSelect.test.tsx.snap
@@ -184,7 +184,7 @@ exports[`<TargetSelect /> renders correctly 1`] = `
           <span
             className="pf-c-select__toggle-text"
           >
-            Select Target...
+            Select target...
           </span>
         </div>
         <span


### PR DESCRIPTION
Fixes #504 

Reworded helper texts and target-select placeholders. Added some tests for empty states in dashboard.