### PR TITLE
fix(rules): show error view and modal when template retrieving fails

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -67,13 +67,14 @@ import {
 import { BellIcon, CaretDownIcon, CogIcon, HelpIcon, UserIcon } from '@patternfly/react-icons';
 import { map } from 'rxjs/operators';
 import { matchPath, NavLink, useHistory, useLocation } from 'react-router-dom';
-import { Notification, Notifications, NotificationsContext } from '@app/Notifications/Notifications';
+import { Notification, NotificationsContext } from '@app/Notifications/Notifications';
 import { AuthModal } from './AuthModal';
 import { SslErrorModal } from './SslErrorModal';
 import { AboutCryostatModal } from '@app/About/AboutCryostatModal';
 import cryostatLogoHorizontal from '@app/assets/logo-cryostat-3-horizontal.svg';
 import { SessionState } from '@app/Shared/Services/Login.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -82,6 +83,7 @@ interface IAppLayout {
 const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
   const serviceContext = React.useContext(ServiceContext);
   const notificationsContext = React.useContext(NotificationsContext);
+  const addSubscription = useSubscriptions();
   const routerHistory = useHistory();
   const logoProps = {
     href: '/',
@@ -102,108 +104,121 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
   const location = useLocation();
 
   React.useEffect(() => {
-    const sub = serviceContext.target.authFailure().subscribe(() => {
-      setShowAuthModal(true);
-    });
-    return () => sub.unsubscribe();
-  }, [serviceContext.target]);
+    addSubscription(
+      serviceContext.target.authFailure().subscribe(() => {
+        setShowAuthModal(true);
+      })
+    );
+  }, [serviceContext.target, setShowAuthModal, addSubscription]);
 
   React.useEffect(() => {
-    const sub = notificationsContext.notifications().subscribe(setNotifications);
-    return () => sub.unsubscribe();
-  }, []);
+    addSubscription(notificationsContext.notifications().subscribe(setNotifications));
+  }, [notificationsContext.notifications, addSubscription]);
 
   React.useEffect(() => {
-    const sub = notificationsContext.unreadNotifications().subscribe((s) => setUnreadNotificationsCount(s.length));
-    return () => sub.unsubscribe();
+    addSubscription(notificationsContext.unreadNotifications().subscribe((s) => setUnreadNotificationsCount(s.length)));
   }, [
-    notificationsContext,
     notificationsContext.unreadNotifications,
     unreadNotificationsCount,
     setUnreadNotificationsCount,
+    addSubscription,
   ]);
 
   React.useEffect(() => {
-    const sub = notificationsContext
-      .unreadNotifications()
-      .pipe(
-        map((notifications: Notification[]) =>
-          _.filter(notifications, (n) => n.variant === AlertVariant.danger || n.variant === AlertVariant.warning)
+    addSubscription(
+      notificationsContext
+        .unreadNotifications()
+        .pipe(
+          map((notifications: Notification[]) =>
+            _.filter(notifications, (n) => n.variant === AlertVariant.danger || n.variant === AlertVariant.warning)
+          )
         )
-      )
-      .subscribe((s) => setErrorNotificationsCount(s.length));
-    return () => sub.unsubscribe();
+        .subscribe((s) => setErrorNotificationsCount(s.length))
+    );
   }, [
     notificationsContext,
     notificationsContext.unreadNotifications,
     unreadNotificationsCount,
     setUnreadNotificationsCount,
+    addSubscription,
   ]);
 
-  const dismissAuthModal = () => {
+  const dismissAuthModal = React.useCallback(() => {
     setShowAuthModal(false);
-  };
+  }, [setShowAuthModal]);
+
   const handleMarkNotificationRead = React.useCallback(
-    (key) => {
-      notificationsContext.setRead(key, true);
-    },
-    [notificationsContext]
+    (key) => notificationsContext.setRead(key, true),
+    [notificationsContext.setRead]
   );
 
   React.useEffect(() => {
-    const sub = serviceContext.target.sslFailure().subscribe(() => {
-      setShowSslErrorModal(true);
-    });
-    return () => sub.unsubscribe();
-  }, [serviceContext.target]);
+    addSubscription(
+      serviceContext.target.sslFailure().subscribe(() => {
+        setShowSslErrorModal(true);
+      })
+    );
+  }, [serviceContext.target, serviceContext.target.sslFailure, setShowSslErrorModal, addSubscription]);
 
-  const dismissSslErrorModal = () => {
-    setShowSslErrorModal(false);
-  };
+  const dismissSslErrorModal = React.useCallback(() => setShowSslErrorModal(false), [setShowSslErrorModal]);
 
-  const onNavToggleMobile = () => {
-    setIsNavOpenMobile(!isNavOpenMobile);
-  };
-  const onNavToggle = () => {
-    setIsNavOpen(!isNavOpen);
-  };
-  const onPageResize = (props: { mobileView: boolean; windowSize: number }) => {
-    setIsMobileView(props.mobileView);
-  };
-  const mobileOnSelect = (selected) => {
-    if (isMobileView) setIsNavOpenMobile(false);
-  };
-  const handleSettingsButtonClick = () => {
+  const onNavToggleMobile = React.useCallback(() => {
+    setIsNavOpenMobile((isNavOpenMobile) => !isNavOpenMobile);
+  }, [setIsNavOpenMobile]);
+
+  const onNavToggle = React.useCallback(() => {
+    setIsNavOpen((isNavOpen) => !isNavOpen);
+  }, [setIsNavOpen]);
+
+  const onPageResize = React.useCallback(
+    (props: { mobileView: boolean; windowSize: number }) => {
+      setIsMobileView(props.mobileView);
+    },
+    [setIsMobileView]
+  );
+
+  const mobileOnSelect = React.useCallback(
+    (selected) => {
+      if (isMobileView) {
+        setIsNavOpenMobile(false);
+      }
+    },
+    [isMobileView, setIsNavOpenMobile]
+  );
+
+  const handleSettingsButtonClick = React.useCallback(() => {
     routerHistory.push('/settings');
-  };
-  const handleNotificationCenterToggle = () => {
-    setNotificationDrawerExpanded(!isNotificationDrawerExpanded);
-  };
-  const handleCloseNotificationCenter = () => {
+  }, [routerHistory.push]);
+
+  const handleNotificationCenterToggle = React.useCallback(() => {
+    setNotificationDrawerExpanded((isNotificationDrawerExpanded) => !isNotificationDrawerExpanded);
+  }, [setNotificationDrawerExpanded]);
+
+  const handleCloseNotificationCenter = React.useCallback(() => {
     setNotificationDrawerExpanded(false);
-  };
-  const handleAboutModalToggle = () => {
-    setAboutModalOpen(!aboutModalOpen);
-  };
+  }, [setNotificationDrawerExpanded]);
+
+  const handleAboutModalToggle = React.useCallback(() => {
+    setAboutModalOpen((aboutModalOpen) => !aboutModalOpen);
+  }, [setAboutModalOpen]);
 
   React.useEffect(() => {
-    const sub = serviceContext.login.getSessionState().subscribe((sessionState) => {
-      setShowUserIcon(sessionState === SessionState.USER_SESSION);
-    });
-    return () => sub.unsubscribe();
-  }, [serviceContext.target]);
+    addSubscription(
+      serviceContext.login.getSessionState().subscribe((sessionState) => {
+        setShowUserIcon(sessionState === SessionState.USER_SESSION);
+      })
+    );
+  }, [serviceContext.login, serviceContext.login.getSessionState, setShowUserIcon, addSubscription]);
 
   const handleLogout = React.useCallback(() => {
-    const sub = serviceContext.login.setLoggedOut().subscribe();
-    return () => sub.unsubscribe();
-  }, [serviceContext.login]);
+    addSubscription(serviceContext.login.setLoggedOut().subscribe());
+  }, [serviceContext.login, serviceContext.login.setLoggedOut, addSubscription]);
 
   const handleUserInfoToggle = React.useCallback(() => setShowUserInfoDropdown((v) => !v), [setShowUserInfoDropdown]);
 
   React.useEffect(() => {
-    const sub = serviceContext.login.getUsername().subscribe(setUsername);
-    return () => sub.unsubscribe();
-  }, [serviceContext, serviceContext.login]);
+    addSubscription(serviceContext.login.getUsername().subscribe(setUsername));
+  }, [serviceContext, serviceContext.login, addSubscription, setUsername]);
 
   const userInfoItems = [
     <DropdownGroup key={0}>
@@ -247,6 +262,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
       </PageHeaderTools>
     </>
   );
+
   const Header = (
     <>
       <PageHeader

--- a/src/app/ErrorView/ErrorView.tsx
+++ b/src/app/ErrorView/ErrorView.tsx
@@ -36,23 +36,26 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { Bullseye, Text } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 export interface ErrorViewProps {
+  title: string;
   message: string;
 }
 
 export const ErrorView: React.FunctionComponent<ErrorViewProps> = (props) => {
   return (
     <>
-      <br />
-      <Bullseye>
-        <ExclamationCircleIcon size="md" color="Red" />
-      </Bullseye>
-      <Bullseye>
-        <Text>Error:&nbsp;{props.message}</Text>
-      </Bullseye>
+      <EmptyState>
+        <EmptyStateIcon icon={ExclamationCircleIcon} color={"#a30000"} />
+        <Title headingLevel="h4" size="lg">
+          {props.title}
+        </Title>
+        <EmptyStateBody>
+          {props.message}
+        </EmptyStateBody>
+      </EmptyState>
     </>
   );
 };

--- a/src/app/ErrorView/ErrorView.tsx
+++ b/src/app/ErrorView/ErrorView.tsx
@@ -48,13 +48,11 @@ export const ErrorView: React.FunctionComponent<ErrorViewProps> = (props) => {
   return (
     <>
       <EmptyState>
-        <EmptyStateIcon icon={ExclamationCircleIcon} color={"#a30000"} />
+        <EmptyStateIcon icon={ExclamationCircleIcon} color={'#a30000'} />
         <Title headingLevel="h4" size="lg">
           {props.title}
         </Title>
-        <EmptyStateBody>
-          {props.message}
-        </EmptyStateBody>
+        <EmptyStateBody>{props.message}</EmptyStateBody>
       </EmptyState>
     </>
   );

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -374,7 +374,7 @@ export const EventTemplates = () => {
   );
 
   if (errorMessage != '') {
-    return <ErrorView message={errorMessage} title={"Fail to retrieve event templates"}/>;
+    return <ErrorView message={errorMessage} title={'Fail to retrieve event templates'} />;
   } else if (isLoading) {
     return (
       <>

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -374,7 +374,7 @@ export const EventTemplates = () => {
   );
 
   if (errorMessage != '') {
-    return <ErrorView message={errorMessage} />;
+    return <ErrorView message={errorMessage} title={"Fail to retrieve event templates"}/>;
   } else if (isLoading) {
     return (
       <>

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -221,7 +221,7 @@ export const EventTypes = () => {
 
   // TODO replace table with data list so collapsed event options can be custom formatted
   if (errorMessage != '') {
-    return <ErrorView message={errorMessage} title={"Fail to retrieve event types"}/>;
+    return <ErrorView message={errorMessage} title={'Fail to retrieve event types'} />;
   } else if (isLoading) {
     return <LoadingView />;
   } else {

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -221,7 +221,7 @@ export const EventTypes = () => {
 
   // TODO replace table with data list so collapsed event options can be custom formatted
   if (errorMessage != '') {
-    return <ErrorView message={errorMessage} />;
+    return <ErrorView message={errorMessage} title={"Fail to retrieve event types"}/>;
   } else if (isLoading) {
     return <LoadingView />;
   } else {

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -164,6 +164,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
   );
 
   const refreshRecordingList = React.useCallback(() => {
+
     setIsLoading(true);
     addSubscription(
       context.target
@@ -176,8 +177,10 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
           first()
         )
         .subscribe(
-          (value) => handleRecordings(value),
-          (err) => handleError(err)
+          {
+            next: handleRecordings,
+            error: handleError
+          }
         )
     );
   }, [addSubscription, context, context.target, context.api, setIsLoading, handleRecordings, handleError]);

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -164,7 +164,6 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
   );
 
   const refreshRecordingList = React.useCallback(() => {
-
     setIsLoading(true);
     addSubscription(
       context.target
@@ -176,12 +175,10 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
           ),
           first()
         )
-        .subscribe(
-          {
-            next: handleRecordings,
-            error: handleError
-          }
-        )
+        .subscribe({
+          next: handleRecordings,
+          error: handleError,
+        })
     );
   }, [addSubscription, context, context.target, context.api, setIsLoading, handleRecordings, handleError]);
 

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -541,7 +541,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
             isEmptyFilterResult={!filteredRecordings.length}
             clearFilters={handleClearFilters}
             isNestedTable={props.isNestedTable}
-            errorMessage=""
+            errorMessage={''}
           >
             {recordingRows}
           </RecordingsTable>

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -68,9 +68,11 @@ export interface RecordingsTableProps {
 export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (props) => {
   let view: JSX.Element;
   if (props.errorMessage != '') {
-    view =  <>
-      <ErrorView message={props.errorMessage} title={"Error retrieving recordings"}></ErrorView>
-  </>;
+    view = (
+      <>
+        <ErrorView message={props.errorMessage} title={'Error retrieving recordings'}></ErrorView>
+      </>
+    );
   } else if (props.isLoading) {
     view = <LoadingView />;
   } else if (props.isEmpty) {

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -47,6 +47,7 @@ import {
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { TableComposable, Thead, Tr, Th, OuterScrollContainer, InnerScrollContainer } from '@patternfly/react-table';
 import { LoadingView } from '@app/LoadingView/LoadingView';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { ErrorView } from '@app/ErrorView/ErrorView';
 
 export interface RecordingsTableProps {
@@ -67,7 +68,9 @@ export interface RecordingsTableProps {
 export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (props) => {
   let view: JSX.Element;
   if (props.errorMessage != '') {
-    view = <ErrorView message={props.errorMessage} />;
+    view =  <>
+      <ErrorView message={props.errorMessage} title={"Error retrieving recordings"}></ErrorView>
+  </>;
   } else if (props.isLoading) {
     view = <LoadingView />;
   } else if (props.isEmpty) {

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -211,7 +211,7 @@ const Comp = () => {
     maxSizeUnits,
   ]);
 
-  const handleTemlateList = React.useCallback(
+  const handleTemplateList = React.useCallback(
     (templates) => {
       setTemplates(templates);
       setErrorMessage('');
@@ -239,7 +239,7 @@ const Comp = () => {
           first()
         )
         .subscribe({
-          next: handleTemlateList,
+          next: handleTemplateList,
           error: handleError,
         })
     );

--- a/src/test/Recordings/RecordingsTable.test.tsx
+++ b/src/test/Recordings/RecordingsTable.test.tsx
@@ -167,7 +167,7 @@ describe('<RecordingsTable />', () => {
       </RecordingsTable>
     );
 
-    expect(screen.getByText('Error: some error')).toBeInTheDocument();
+    expect(screen.getByText('some error')).toBeInTheDocument();
   });
 
   it('renders correctly when table data is still loading', () => {

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -134,13 +134,13 @@ describe('<CreateRule />', () => {
     const subj = new Subject<void>();
     const mockTargetSvc = {
       target: () => of(mockTarget),
-      authFailure: () => subj.asObservable()
+      authFailure: () => subj.asObservable(),
     } as TargetService;
     const services: Services = {
       ...defaultServices,
       target: mockTargetSvc,
     };
-    
+
     render(
       <ServiceContext.Provider value={services}>
         <Router location={history.location} history={history}>
@@ -151,11 +151,11 @@ describe('<CreateRule />', () => {
 
     await doAct(async () => subj.next());
 
-    const failTitle = screen.getByText("Fail to retrieve event templates");
+    const failTitle = screen.getByText('Fail to retrieve event templates');
     expect(failTitle).toBeInTheDocument();
     expect(failTitle).toBeVisible();
 
-    const authFailText = screen.getByText("Auth failure");
+    const authFailText = screen.getByText('Auth failure');
     expect(authFailText).toBeInTheDocument();
     expect(authFailText).toBeVisible();
   });

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -38,16 +38,16 @@
 import * as React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import '@testing-library/jest-dom';
 import renderer, { act } from 'react-test-renderer';
-import { render, cleanup, screen, waitFor } from '@testing-library/react';
+import { act as doAct, render, cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Rule } from '@app/Rules/Rules';
-import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
+import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/Services';
 import { CreateRule } from '@app/Rules/CreateRule';
 import { EventTemplate } from '@app/CreateRecording/CreateRecording';
-import { Target } from '@app/Shared/Services/Target.service';
+import { Target, TargetService } from '@app/Shared/Services/Target.service';
 import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
 
 const escapeKeyboardInput = (value: string) => {
@@ -107,6 +107,7 @@ jest.spyOn(defaultServices.api, 'doGet').mockReturnValue(of([mockEventTemplate])
 jest.spyOn(defaultServices.target, 'target').mockReturnValue(of(mockTarget));
 jest.spyOn(defaultServices.targets, 'targets').mockReturnValue(of([mockTarget]));
 jest.spyOn(defaultServices.targets, 'queryForTargets').mockReturnValue(of());
+jest.spyOn(defaultServices.target, 'authFailure').mockReturnValue(of());
 
 describe('<CreateRule />', () => {
   beforeEach(() => {
@@ -127,6 +128,36 @@ describe('<CreateRule />', () => {
       );
     });
     expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  it('should show error view if failing to retrieve templates', async () => {
+    const subj = new Subject<void>();
+    const mockTargetSvc = {
+      target: () => of(mockTarget),
+      authFailure: () => subj.asObservable()
+    } as TargetService;
+    const services: Services = {
+      ...defaultServices,
+      target: mockTargetSvc,
+    };
+    
+    render(
+      <ServiceContext.Provider value={services}>
+        <Router location={history.location} history={history}>
+          <CreateRule />
+        </Router>
+      </ServiceContext.Provider>
+    );
+
+    await doAct(async () => subj.next());
+
+    const failTitle = screen.getByText("Fail to retrieve event templates");
+    expect(failTitle).toBeInTheDocument();
+    expect(failTitle).toBeVisible();
+
+    const authFailText = screen.getByText("Auth failure");
+    expect(authFailText).toBeInTheDocument();
+    expect(authFailText).toBeVisible();
   });
 
   it('should submit form if form input is valid', async () => {


### PR DESCRIPTION
Fixes #527 
Fixes #485 
Depends on https://github.com/cryostatio/cryostat/issues/1104

**Fixes**
- Added Auth form or SSL warning if failing to retrieve a template list from selected target.
- Editted ErrorView for better layout and visuals :D

**Chore**
- Use `useSubscriptions` for subs and `React.useCallback` for callbacks in `AppLayout`.