### PR TITLE
feat(auth): add retry button on auth failure

### DIFF
--- a/src/app/ErrorView/ErrorView.tsx
+++ b/src/app/ErrorView/ErrorView.tsx
@@ -39,9 +39,10 @@ import * as React from 'react';
 import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
+export const authFailMessage = 'Auth failure';
 export interface ErrorViewProps {
-  title: string;
-  message: string;
+  title: string | React.ReactNode;
+  message: string | React.ReactNode;
 }
 
 export const ErrorView: React.FunctionComponent<ErrorViewProps> = (props) => {

--- a/src/app/ErrorView/ErrorView.tsx
+++ b/src/app/ErrorView/ErrorView.tsx
@@ -36,13 +36,23 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Title,
+  Text,
+  StackItem,
+  Stack,
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 export const authFailMessage = 'Auth failure';
 export interface ErrorViewProps {
   title: string | React.ReactNode;
   message: string | React.ReactNode;
+  retry?: () => void;
 }
 
 export const ErrorView: React.FunctionComponent<ErrorViewProps> = (props) => {
@@ -53,7 +63,21 @@ export const ErrorView: React.FunctionComponent<ErrorViewProps> = (props) => {
         <Title headingLevel="h4" size="lg">
           {props.title}
         </Title>
-        <EmptyStateBody>{props.message}</EmptyStateBody>
+        <EmptyStateBody>
+          <>
+            <Stack>
+              <StackItem>{props.message}</StackItem>
+              {props.retry && (
+                <StackItem>
+                  <Button variant="link" onClick={props.retry}>
+                    Retry
+                  </Button>
+                </StackItem>
+              )}
+            </Stack>
+            <Text></Text>
+          </>
+        </EmptyStateBody>
       </EmptyState>
     </>
   );

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -374,19 +374,17 @@ export const EventTemplates = () => {
     </>
   );
 
+  const authRetry = React.useCallback(() => {
+    context.target.setAuthRetry();
+  }, [context.target, context.target.setAuthRetry]);
+
   if (errorMessage != '') {
-    const isAuthError = React.useMemo(() => errorMessage === authFailMessage, [errorMessage, authFailMessage]);
-
-    const authRetry = React.useCallback(() => {
-      context.target.setAuthRetry();
-    }, [context.target, context.target.setAuthRetry]);
-
     return (
       <ErrorView
         message={
           <>
             <Text>{errorMessage}</Text>
-            {isAuthError && (
+            {errorMessage === authFailMessage && (
               <Button variant="link" onClick={authRetry}>
                 Retry
               </Button>

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -54,6 +54,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
   TextInput,
+  Text,
 } from '@patternfly/react-core';
 import { UploadIcon } from '@patternfly/react-icons';
 import {
@@ -71,7 +72,7 @@ import {
 import { useHistory } from 'react-router-dom';
 import { concatMap, filter, first } from 'rxjs/operators';
 import { LoadingView } from '@app/LoadingView/LoadingView';
-import { ErrorView } from '@app/ErrorView/ErrorView';
+import { authFailMessage, ErrorView } from '@app/ErrorView/ErrorView';
 import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
 
@@ -374,7 +375,27 @@ export const EventTemplates = () => {
   );
 
   if (errorMessage != '') {
-    return <ErrorView message={errorMessage} title={'Fail to retrieve event templates'} />;
+    const isAuthError = React.useMemo(() => errorMessage === authFailMessage, [errorMessage, authFailMessage]);
+
+    const authRetry = React.useCallback(() => {
+      context.target.setAuthRetry();
+    }, [context.target, context.target.setAuthRetry]);
+
+    return (
+      <ErrorView
+        message={
+          <>
+            <Text>{errorMessage}</Text>
+            {isAuthError && (
+              <Button variant="link" onClick={authRetry}>
+                Retry
+              </Button>
+            )}
+          </>
+        }
+        title={'Fail to retrieve event templates'}
+      />
+    );
   } else if (isLoading) {
     return (
       <>

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -203,7 +203,7 @@ export const EventTemplates = () => {
 
   React.useEffect(() => {
     const sub = context.target.authFailure().subscribe(() => {
-      setErrorMessage('Auth failure');
+      setErrorMessage(authFailMessage);
     });
     return () => sub.unsubscribe();
   }, [context.target]);
@@ -379,7 +379,7 @@ export const EventTemplates = () => {
   }, [context.target, context.target.setAuthRetry]);
 
   if (errorMessage != '') {
-    return <ErrorView title={'Fail to retrieve event templates'} message={errorMessage} retry={authRetry} />;
+    return <ErrorView title={'Error retrieving event templates'} message={errorMessage} retry={authRetry} />;
   } else if (isLoading) {
     return (
       <>

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -379,21 +379,7 @@ export const EventTemplates = () => {
   }, [context.target, context.target.setAuthRetry]);
 
   if (errorMessage != '') {
-    return (
-      <ErrorView
-        message={
-          <>
-            <Text>{errorMessage}</Text>
-            {errorMessage === authFailMessage && (
-              <Button variant="link" onClick={authRetry}>
-                Retry
-              </Button>
-            )}
-          </>
-        }
-        title={'Fail to retrieve event templates'}
-      />
-    );
+    return <ErrorView title={'Fail to retrieve event templates'} message={errorMessage} retry={authRetry} />;
   } else if (isLoading) {
     return (
       <>

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -46,11 +46,13 @@ import {
   ToolbarItemVariant,
   Pagination,
   TextInput,
+  Text,
+  Button,
 } from '@patternfly/react-core';
 import { expandable, Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import { concatMap, filter, first } from 'rxjs/operators';
 import { LoadingView } from '@app/LoadingView/LoadingView';
-import { ErrorView } from '@app/ErrorView/ErrorView';
+import { authFailMessage, ErrorView } from '@app/ErrorView/ErrorView';
 
 export interface EventType {
   name: string;
@@ -221,7 +223,27 @@ export const EventTypes = () => {
 
   // TODO replace table with data list so collapsed event options can be custom formatted
   if (errorMessage != '') {
-    return <ErrorView message={errorMessage} title={'Fail to retrieve event types'} />;
+    const isAuthError = React.useMemo(() => errorMessage === authFailMessage, [errorMessage, authFailMessage]);
+
+    const authRetry = React.useCallback(() => {
+      context.target.setAuthRetry();
+    }, [context.target, context.target.setAuthRetry]);
+
+    return (
+      <ErrorView
+        message={
+          <>
+            <Text>{errorMessage}</Text>
+            {isAuthError && (
+              <Button variant="link" onClick={authRetry}>
+                Retry
+              </Button>
+            )}
+          </>
+        }
+        title={'Fail to retrieve event types'}
+      />
+    );
   } else if (isLoading) {
     return <LoadingView />;
   } else {

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -227,21 +227,7 @@ export const EventTypes = () => {
 
   // TODO replace table with data list so collapsed event options can be custom formatted
   if (errorMessage != '') {
-    return (
-      <ErrorView
-        message={
-          <>
-            <Text>{errorMessage}</Text>
-            {errorMessage === authFailMessage && (
-              <Button variant="link" onClick={authRetry}>
-                Retry
-              </Button>
-            )}
-          </>
-        }
-        title={'Fail to retrieve event types'}
-      />
-    );
+    return <ErrorView title={'Fail to retrieve event types'} message={errorMessage} retry={authRetry} />;
   } else if (isLoading) {
     return <LoadingView />;
   } else {

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -146,7 +146,7 @@ export const EventTypes = () => {
 
   React.useEffect(() => {
     const sub = context.target.authFailure().subscribe(() => {
-      setErrorMessage('Auth failure');
+      setErrorMessage(authFailMessage);
     });
     return () => sub.unsubscribe();
   }, [context.target]);
@@ -227,7 +227,7 @@ export const EventTypes = () => {
 
   // TODO replace table with data list so collapsed event options can be custom formatted
   if (errorMessage != '') {
-    return <ErrorView title={'Fail to retrieve event types'} message={errorMessage} retry={authRetry} />;
+    return <ErrorView title={'Error retrieving event types'} message={errorMessage} retry={authRetry} />;
   } else if (isLoading) {
     return <LoadingView />;
   } else {

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -221,20 +221,18 @@ export const EventTypes = () => {
     }
   };
 
+  const authRetry = React.useCallback(() => {
+    context.target.setAuthRetry();
+  }, [context.target, context.target.setAuthRetry]);
+
   // TODO replace table with data list so collapsed event options can be custom formatted
   if (errorMessage != '') {
-    const isAuthError = React.useMemo(() => errorMessage === authFailMessage, [errorMessage, authFailMessage]);
-
-    const authRetry = React.useCallback(() => {
-      context.target.setAuthRetry();
-    }, [context.target, context.target.setAuthRetry]);
-
     return (
       <ErrorView
         message={
           <>
             <Text>{errorMessage}</Text>
-            {isAuthError && (
+            {errorMessage === authFailMessage && (
               <Button variant="link" onClick={authRetry}>
                 Retry
               </Button>

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -82,6 +82,7 @@ import {
 } from '@app/Shared/Redux/RecordingFilterActions';
 import { TargetRecordingFilters, UpdateFilterOptions } from '@app/Shared/Redux/RecordingFilterReducer';
 import { RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
+import { authFailMessage } from '@app/ErrorView/ErrorView';
 
 export enum PanelContent {
   LABELS,
@@ -259,7 +260,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
   React.useEffect(() => {
     addSubscription(
       context.target.authFailure().subscribe(() => {
-        setErrorMessage('Auth failure');
+        setErrorMessage(authFailMessage);
       })
     );
   }, [context, context.target, setErrorMessage, addSubscription]);

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -523,17 +523,18 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
             toolbar={RecordingsToolbar}
             tableColumns={tableColumns}
             tableFooter={
-              filteredRecordings.length > 0 && 
-              <TableComposable borders={false}>
-                <Tbody>
-                  <Tr>
-                    <Td></Td>
-                    <Td width={15}>
-                      <b>Total size: {formatBytes(totalArchiveSize)}</b>
-                    </Td>
-                  </Tr>
-                </Tbody>
-              </TableComposable>
+              filteredRecordings.length > 0 && (
+                <TableComposable borders={false}>
+                  <Tbody>
+                    <Tr>
+                      <Td></Td>
+                      <Td width={15}>
+                        <b>Total size: {formatBytes(totalArchiveSize)}</b>
+                      </Td>
+                    </Tr>
+                  </Tbody>
+                </TableComposable>
+              )
             }
             isHeaderChecked={headerChecked}
             onHeaderCheck={handleHeaderCheck}

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -523,6 +523,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
             toolbar={RecordingsToolbar}
             tableColumns={tableColumns}
             tableFooter={
+              filteredRecordings.length > 0 && 
               <TableComposable borders={false}>
                 <Tbody>
                   <Tr>

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -41,16 +41,17 @@ import { TargetView } from '@app/TargetView/TargetView';
 import { Card, CardBody, CardHeader, Tab, Tabs, Text, TextVariants } from '@patternfly/react-core';
 import { ActiveRecordingsTable } from './ActiveRecordingsTable';
 import { ArchivedRecordingsTable } from './ArchivedRecordingsTable';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 
 export const Recordings = () => {
   const context = React.useContext(ServiceContext);
   const [activeTab, setActiveTab] = React.useState(0);
   const [archiveEnabled, setArchiveEnabled] = React.useState(false);
+  const addSubscription = useSubscriptions();
 
   React.useEffect(() => {
-    const sub = context.api.isArchiveEnabled().subscribe(setArchiveEnabled);
-    return () => sub.unsubscribe();
-  }, [context.api]);
+    addSubscription(context.api.isArchiveEnabled().subscribe(setArchiveEnabled));
+  }, [context.api, context.api.isArchiveEnabled, addSubscription]);
 
   const cardBody = React.useMemo(() => {
     return archiveEnabled ? (

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -48,7 +48,7 @@ import {
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { TableComposable, Thead, Tr, Th, OuterScrollContainer, InnerScrollContainer } from '@patternfly/react-table';
 import { LoadingView } from '@app/LoadingView/LoadingView';
-import { authFailMessage, ErrorView } from '@app/ErrorView/ErrorView';
+import { ErrorView } from '@app/ErrorView/ErrorView';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface RecordingsTableProps {

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -43,12 +43,13 @@ import {
   EmptyStateBody,
   Button,
   EmptyStateSecondaryActions,
+  Text,
 } from '@patternfly/react-core';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { TableComposable, Thead, Tr, Th, OuterScrollContainer, InnerScrollContainer } from '@patternfly/react-table';
 import { LoadingView } from '@app/LoadingView/LoadingView';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import { ErrorView } from '@app/ErrorView/ErrorView';
+import { authFailMessage, ErrorView } from '@app/ErrorView/ErrorView';
+import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface RecordingsTableProps {
   toolbar: React.ReactElement;
@@ -66,11 +67,33 @@ export interface RecordingsTableProps {
 }
 
 export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (props) => {
+  const context = React.useContext(ServiceContext);
   let view: JSX.Element;
   if (props.errorMessage != '') {
+    const isAuthError = React.useMemo(
+      () => props.errorMessage === authFailMessage,
+      [props.errorMessage, authFailMessage]
+    );
+
+    const authRetry = React.useCallback(() => {
+      context.target.setAuthRetry();
+    }, [context.target, context.target.setAuthRetry]);
+
     view = (
       <>
-        <ErrorView message={props.errorMessage} title={'Error retrieving recordings'}></ErrorView>
+        <ErrorView
+          message={
+            <>
+              <Text>{props.errorMessage}</Text>
+              {isAuthError && (
+                <Button variant="link" onClick={authRetry}>
+                  Retry
+                </Button>
+              )}
+            </>
+          }
+          title={'Error retrieving recordings'}
+        ></ErrorView>
       </>
     );
   } else if (props.isLoading) {

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -77,19 +77,7 @@ export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (p
   if (props.errorMessage != '') {
     view = (
       <>
-        <ErrorView
-          message={
-            <>
-              <Text>{props.errorMessage}</Text>
-              {props.errorMessage === authFailMessage && (
-                <Button variant="link" onClick={authRetry}>
-                  Retry
-                </Button>
-              )}
-            </>
-          }
-          title={'Error retrieving recordings'}
-        ></ErrorView>
+        <ErrorView title={'Error retrieving recordings'} message={props.errorMessage} retry={authRetry}></ErrorView>
       </>
     );
   } else if (props.isLoading) {

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -69,23 +69,19 @@ export interface RecordingsTableProps {
 export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (props) => {
   const context = React.useContext(ServiceContext);
   let view: JSX.Element;
+
+  const authRetry = React.useCallback(() => {
+    context.target.setAuthRetry();
+  }, [context.target, context.target.setAuthRetry]);
+
   if (props.errorMessage != '') {
-    const isAuthError = React.useMemo(
-      () => props.errorMessage === authFailMessage,
-      [props.errorMessage, authFailMessage]
-    );
-
-    const authRetry = React.useCallback(() => {
-      context.target.setAuthRetry();
-    }, [context.target, context.target.setAuthRetry]);
-
     view = (
       <>
         <ErrorView
           message={
             <>
               <Text>{props.errorMessage}</Text>
-              {isAuthError && (
+              {props.errorMessage === authFailMessage && (
                 <Button variant="link" onClick={authRetry}>
                   Retry
                 </Button>

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -274,19 +274,7 @@ const Comp = () => {
       <Grid hasGutter>
         <GridItem xl={7}>
           {errorMessage ? (
-            <ErrorView
-              message={
-                <>
-                  <Text>{errorMessage}</Text>
-                  {errorMessage === authFailMessage && (
-                    <Button variant="link" onClick={authRetry}>
-                      Retry
-                    </Button>
-                  )}
-                </>
-              }
-              title={'Fail to retrieve event templates'}
-            ></ErrorView>
+            <ErrorView title={'Fail to retrieve event templates'} message={errorMessage} retry={authRetry}></ErrorView>
           ) : (
             <Card>
               <CardBody>

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -265,8 +265,6 @@ const Comp = () => {
     },
   ];
 
-  const isAuthError = React.useMemo(() => errorMessage === authFailMessage, [errorMessage, authFailMessage]);
-
   const authRetry = React.useCallback(() => {
     context.target.setAuthRetry();
   }, [context.target, context.target.setAuthRetry]);
@@ -280,7 +278,7 @@ const Comp = () => {
               message={
                 <>
                   <Text>{errorMessage}</Text>
-                  {isAuthError && (
+                  {errorMessage === authFailMessage && (
                     <Button variant="link" onClick={authRetry}>
                       Retry
                     </Button>

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -51,6 +51,8 @@ import {
   GridItem,
   Split,
   SplitItem,
+  Stack,
+  StackItem,
   Switch,
   Text,
   TextInput,
@@ -69,7 +71,7 @@ import { MatchExpressionEvaluator } from '../Shared/MatchExpressionEvaluator';
 import { FormSelectTemplateSelector } from '../TemplateSelector/FormSelectTemplateSelector';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { iif } from 'rxjs';
-import { ErrorView } from '@app/ErrorView/ErrorView';
+import { authFailMessage, ErrorView } from '@app/ErrorView/ErrorView';
 
 // FIXME check if this is correct/matches backend name validation
 export const RuleNamePattern = /^[\w_]+$/;
@@ -219,7 +221,6 @@ const Comp = () => {
     [setTemplate, setErrorMessage]
   );
 
-  // FIXME Error 427 JMX Authentication is handled differently than Error 502 Untrusted SSL.
   const refreshTemplateList = React.useCallback(() => {
     addSubscription(
       context.target
@@ -252,10 +253,10 @@ const Comp = () => {
   React.useEffect(() => {
     addSubscription(
       context.target.authFailure().subscribe(() => {
-        setErrorMessage('Auth failure');
+        setErrorMessage(authFailMessage);
       })
     );
-  }, [context.target, setErrorMessage, addSubscription]);
+  }, [context.target, authFailMessage, setErrorMessage, addSubscription]);
 
   const breadcrumbs: BreadcrumbTrail[] = [
     {
@@ -264,12 +265,30 @@ const Comp = () => {
     },
   ];
 
+  const isAuthError = React.useMemo(() => errorMessage === authFailMessage, [errorMessage, authFailMessage]);
+
+  const authRetry = React.useCallback(() => {
+    context.target.setAuthRetry();
+  }, [context.target, context.target.setAuthRetry]);
+
   return (
     <BreadcrumbPage pageTitle="Create" breadcrumbs={breadcrumbs}>
       <Grid hasGutter>
         <GridItem xl={7}>
           {errorMessage ? (
-            <ErrorView message={errorMessage} title={'Fail to retrieve event templates'}></ErrorView>
+            <ErrorView
+              message={
+                <>
+                  <Text>{errorMessage}</Text>
+                  {isAuthError && (
+                    <Button variant="link" onClick={authRetry}>
+                      Retry
+                    </Button>
+                  )}
+                </>
+              }
+              title={'Fail to retrieve event templates'}
+            ></ErrorView>
           ) : (
             <Card>
               <CardBody>

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -274,7 +274,7 @@ const Comp = () => {
       <Grid hasGutter>
         <GridItem xl={7}>
           {errorMessage ? (
-            <ErrorView title={'Fail to retrieve event templates'} message={errorMessage} retry={authRetry}></ErrorView>
+            <ErrorView title={'Error retrieving event templates'} message={errorMessage} retry={authRetry}></ErrorView>
           ) : (
             <Card>
               <CardBody>

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -148,11 +148,6 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
     onSelect(undefined, undefined, true);
   }, [onSelect]);
 
-  const refreshTargetList = React.useCallback(() => {
-    setLoading(true);
-    addSubscription(context.targets.queryForTargets().subscribe(() => setLoading(false)));
-  }, [addSubscription, context, context.targets, setLoading]);
-
   React.useEffect(() => {
     addSubscription(
       context.targets.targets().subscribe((targets) => {
@@ -187,17 +182,6 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   React.useLayoutEffect(() => {
     addSubscription(context.target.target().subscribe(setSelected));
   }, [addSubscription, context, context.target, setSelected]);
-
-  React.useEffect(() => {
-    if (!context.settings.autoRefreshEnabled()) {
-      return;
-    }
-    const id = window.setInterval(
-      () => refreshTargetList(),
-      context.settings.autoRefreshPeriod() * context.settings.autoRefreshUnits()
-    );
-    return () => window.clearInterval(id);
-  }, [context, context.target, context.settings, refreshTargetList]);
 
   const showCreateTargetModal = React.useCallback(() => {
     setModalOpen(true);
@@ -324,13 +308,6 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
               onClick={handleDeleteButton}
               variant="control"
               icon={<TrashIcon />}
-            />
-            <Button
-              aria-label="Refresh targets"
-              isDisabled={isLoading}
-              onClick={refreshTargetList}
-              variant="control"
-              icon={<Spinner2Icon />}
             />
           </CardActions>
         </CardHeader>

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -38,7 +38,7 @@
 import * as React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import { of, Subject } from 'rxjs';
+import { of, retry, Subject } from 'rxjs';
 import '@testing-library/jest-dom';
 import renderer, { act } from 'react-test-renderer';
 import { act as doAct, render, cleanup, screen, waitFor } from '@testing-library/react';
@@ -158,6 +158,10 @@ describe('<CreateRule />', () => {
     const authFailText = screen.getByText('Auth failure');
     expect(authFailText).toBeInTheDocument();
     expect(authFailText).toBeVisible();
+
+    const retryButton = screen.getByText("Retry");
+    expect(retryButton).toBeInTheDocument();
+    expect(retryButton).toBeVisible();
   });
 
   it('should submit form if form input is valid', async () => {

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -159,7 +159,7 @@ describe('<CreateRule />', () => {
     expect(authFailText).toBeInTheDocument();
     expect(authFailText).toBeVisible();
 
-    const retryButton = screen.getByText("Retry");
+    const retryButton = screen.getByText('Retry');
     expect(retryButton).toBeInTheDocument();
     expect(retryButton).toBeVisible();
   });

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -151,7 +151,7 @@ describe('<CreateRule />', () => {
 
     await doAct(async () => subj.next());
 
-    const failTitle = screen.getByText('Fail to retrieve event templates');
+    const failTitle = screen.getByText('Error retrieving event templates');
     expect(failTitle).toBeInTheDocument();
     expect(failTitle).toBeVisible();
 

--- a/src/test/Rules/__snapshots__/CreateRule.test.tsx.snap
+++ b/src/test/Rules/__snapshots__/CreateRule.test.tsx.snap
@@ -1021,41 +1021,6 @@ exports[`<CreateRule /> renders correctly 1`] = `
                             </svg>
                           </span>
                         </button>
-                        <button
-                          aria-disabled={false}
-                          aria-label="Refresh targets"
-                          className="pf-c-button pf-m-control"
-                          data-ouia-component-id="OUIA-Generated-Button-control-3"
-                          data-ouia-component-type="PF4/Button"
-                          data-ouia-safe={true}
-                          disabled={false}
-                          onClick={[Function]}
-                          role={null}
-                          type="button"
-                        >
-                          <span
-                            className="pf-c-button__icon pf-m-start"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              aria-labelledby={null}
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style={
-                                Object {
-                                  "verticalAlign": "-0.125em",
-                                }
-                              }
-                              viewBox="0 0 1024 1024"
-                              width="1em"
-                            >
-                              <path
-                                d="M515.8,0 C655.3,0 781.6,58.4 873.4,150.2 L968.9,54.7 C989,34.5 1024,48.8 1024,77.3 L1024,352 C1024,369.7 1009.2,384.1 991.5,384 L716.8,384 C688.3,384 674,349.5 694.2,329.3 L783,240.5 C713.5,171.1 617.8,128 512,128 C300.4,128 128,300.2 128,512 C128,723.8 300.2,895.1 511.9,895 C606.9,895 693.9,861.2 761,803.9 C773.7,793.1 792.6,793.8 804.4,805.6 L849.6,850.9 C862.6,864 861.9,885.4 848,897.6 C758,976.3 640.3,1024 511.7,1024 C229.1,1024 0,797 0,510.7 C0,226.2 235,0 515.8,0"
-                              />
-                            </svg>
-                          </span>
-                        </button>
                       </div>
                     </div>
                     <div

--- a/src/test/Targets/TargetSelect.test.tsx
+++ b/src/test/Targets/TargetSelect.test.tsx
@@ -132,7 +132,6 @@ describe('<TargetSelect />', () => {
 
     expect(screen.getByLabelText('Create target')).toBeInTheDocument();
     expect(screen.getByLabelText('Delete target')).toBeInTheDocument();
-    expect(screen.getByLabelText('Refresh targets')).toBeInTheDocument();
     expect(screen.getByLabelText('Options menu')).toBeInTheDocument();
   });
 
@@ -203,19 +202,6 @@ describe('<TargetSelect />', () => {
 
     expect(deleteTargetRequestSpy).toBeCalledTimes(0);
     expect(deleteButton).toBeDisabled();
-  });
-
-  it('refreshes targets when button clicked', () => {
-    render(
-      <ServiceContext.Provider value={defaultServices}>
-        <TargetSelect />
-      </ServiceContext.Provider>
-    );
-    const refreshButton = screen.getByLabelText('Refresh targets');
-    userEvent.click(refreshButton);
-
-    const refreshTargetsRequestSpy = jest.spyOn(defaultServices.targets, 'queryForTargets');
-    expect(refreshTargetsRequestSpy).toBeCalledTimes(1);
   });
 
   it('deletes target when warning modal is accepted', async () => {

--- a/src/test/Targets/__snapshots__/TargetSelect.test.tsx.snap
+++ b/src/test/Targets/__snapshots__/TargetSelect.test.tsx.snap
@@ -98,41 +98,6 @@ exports[`<TargetSelect /> renders correctly 1`] = `
           </svg>
         </span>
       </button>
-      <button
-        aria-disabled={false}
-        aria-label="Refresh targets"
-        className="pf-c-button pf-m-control"
-        data-ouia-component-id="OUIA-Generated-Button-control-3"
-        data-ouia-component-type="PF4/Button"
-        data-ouia-safe={true}
-        disabled={false}
-        onClick={[Function]}
-        role={null}
-        type="button"
-      >
-        <span
-          className="pf-c-button__icon pf-m-start"
-        >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 1024 1024"
-            width="1em"
-          >
-            <path
-              d="M515.8,0 C655.3,0 781.6,58.4 873.4,150.2 L968.9,54.7 C989,34.5 1024,48.8 1024,77.3 L1024,352 C1024,369.7 1009.2,384.1 991.5,384 L716.8,384 C688.3,384 674,349.5 694.2,329.3 L783,240.5 C713.5,171.1 617.8,128 512,128 C300.4,128 128,300.2 128,512 C128,723.8 300.2,895.1 511.9,895 C606.9,895 693.9,861.2 761,803.9 C773.7,793.1 792.6,793.8 804.4,805.6 L849.6,850.9 C862.6,864 861.9,885.4 848,897.6 C758,976.3 640.3,1024 511.7,1024 C229.1,1024 0,797 0,510.7 C0,226.2 235,0 515.8,0"
-            />
-          </svg>
-        </span>
-      </button>
     </div>
   </div>
   <div


### PR DESCRIPTION
Fixes #485
Related to #540 

The issue is that the observable for `427` error code is hanged waiting for retry.

So, I added a `Retry` button for auth failure, which picks up the hanged `Observable` to retry. If the user does not click cancel, it will still be there until moving away to another page or reloads.

Also, just noticed the total size for archived recording is displayed when there are no recordings. This is removed now.