### PR TITLE
fix(auth): only show retry button for auth failures

### DIFF
--- a/src/app/ErrorView/ErrorView.tsx
+++ b/src/app/ErrorView/ErrorView.tsx
@@ -49,6 +49,7 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 export const authFailMessage = 'Auth failure';
+export const isAuthFail = (message: string) => message === authFailMessage;
 export interface ErrorViewProps {
   title: string | React.ReactNode;
   message: string | React.ReactNode;

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -258,11 +258,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
   }, [addSubscription, context, context.notificationChannel, setRecordings]);
 
   React.useEffect(() => {
-    addSubscription(
-      context.target.authFailure().subscribe(() => {
-        setErrorMessage(authFailMessage);
-      })
-    );
+    addSubscription(context.target.authFailure().subscribe(() => setErrorMessage(authFailMessage)));
   }, [context, context.target, setErrorMessage, addSubscription]);
 
   React.useEffect(() => {

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -68,12 +68,13 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
   const addSubscription = useSubscriptions();
 
   React.useEffect(() => {
-    const sub = context.api
-      .grafanaDatasourceUrl()
-      .pipe(first())
-      .subscribe(() => setGrafanaEnabled(true));
-    return () => sub.unsubscribe();
-  }, [context.api, setGrafanaEnabled]);
+    addSubscription(
+      context.api
+        .grafanaDatasourceUrl()
+        .pipe(first())
+        .subscribe(() => setGrafanaEnabled(true))
+    );
+  }, [context.api, setGrafanaEnabled, addSubscription]);
 
   const grafanaUpload = React.useCallback(() => {
     notifications.info('Upload Started', `Recording "${props.recording.name}" uploading...`);

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -48,7 +48,7 @@ import {
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { TableComposable, Thead, Tr, Th, OuterScrollContainer, InnerScrollContainer } from '@patternfly/react-table';
 import { LoadingView } from '@app/LoadingView/LoadingView';
-import { ErrorView } from '@app/ErrorView/ErrorView';
+import { ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface RecordingsTableProps {
@@ -77,7 +77,11 @@ export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (p
   if (props.errorMessage != '') {
     view = (
       <>
-        <ErrorView title={'Error retrieving recordings'} message={props.errorMessage} retry={authRetry}></ErrorView>
+        <ErrorView
+          title={'Error retrieving recordings'}
+          message={props.errorMessage}
+          retry={isAuthFail(props.errorMessage) ? authRetry : undefined}
+        />
       </>
     );
   } else if (props.isLoading) {

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -51,8 +51,6 @@ import {
   GridItem,
   Split,
   SplitItem,
-  Stack,
-  StackItem,
   Switch,
   Text,
   TextInput,
@@ -71,7 +69,7 @@ import { MatchExpressionEvaluator } from '../Shared/MatchExpressionEvaluator';
 import { FormSelectTemplateSelector } from '../TemplateSelector/FormSelectTemplateSelector';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { iif } from 'rxjs';
-import { authFailMessage, ErrorView } from '@app/ErrorView/ErrorView';
+import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
 
 // FIXME check if this is correct/matches backend name validation
 export const RuleNamePattern = /^[\w_]+$/;
@@ -274,7 +272,11 @@ const Comp = () => {
       <Grid hasGutter>
         <GridItem xl={7}>
           {errorMessage ? (
-            <ErrorView title={'Error retrieving event templates'} message={errorMessage} retry={authRetry}></ErrorView>
+            <ErrorView
+              title={'Error retrieving event templates'}
+              message={errorMessage}
+              retry={isAuthFail(errorMessage) ? authRetry : undefined}
+            />
           ) : (
             <Card>
               <CardBody>

--- a/src/test/Common.tsx
+++ b/src/test/Common.tsx
@@ -62,12 +62,13 @@ export const renderWithServiceContextAndReduxStore = (
   {
     preloadState = {},
     store = setupStore(preloadState), // Create a new store instance if no store was passed in
+    services = defaultServices,
     ...renderOptions
   } = {}
 ) => {
   const Wrapper = ({ children }: PropsWithChildren<{}>) => {
     return (
-      <ServiceContext.Provider value={defaultServices}>
+      <ServiceContext.Provider value={services}>
         <Provider store={store}>{children}</Provider>
       </ServiceContext.Provider>
     );
@@ -80,13 +81,14 @@ export const renderWithServiceContextAndReduxStoreWithRouter = (
   {
     preloadState = {},
     store = setupStore(preloadState), // Create a new store instance if no store was passed in
+    services = defaultServices,
     history,
     ...renderOptions
   }
 ) => {
   const Wrapper = ({ children }: PropsWithChildren<{}>) => {
     return (
-      <ServiceContext.Provider value={defaultServices}>
+      <ServiceContext.Provider value={services}>
         <Provider store={store}>
           <Router location={history.location} history={history}>
             {children}

--- a/src/test/Events/EventTypes.test.tsx
+++ b/src/test/Events/EventTypes.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { act as doAct, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { of, Subject } from 'rxjs';
+import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/Services';
+import { TargetService } from '@app/Shared/Services/Target.service';
+import { EventType, EventTypes } from '@app/Events/EventTypes';
+
+const mockConnectUrl = 'service:jmx:rmi://someUrl';
+const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };
+
+const mockEventType: EventType = {
+  name: 'Some Event',
+  typeId: 'org.some_eventId',
+  description: 'Some Descriptions',
+  category: ['Category 1', 'Category 2'],
+  options: [{ some_key: { name: 'some_name', description: 'a_desc', defaultValue: 'some_value' } }],
+};
+
+jest.spyOn(defaultServices.api, 'doGet').mockReturnValue(of([mockEventType]));
+jest.spyOn(defaultServices.target, 'target').mockReturnValue(of(mockTarget));
+jest.spyOn(defaultServices.target, 'authFailure').mockReturnValue(of());
+
+describe('<EventTypes />', () => {
+  it('renders correctly', async () => {
+    let tree;
+    await act(async () => {
+      tree = renderer.create(
+        <ServiceContext.Provider value={defaultServices}>
+          <EventTypes />
+        </ServiceContext.Provider>
+      );
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  it('should show error view if failing to retrieve event types', async () => {
+    const subj = new Subject<void>();
+    const mockTargetSvc = {
+      target: () => of(mockTarget),
+      authFailure: () => subj.asObservable(),
+    } as TargetService;
+    const services: Services = {
+      ...defaultServices,
+      target: mockTargetSvc,
+    };
+
+    render(
+      <ServiceContext.Provider value={services}>
+        <EventTypes />
+      </ServiceContext.Provider>
+    );
+
+    await doAct(async () => subj.next());
+
+    const failTitle = screen.getByText('Error retrieving event types');
+    expect(failTitle).toBeInTheDocument();
+    expect(failTitle).toBeVisible();
+
+    const authFailText = screen.getByText('Auth failure');
+    expect(authFailText).toBeInTheDocument();
+    expect(authFailText).toBeVisible();
+
+    const retryButton = screen.getByText('Retry');
+    expect(retryButton).toBeInTheDocument();
+    expect(retryButton).toBeVisible();
+  });
+});

--- a/src/test/Events/__snapshots__/EventTypes.test.tsx.snap
+++ b/src/test/Events/__snapshots__/EventTypes.test.tsx.snap
@@ -1,0 +1,390 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<EventTypes /> renders correctly 1`] = `
+Array [
+  <div
+    className="pf-c-toolbar"
+    data-ouia-component-id="OUIA-Generated-Toolbar-1"
+    data-ouia-component-type="PF4/Toolbar"
+    data-ouia-safe={true}
+    id="event-types-toolbar"
+  >
+    <div
+      className="pf-c-toolbar__content"
+    >
+      <div
+        className="pf-c-toolbar__content-section"
+      >
+        <div
+          className="pf-c-toolbar__item"
+        >
+          <input
+            aria-invalid={false}
+            aria-label="Event filter"
+            className="pf-c-form-control"
+            data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+            data-ouia-component-type="PF4/TextInput"
+            data-ouia-safe={true}
+            disabled={false}
+            id="eventFilter"
+            name="eventFilter"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Filter..."
+            readOnly={false}
+            required={false}
+            type="search"
+          />
+        </div>
+        <div
+          className="pf-c-toolbar__item pf-m-pagination"
+        >
+          <div
+            className="pf-c-pagination pf-m-compact"
+            data-ouia-component-id="OUIA-Generated-Pagination-top-1"
+            data-ouia-component-type="PF4/Pagination"
+            data-ouia-safe={true}
+            id="event-types-pagination-2"
+          >
+            <div
+              className="pf-c-pagination__total-items"
+            >
+              <b>
+                1
+                 - 
+                1
+              </b>
+               
+              of
+               
+              <b>
+                1
+              </b>
+               
+              
+            </div>
+            <div
+              className="pf-c-options-menu"
+              data-ouia-component-type="PF4/PaginationOptionsMenu"
+              data-ouia-safe={true}
+            >
+              <div
+                className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+              >
+                <span
+                  className="pf-c-options-menu__toggle-text"
+                >
+                  <b>
+                    1
+                     - 
+                    1
+                  </b>
+                   
+                  of
+                   
+                  <b>
+                    1
+                  </b>
+                   
+                  
+                </span>
+                <button
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
+                  aria-label="Items per page"
+                  className="  pf-c-options-menu__toggle-button"
+                  data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
+                  data-ouia-component-type="PF4/DropdownToggle"
+                  data-ouia-safe={true}
+                  disabled={false}
+                  id="event-types-pagination-toggle-2"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="pf-c-options-menu__toggle-button-icon"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <nav
+              aria-label="Pagination"
+              className="pf-c-pagination__nav"
+            >
+              <div
+                className="pf-c-pagination__nav-control"
+              >
+                <button
+                  aria-disabled={true}
+                  aria-label="Go to previous page"
+                  className="pf-c-button pf-m-plain pf-m-disabled"
+                  data-action="previous"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={true}
+                  onClick={[Function]}
+                  role={null}
+                  tabIndex={null}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <div
+                className="pf-c-pagination__nav-control"
+              >
+                <button
+                  aria-disabled={true}
+                  aria-label="Go to next page"
+                  className="pf-c-button pf-m-plain pf-m-disabled"
+                  data-action="next"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={true}
+                  onClick={[Function]}
+                  role={null}
+                  tabIndex={null}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    aria-labelledby={null}
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style={
+                      Object {
+                        "verticalAlign": "-0.125em",
+                      }
+                    }
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </nav>
+          </div>
+        </div>
+      </div>
+      <div
+        className="pf-c-toolbar__expandable-content"
+        id="event-types-toolbar-expandable-content-2"
+      >
+        <div
+          className="pf-c-toolbar__group"
+        />
+      </div>
+    </div>
+    <div
+      className="pf-c-toolbar__content pf-m-hidden"
+      hidden={true}
+    >
+      <div
+        className="pf-c-toolbar__group"
+      />
+    </div>
+  </div>,
+  <table
+    aria-label="Event Types table"
+    className="pf-c-table pf-m-grid-md pf-m-compact"
+    data-ouia-component-id="OUIA-Generated-Table-2"
+    data-ouia-component-type="PF4/Table"
+    data-ouia-safe={true}
+    role="grid"
+  >
+    <thead
+      className=""
+    >
+      <tr
+        className=""
+        data-ouia-component-id="OUIA-Generated-TableRow-1"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe={true}
+        hidden={false}
+      >
+        <th
+          className=""
+          data-key={0}
+          data-label=""
+          onMouseEnter={[Function]}
+          scope={null}
+        >
+          
+        </th>
+        <th
+          className=""
+          data-key={1}
+          data-label="Name"
+          onMouseEnter={[Function]}
+          scope="col"
+        >
+          Name
+        </th>
+        <th
+          className=""
+          data-key={2}
+          data-label="Type ID"
+          onMouseEnter={[Function]}
+          scope="col"
+        >
+          Type ID
+        </th>
+        <th
+          className=""
+          data-key={3}
+          data-label="Description"
+          onMouseEnter={[Function]}
+          scope="col"
+        >
+          Description
+        </th>
+        <th
+          className=""
+          data-key={4}
+          data-label="Categories"
+          onMouseEnter={[Function]}
+          scope="col"
+        >
+          Categories
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      className=""
+      role="rowgroup"
+    >
+      <tr
+        className=""
+        data-ouia-component-id="OUIA-Generated-TableRow-2"
+        data-ouia-component-type="PF4/TableRow"
+        data-ouia-safe={true}
+        hidden={false}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+      >
+        <td
+          className="pf-c-table__toggle"
+          data-key={0}
+          data-label={null}
+          onMouseEnter={[Function]}
+        >
+          <button
+            aria-disabled={false}
+            aria-expanded={false}
+            aria-label="Details"
+            aria-labelledby="simple-node0 expandable-toggle0"
+            className="pf-c-button pf-m-plain"
+            data-ouia-component-id="OUIA-Generated-Button-plain-3"
+            data-ouia-component-type="PF4/Button"
+            data-ouia-safe={true}
+            disabled={false}
+            id="expandable-toggle0"
+            onClick={[Function]}
+            role={null}
+            type="button"
+          >
+            <div
+              className="pf-c-table__toggle-icon"
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                />
+              </svg>
+            </div>
+          </button>
+        </td>
+        <td
+          className=""
+          data-key={1}
+          data-label="Name"
+          onMouseEnter={[Function]}
+        >
+          Some Event
+        </td>
+        <td
+          className=""
+          data-key={2}
+          data-label="Type ID"
+          onMouseEnter={[Function]}
+        >
+          org.some_eventId
+        </td>
+        <td
+          className=""
+          data-key={3}
+          data-label="Description"
+          onMouseEnter={[Function]}
+        >
+          Some Descriptions
+        </td>
+        <td
+          className=""
+          data-key={4}
+          data-label="Categories"
+          onMouseEnter={[Function]}
+        >
+          Category 1, Category 2
+        </td>
+      </tr>
+    </tbody>
+  </table>,
+]
+`;

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -124,7 +124,7 @@ jest.mock('@app/Recordings/RecordingFilters', () => {
 jest.spyOn(defaultServices.api, 'deleteArchivedRecording').mockReturnValue(of(true));
 jest.spyOn(defaultServices.api, 'downloadRecording').mockReturnValue();
 jest.spyOn(defaultServices.api, 'downloadReport').mockReturnValue();
-jest.spyOn(defaultServices.api, 'grafanaDatasourceUrl').mockReturnValue(of('/grafanaUrl'));
+jest.spyOn(defaultServices.api, 'grafanaDatasourceUrl').mockReturnValue(of('/datasource'));
 jest.spyOn(defaultServices.api, 'grafanaDashboardUrl').mockReturnValue(of('/grafanaUrl'));
 jest.spyOn(defaultServices.api, 'graphql').mockReturnValue(of(mockArchivedRecordingsResponse));
 jest.spyOn(defaultServices.api, 'uploadArchivedRecordingToGrafana').mockReturnValue(of(true));


### PR DESCRIPTION
Related to #544 

**Fixes**

- Retry button should only show on auth failture.
- Add missing tests (i.e. checking auth failture view) for `EventTypes` component.

**Chore**
- Use `useSubscriptions` hook where possible in Events/Recordings view.
- Use `React.useMemo` and `React.useCallback` to reduce re-computation of inner functions in Event views.

