### PR TITLE
fix(archive): all-archive should properly display when refreshing

### DIFF
--- a/src/app/Archives/Archives.tsx
+++ b/src/app/Archives/Archives.tsx
@@ -45,6 +45,7 @@ import { ArchivedRecordingsTable } from '@app/Recordings/ArchivedRecordingsTable
 import { Target } from '@app/Shared/Services/Target.service';
 import { of } from 'rxjs';
 import { UPLOADS_SUBDIRECTORY } from '@app/Shared/Services/Api.service';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 
 /*
   This specific target is used as the "source" for the Uploads version of the ArchivedRecordingsTable.
@@ -58,14 +59,16 @@ export const uploadAsTarget: Target = {
   alias: '',
 };
 
-export const Archives = () => {
+export interface ArchivesProps {}
+
+export const Archives: React.FunctionComponent<ArchivesProps> = () => {
   const context = React.useContext(ServiceContext);
+  const addSubscription = useSubscriptions();
   const [activeTab, setActiveTab] = React.useState(0);
   const [archiveEnabled, setArchiveEnabled] = React.useState(false);
 
   React.useEffect(() => {
-    const sub = context.api.isArchiveEnabled().subscribe(setArchiveEnabled);
-    return () => sub.unsubscribe();
+    addSubscription(context.api.isArchiveEnabled().subscribe(setArchiveEnabled));
   }, [context.api]);
 
   const cardBody = React.useMemo(() => {

--- a/src/app/Archives/Archives.tsx
+++ b/src/app/Archives/Archives.tsx
@@ -69,7 +69,7 @@ export const Archives: React.FunctionComponent<ArchivesProps> = () => {
 
   React.useEffect(() => {
     addSubscription(context.api.isArchiveEnabled().subscribe(setArchiveEnabled));
-  }, [context.api]);
+  }, [context.api, addSubscription, setArchiveEnabled]);
 
   const cardBody = React.useMemo(() => {
     return archiveEnabled ? (

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -500,9 +500,8 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
       props.recording.maxAge,
       props.recording.maxSize,
     ]);
-
     return (
-      <Tbody key={props.index} isExpanded={isExpanded[props.index]}>
+      <Tbody key={props.index} isExpanded={isExpanded}>
         {parentRow}
         {childRow}
       </Tbody>

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -441,7 +441,7 @@ export const ArchivedRecordingsTable: React.FunctionComponent<ArchivedRecordings
     }, [props.recording, props.recording.name, props.index, isExpanded, tableColumns]);
 
     return (
-      <Tbody key={props.index} isExpanded={isExpanded[props.index]}>
+      <Tbody key={props.index} isExpanded={isExpanded}>
         {parentRow}
         {childRow}
       </Tbody>

--- a/src/app/Shared/Services/Target.service.tsx
+++ b/src/app/Shared/Services/Target.service.tsx
@@ -39,6 +39,24 @@ import { Observable, Subject, BehaviorSubject } from 'rxjs';
 
 export const NO_TARGET = {} as Target;
 
+export const includesTarget = (arr: Target[], target: Target): boolean => {
+  return arr.some((t) => t.connectUrl === target.connectUrl);
+};
+
+export const isEqualTarget = (a: Target, b: Target): boolean => {
+  return a.connectUrl === b.connectUrl;
+};
+
+export const indexOfTarget = (arr: Target[], target: Target): number => {
+  let index = -1;
+  arr.forEach((t, idx) => {
+    if (t.connectUrl === target.connectUrl) {
+      index = idx;
+    }
+  });
+  return index;
+};
+
 export interface Target {
   connectUrl: string;
   alias: string;

--- a/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
@@ -161,6 +161,10 @@ jest.mock('@app/Recordings/ArchivedRecordingsTable', () => {
   };
 });
 
+jest.mock('@app/Shared/Services/Target.service', () => ({
+  ...jest.requireActual('@app/Shared/Services/Target.service'), // Require actual implementation of utility functions for Target
+}));
+
 jest
   .spyOn(defaultServices.api, 'graphql')
   .mockReturnValueOnce(of(mockTargetsAndCountsResponse)) // renders correctly
@@ -185,60 +189,40 @@ jest
   .mockReturnValueOnce(of()) // renders correctly
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // has the correct table elements
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // hides targets with zero recordings
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // correctly handles the search function
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // expands targets to show their <ArchivedRecordingsTable />
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // does not expand targets with zero recordings
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of(mockTargetFoundNotification)) // adds a target upon receiving a notification
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of(mockTargetLostNotification)) // removes a target upon receiving a notification
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // increments the count when an archived recording is saved
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
   .mockReturnValueOnce(of(mockRecordingSavedNotification))
   .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // decrements the count when an archived recording is deleted
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of(mockRecordingDeletedNotification));
 


### PR DESCRIPTION
Fixes #549 

**Fixes**

All Archive view now correctly refresh view when auto-refresh is enabled. The issue was that there is a call to `Array.includes`, which only checks object reference.

**Chore**

Counts of archives for each target should not be an saved in an array (i.e. sorting might be supported). Alternative was `Map<string, number>` with key is `target.connectUrl`. This way, subscriptions to notification channel are only called once in `React.useEffect` for each type.