### PR TITLE
fix(filters): fix datetimepicker error text alignments

### DIFF
--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -718,7 +718,9 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
           filters={props.targetRecordingFilters}
           updateFilters={props.updateFilters}
         />
-        <ToolbarGroup variant="button-group">{buttons}</ToolbarGroup>
+        <ToolbarGroup style={{ alignSelf: 'start' }} variant="button-group">
+          {buttons}
+        </ToolbarGroup>
         {deleteActiveWarningModal}
       </ToolbarContent>
     </Toolbar>

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -651,7 +651,7 @@ const ArchivedRecordingsToolbar: React.FunctionComponent<ArchivedRecordingsToolb
           filters={props.targetRecordingFilters}
           updateFilters={props.updateFilters}
         />
-        <ToolbarGroup variant="button-group">
+        <ToolbarGroup variant="button-group" style={{ alignSelf: 'start' }}>
           <ToolbarItem>
             <Button
               key="edit labels"

--- a/src/app/Recordings/Filters/DateTimePicker.tsx
+++ b/src/app/Recordings/Filters/DateTimePicker.tsx
@@ -36,7 +36,16 @@
  * SOFTWARE.
  */
 
-import { Button, ButtonVariant, DatePicker, Flex, FlexItem, Text, TimePicker } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  DatePicker,
+  Flex,
+  FlexItem,
+  InputGroup,
+  Text,
+  TimePicker,
+} from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import React from 'react';
 
@@ -74,22 +83,24 @@ export const DateTimePicker: React.FunctionComponent<DateTimePickerProps> = (pro
 
   const handleSubmit = React.useCallback(() => {
     selectedDate!.setUTCHours(selectedHour, selectedMinute);
-    props.onSubmit(`${selectedDate!.toISOString()}`);
+    props.onSubmit(selectedDate!.toISOString());
   }, [selectedDate, selectedHour, selectedMinute, props.onSubmit]);
 
   return (
     <Flex>
       <FlexItem>
-        <DatePicker appendTo="parent" onChange={onDateChange} aria-label="Date Picker" placeholder="YYYY-MM-DD" />
-        <TimePicker
-          isOpen={isTimeOpen}
-          setIsOpen={onTimeToggle}
-          is24Hour
-          aria-label="Time Picker"
-          className="time-picker"
-          menuAppendTo="parent"
-          onChange={onTimeChange}
-        />
+        <InputGroup>
+          <DatePicker appendTo="parent" onChange={onDateChange} aria-label="Date Picker" placeholder="YYYY-MM-DD" />
+          <TimePicker
+            isOpen={isTimeOpen}
+            setIsOpen={onTimeToggle}
+            is24Hour
+            aria-label="Time Picker"
+            className="time-picker"
+            menuAppendTo="parent"
+            onChange={onTimeChange}
+          />
+        </InputGroup>
       </FlexItem>
       <FlexItem>
         <Text>UTC</Text>

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -202,33 +202,18 @@ export const RecordingFilters: React.FunctionComponent<RecordingFiltersProps> = 
 
   const filterDropdownItems = React.useMemo(
     () => [
-      <InputGroup>
-        <NameFilter recordings={props.recordings} onSubmit={onNameInput} filteredNames={props.filters.Name} />
-      </InputGroup>,
-      <InputGroup>
-        <LabelFilter recordings={props.recordings} onSubmit={onLabelInput} filteredLabels={props.filters.Label} />
-      </InputGroup>,
+      <NameFilter recordings={props.recordings} onSubmit={onNameInput} filteredNames={props.filters.Name} />,
+      <LabelFilter recordings={props.recordings} onSubmit={onLabelInput} filteredLabels={props.filters.Label} />,
       ...(!props.isArchived
         ? [
-            <InputGroup>
-              <RecordingStateFilter
-                filteredStates={props.filters.State}
-                onSelectToggle={onRecordingStateSelectToggle}
-              />
-            </InputGroup>,
-            <InputGroup>
-              <DateTimePicker onSubmit={onStartedBeforeInput} />
-            </InputGroup>,
-            <InputGroup>
-              <DateTimePicker onSubmit={onStartedAfterInput} />
-            </InputGroup>,
-            <InputGroup>
-              <DurationFilter
-                durations={props.filters.DurationSeconds}
-                onContinuousDurationSelect={onContinuousDurationSelect}
-                onDurationInput={onDurationInput}
-              ></DurationFilter>
-            </InputGroup>,
+            <RecordingStateFilter filteredStates={props.filters.State} onSelectToggle={onRecordingStateSelectToggle} />,
+            <DateTimePicker onSubmit={onStartedBeforeInput} />,
+            <DateTimePicker onSubmit={onStartedAfterInput} />,
+            <DurationFilter
+              durations={props.filters.DurationSeconds}
+              onContinuousDurationSelect={onContinuousDurationSelect}
+              onDurationInput={onDurationInput}
+            ></DurationFilter>,
           ]
         : []),
     ],
@@ -252,19 +237,23 @@ export const RecordingFilters: React.FunctionComponent<RecordingFiltersProps> = 
   return (
     <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
       <ToolbarGroup variant="filter-group">
-        <ToolbarItem>{categoryDropdown}</ToolbarItem>
-        {Object.keys(props.filters).map((filterKey, i) => (
-          <ToolbarFilter
-            key={filterKey}
-            chips={props.filters[filterKey]}
-            deleteChip={onDelete}
-            deleteChipGroup={onDeleteGroup}
-            categoryName={filterKey}
-            showToolbarItem={filterKey === currentCategory}
-          >
-            {filterDropdownItems[i]}
-          </ToolbarFilter>
-        ))}
+        <ToolbarItem>
+          <InputGroup>
+            {categoryDropdown}
+            {Object.keys(props.filters).map((filterKey, i) => (
+              <ToolbarFilter
+                key={filterKey}
+                chips={props.filters[filterKey]}
+                deleteChip={onDelete}
+                deleteChipGroup={onDeleteGroup}
+                categoryName={filterKey}
+                showToolbarItem={filterKey === currentCategory}
+              >
+                {filterDropdownItems[i]}
+              </ToolbarFilter>
+            ))}
+          </InputGroup>
+        </ToolbarItem>
       </ToolbarGroup>
     </ToolbarToggleGroup>
   );


### PR DESCRIPTION
Fixes #570 

Correctly aligned toolbar items when there is an error text in Datetime Picker. A couple refactoring and quick hack with `align-self` and `InputGroup` solved the issue.

![Screenshot from 2022-10-26 18-59-41](https://user-images.githubusercontent.com/68053619/198154764-f10926d0-cf66-4cd6-83c2-742174979374.png)
