### PR TITLE
fix(target): add back target auto-refresh option

### DIFF
--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -155,7 +155,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
       context.settings.autoRefreshPeriod() * context.settings.autoRefreshUnits()
     );
     return () => window.clearInterval(id);
-  }, [context, context.target, context.settings, refreshTargetList]);
+  }, [context.settings, refreshTargetList]);
 
   const showCreateTargetModal = React.useCallback(() => {
     setModalOpen(true);

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -141,6 +141,22 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
     addSubscription(context.target.target().subscribe(setSelected));
   }, [addSubscription, context.target, setSelected]);
 
+  const refreshTargetList = React.useCallback(() => {
+    setLoading(true);
+    addSubscription(context.targets.queryForTargets().subscribe(() => setLoading(false)));
+  }, [addSubscription, context.targets, setLoading]);
+
+  React.useEffect(() => {
+    if (!context.settings.autoRefreshEnabled()) {
+      return;
+    }
+    const id = window.setInterval(
+      () => refreshTargetList(),
+      context.settings.autoRefreshPeriod() * context.settings.autoRefreshUnits()
+    );
+    return () => window.clearInterval(id);
+  }, [context, context.target, context.settings, refreshTargetList]);
+
   const showCreateTargetModal = React.useCallback(() => {
     setModalOpen(true);
   }, [setModalOpen]);


### PR DESCRIPTION
Related to #544 

#544 removed refresh target button. However, we should still keep the options to auto-refresh target list if enabled.