### PR TITLE
fix(match-exp): match-expression-evaluator handles non-empty match-expr with no target selected

### DIFF
--- a/src/app/Shared/MatchExpressionEvaluator.tsx
+++ b/src/app/Shared/MatchExpressionEvaluator.tsx
@@ -127,7 +127,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
         if (!target?.connectUrl) {
           return (
             <Label color="grey" icon={<InfoCircleIcon />}>
-            No Target Selected for Match Expression
+              No Target Selected for Match Expression
             </Label>
           );
         }
@@ -135,7 +135,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
           <Label color="grey" icon={<InfoCircleIcon />}>
             No Match Expression
           </Label>
-        )
+        );
     }
   }, [valid, target?.connectUrl]);
 

--- a/src/app/Shared/MatchExpressionEvaluator.tsx
+++ b/src/app/Shared/MatchExpressionEvaluator.tsx
@@ -127,7 +127,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
         if (!target?.connectUrl) {
           return (
             <Label color="grey" icon={<InfoCircleIcon />}>
-              No Target Selected for Match Expression
+              No Target Selected
             </Label>
           );
         }

--- a/src/app/Shared/MatchExpressionEvaluator.tsx
+++ b/src/app/Shared/MatchExpressionEvaluator.tsx
@@ -75,7 +75,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
 
   React.useEffect(() => {
     addSubscription(context.target.target().subscribe(setTarget));
-  }, [addSubscription, context, context.target]);
+  }, [addSubscription, context.target, setTarget]);
 
   React.useEffect(() => {
     if (!props.matchExpression || !target?.connectUrl) {
@@ -95,7 +95,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
       setValid(ValidatedOptions.error);
       return;
     }
-  }, [target, props.matchExpression]);
+  }, [target, props.matchExpression, setValid]);
 
   React.useEffect(() => {
     if (!!props.onChange) {
@@ -124,13 +124,20 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
           </Label>
         );
       default:
+        if (!target?.connectUrl) {
+          return (
+            <Label color="grey" icon={<InfoCircleIcon />}>
+            No Target Selected for Match Expression
+            </Label>
+          );
+        }
         return (
           <Label color="grey" icon={<InfoCircleIcon />}>
             No Match Expression
           </Label>
-        );
+        )
     }
-  }, [valid]);
+  }, [valid, target?.connectUrl]);
 
   const exampleExpression = React.useMemo(() => {
     let body: string;


### PR DESCRIPTION
Fixes #573 