### PR TITLE
build(webpack): code-split bundles and add content-hash to output files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prettier:check": "prettier --check './src/**/*.{tsx,ts}'",
     "prettier:apply": "prettier --write './src/**/*.{tsx,ts}'",
     "build:bundle-profile": "webpack --config webpack.prod.js --profile --json > stats.json",
-    "build:bundle-analyze": "webpack-bundle-analyzer ./stats.json",
+    "build:bundle-analyze": "webpack-bundle-analyzer ./stats.json dist",
     "build:bundle-profile-analyze": "npm-run-all -l build:bundle-profile build:bundle-analyze",
     "yarn:install": "yarn install",
     "yarn:frzinstall": "yarn install --frozen-lockfile"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/victory": "^33.1.5",
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
+    "@vue/preload-webpack-plugin": "^2.0.0",
     "css-loader": "^5.2.6",
     "css-minimizer-webpack-plugin": "^4.0.0",
     "dotenv-webpack": "^7.1.0",

--- a/src/app/About/About.tsx
+++ b/src/app/About/About.tsx
@@ -43,7 +43,9 @@ import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { AboutDescription, CRYOSTAT_TRADEMARK } from './AboutDescription';
 import { Brand, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react-core';
 
-export const About = () => {
+export interface AboutProps {}
+
+export const About: React.FunctionComponent<AboutProps> = (props) => {
   return (
     <BreadcrumbPage pageTitle="About">
       <Card>
@@ -58,3 +60,5 @@ export const About = () => {
     </BreadcrumbPage>
   );
 };
+
+export default About;

--- a/src/app/Archives/Archives.tsx
+++ b/src/app/Archives/Archives.tsx
@@ -62,7 +62,7 @@ export const uploadAsTarget: Target = {
 
 export interface ArchivesProps {}
 
-export const Archives: React.FunctionComponent<ArchivesProps> = () => {
+export const Archives: React.FunctionComponent<ArchivesProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [activeTab, setActiveTab] = React.useState(0);
@@ -103,3 +103,5 @@ export const Archives: React.FunctionComponent<ArchivesProps> = () => {
     </BreadcrumbPage>
   );
 };
+
+export default Archives;

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -121,3 +121,4 @@ const Comp: React.FunctionComponent<RouteComponentProps<{}, StaticContext, Creat
 };
 
 export const CreateRecording = withRouter(Comp);
+export default CreateRecording;

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -38,6 +38,10 @@
 import * as React from 'react';
 import { TargetView } from '@app/TargetView/TargetView';
 
-export const Dashboard = () => {
+export interface DashboardProps {}
+
+export const Dashboard: React.FunctionComponent<DashboardProps> = (props) => {
   return <TargetView pageTitle="Dashboard" compactSelect={true} />;
 };
+
+export default Dashboard;

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -118,3 +118,5 @@ export const Events: React.FunctionComponent<EventsProps> = (props) => {
     </>
   );
 };
+
+export default Events;

--- a/src/app/LoadingView/LoadingView.tsx
+++ b/src/app/LoadingView/LoadingView.tsx
@@ -38,7 +38,9 @@
 import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-export const LoadingView: React.FunctionComponent = () => {
+export interface LoadingViewProps {}
+
+export const LoadingView: React.FunctionComponent<LoadingViewProps> = (props) => {
   return (
     <>
       <br />
@@ -48,3 +50,5 @@ export const LoadingView: React.FunctionComponent = () => {
     </>
   );
 };
+
+export default LoadingView;

--- a/src/app/Login/Login.tsx
+++ b/src/app/Login/Login.tsx
@@ -45,7 +45,9 @@ import { NoopAuthForm } from './NoopAuthForm';
 import { ConnectionError } from './ConnectionError';
 import { AuthMethod } from '@app/Shared/Services/Login.service';
 
-export const Login = () => {
+export interface LoginProps {}
+
+export const Login: React.FunctionComponent<LoginProps> = (props) => {
   const serviceContext = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const [authMethod, setAuthMethod] = React.useState('');
@@ -109,3 +111,5 @@ export const Login = () => {
     </PageSection>
   );
 };
+
+export default Login;

--- a/src/app/NotFound/NotFound.tsx
+++ b/src/app/NotFound/NotFound.tsx
@@ -50,7 +50,9 @@ import '@app/app.css';
 import { MapMarkedAltIcon } from '@patternfly/react-icons';
 import { IAppRoute, routes, flatten } from '@app/routes';
 
-const NotFound: React.FunctionComponent = () => {
+export interface NotFoundProps {}
+
+export const NotFound: React.FunctionComponent<NotFoundProps> = (props) => {
   const cards = flatten(routes)
     .filter((route: IAppRoute): boolean => !!route.description)
     .sort((a: IAppRoute, b: IAppRoute): number => a.title.localeCompare(b.title))
@@ -80,4 +82,4 @@ const NotFound: React.FunctionComponent = () => {
   );
 };
 
-export { NotFound };
+export default NotFound;

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -43,7 +43,9 @@ import { ActiveRecordingsTable } from './ActiveRecordingsTable';
 import { ArchivedRecordingsTable } from './ArchivedRecordingsTable';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 
-export const Recordings = () => {
+export interface RecordingsProps {}
+
+export const Recordings: React.FunctionComponent<RecordingsProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const [activeTab, setActiveTab] = React.useState(0);
   const [archiveEnabled, setArchiveEnabled] = React.useState(false);
@@ -81,3 +83,5 @@ export const Recordings = () => {
     </TargetView>
   );
 };
+
+export default Recordings;

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -553,3 +553,5 @@ const Comp = () => {
 };
 
 export const CreateRule = withRouter(Comp);
+
+export default CreateRule;

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -93,7 +93,9 @@ export interface Rule {
   maxSizeBytes: number;
 }
 
-export const Rules = () => {
+export interface RulesProps {}
+
+export const Rules: React.FunctionComponent<RulesProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const routerHistory = useHistory();
   const addSubscription = useSubscriptions();
@@ -436,3 +438,5 @@ export const Rules = () => {
     </>
   );
 };
+
+export default Rules;

--- a/src/app/SecurityPanel/SecurityPanel.tsx
+++ b/src/app/SecurityPanel/SecurityPanel.tsx
@@ -41,7 +41,9 @@ import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { StoreJmxCredentialsCard } from './Credentials/StoreJmxCredentials';
 import { ImportCertificate } from './ImportCertificate';
 
-export const SecurityPanel = () => {
+export interface SecurityPanelProps {}
+
+export const SecurityPanel: React.FunctionComponent<SecurityPanelProps> = (props) => {
   const securityCards = [ImportCertificate, StoreJmxCredentialsCard].map((c) => ({
     title: c.title,
     description: c.description,
@@ -62,6 +64,8 @@ export const SecurityPanel = () => {
     </BreadcrumbPage>
   );
 };
+
+export default SecurityPanel;
 
 export interface SecurityCard {
   title: string;

--- a/src/app/Settings/Settings.tsx
+++ b/src/app/Settings/Settings.tsx
@@ -46,7 +46,9 @@ import { DeletionDialogControl } from './DeletionDialogControl';
 import { WebSocketDebounce } from './WebSocketDebounce';
 import { AutoRefresh } from './AutoRefresh';
 
-export const Settings: React.FunctionComponent<{}> = () => {
+export interface SettingsProps {}
+
+export const Settings: React.FunctionComponent<SettingsProps> = (props) => {
   const settings = [NotificationControl, CredentialsStorage, DeletionDialogControl, WebSocketDebounce, AutoRefresh].map(
     (c) => ({
       title: c.title,
@@ -70,6 +72,8 @@ export const Settings: React.FunctionComponent<{}> = () => {
     </>
   );
 };
+
+export default Settings;
 
 export interface UserSetting {
   title: string;

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
+import React, { Suspense } from 'react';
 import '@patternfly/react-core/dist/styles/base.css';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { AppLayout } from '@app/AppLayout/AppLayout';
@@ -44,14 +44,17 @@ import '@app/app.css';
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { Provider } from 'react-redux';
 import { store } from '@app/Shared/Redux/ReduxStore';
+import { LoadingView } from '@app/LoadingView/LoadingView';
 
 const App: React.FunctionComponent = () => (
   <ServiceContext.Provider value={defaultServices}>
     <Provider store={store}>
       <Router>
-        <AppLayout>
-          <AppRoutes />
-        </AppLayout>
+        <Suspense fallback={<LoadingView />}>
+          <AppLayout>
+            <AppRoutes />
+          </AppLayout>
+        </Suspense>
       </Router>
     </Provider>
   </ServiceContext.Provider>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { Suspense } from 'react';
+import * as React from 'react';
 import '@patternfly/react-core/dist/styles/base.css';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { AppLayout } from '@app/AppLayout/AppLayout';
@@ -44,17 +44,14 @@ import '@app/app.css';
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { Provider } from 'react-redux';
 import { store } from '@app/Shared/Redux/ReduxStore';
-import { LoadingView } from '@app/LoadingView/LoadingView';
 
 const App: React.FunctionComponent = () => (
   <ServiceContext.Provider value={defaultServices}>
     <Provider store={store}>
       <Router>
-        <Suspense fallback={<LoadingView />}>
-          <AppLayout>
-            <AppRoutes />
-          </AppLayout>
-        </Suspense>
+        <AppLayout>
+          <AppRoutes />
+        </AppLayout>
       </Router>
     </Provider>
   </ServiceContext.Provider>

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 
-import React, { lazy } from 'react';
+import React, { lazy, Suspense } from 'react';
 const CreateRecording = lazy(() => import('@app/CreateRecording/CreateRecording'));
 const Dashboard = lazy(() => import('@app/Dashboard/Dashboard'));
 const Events = lazy(() => import('@app/Events/Events'));
@@ -56,6 +56,7 @@ import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
 import { SessionState } from './Shared/Services/Login.service';
 import { useSubscriptions } from './utils/useSubscriptions';
+import LoadingView from './LoadingView/LoadingView';
 
 let routeFocusTimer: number;
 const OVERVIEW = 'Overview';
@@ -225,23 +226,25 @@ const AppRoutes: React.FunctionComponent<AppRoutesProps> = (props) => {
 
   return (
     <LastLocationProvider>
-      <Switch>
-        {showDashboard ? (
-          flatten(routes).map(({ path, exact, component, title, isAsync }, idx) => (
-            <RouteWithTitleUpdates
-              path={path}
-              exact={exact}
-              component={component}
-              key={idx}
-              title={title}
-              isAsync={isAsync}
-            />
-          ))
-        ) : (
-          <Login />
-        )}
-        <PageNotFound title="404 Page Not Found" />
-      </Switch>
+      <Suspense fallback={<LoadingView />}>
+        <Switch>
+          {showDashboard ? (
+            flatten(routes).map(({ path, exact, component, title, isAsync }, idx) => (
+              <RouteWithTitleUpdates
+                path={path}
+                exact={exact}
+                component={component}
+                key={idx}
+                title={title}
+                isAsync={isAsync}
+              />
+            ))
+          ) : (
+            <Login />
+          )}
+          <PageNotFound title="404 Page Not Found" />
+        </Switch>
+      </Suspense>
     </LastLocationProvider>
   );
 };

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -35,25 +35,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { CreateRecording } from '@app/CreateRecording/CreateRecording';
-import { Dashboard } from '@app/Dashboard/Dashboard';
-import { Events } from '@app/Events/Events';
-import { Login } from '@app/Login/Login';
-import { NotFound } from '@app/NotFound/NotFound';
-import { Recordings } from '@app/Recordings/Recordings';
-import { Archives } from '@app/Archives/Archives';
-import { Rules } from '@app/Rules/Rules';
-import { CreateRule } from '@app/Rules/CreateRule';
-import { Settings } from '@app/Settings/Settings';
-import { SecurityPanel } from '@app/SecurityPanel/SecurityPanel';
+
+import React, { lazy } from 'react';
+const CreateRecording = lazy(() => import('@app/CreateRecording/CreateRecording'));
+const Dashboard = lazy(() => import('@app/Dashboard/Dashboard'));
+const Events = lazy(() => import('@app/Events/Events'));
+const Login = lazy(() => import('@app/Login/Login'));
+const NotFound = lazy(() => import('@app/NotFound/NotFound'));
+const Recordings = lazy(() => import('@app/Recordings/Recordings'));
+const Archives = lazy(() => import('@app/Archives/Archives'));
+const Rules = lazy(() => import('@app/Rules/Rules'));
+const CreateRule = lazy(() => import('@app/Rules/CreateRule'));
+const Settings = lazy(() => import('@app/Settings/Settings'));
+const SecurityPanel = lazy(() => import('@app/SecurityPanel/SecurityPanel'));
+const About = lazy(() => import('@app/About/About'));
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useDocumentTitle } from '@app/utils/useDocumentTitle';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
-import { About } from './About/About';
 import { SessionState } from './Shared/Services/Login.service';
+import { useSubscriptions } from './utils/useSubscriptions';
 
 let routeFocusTimer: number;
 const OVERVIEW = 'Overview';
@@ -68,7 +70,7 @@ export interface IAppRoute {
   exact?: boolean;
   path: string;
   title: string;
-  description?: string; //non-empty description is used to filter routes for the NotFound page
+  description?: string; // non-empty description is used to filter routes for the NotFound page
   isAsync?: boolean;
   navGroup?: string;
   children?: IAppRoute[];
@@ -206,16 +208,20 @@ const PageNotFound = ({ title }: { title: string }) => {
   return <Route component={NotFound} />;
 };
 
-const AppRoutes = () => {
+export interface AppRoutesProps {}
+
+const AppRoutes: React.FunctionComponent<AppRoutesProps> = (props) => {
   const context = React.useContext(ServiceContext);
+  const addSubscription = useSubscriptions();
   const [showDashboard, setShowDashboard] = React.useState(false);
 
   React.useEffect(() => {
-    const sub = context.login
-      .getSessionState()
-      .subscribe((sessionState) => setShowDashboard(sessionState === SessionState.USER_SESSION));
-    return () => sub.unsubscribe();
-  }, [context, context.login, setShowDashboard]);
+    addSubscription(
+      context.login
+        .getSessionState()
+        .subscribe((sessionState) => setShowDashboard(sessionState === SessionState.USER_SESSION))
+    );
+  }, [addSubscription, context.login, setShowDashboard]);
 
   return (
     <LastLocationProvider>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -2,6 +2,7 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const ForkTsCheckerPlugin = require('fork-ts-checker-webpack-plugin');
+const PreloadWebpackPlugin = require('@vue/preload-webpack-plugin');
 
 const BG_IMAGES_DIRNAME = 'bgimages';
 const ASSET_PATH = process.env.ASSET_PATH || '/';
@@ -18,6 +19,10 @@ module.exports = (env) => {
         template: path.resolve(__dirname, 'src', 'index.html'),
         favicon: './src/app/assets/favicon.ico',
       }),
+      new PreloadWebpackPlugin({
+        rel: 'prefetch',
+        include: 'all'
+      })
     ],
     // https://medium.com/hackernoon/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758
     optimization: {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,7 +6,7 @@ const ForkTsCheckerPlugin = require('fork-ts-checker-webpack-plugin');
 const BG_IMAGES_DIRNAME = 'bgimages';
 const ASSET_PATH = process.env.ASSET_PATH || '/';
 
-module.exports = env => {
+module.exports = (env) => {
   return {
     context: __dirname,
     entry: {
@@ -21,9 +21,10 @@ module.exports = env => {
     ],
     // https://medium.com/hackernoon/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758
     optimization: {
-      runtimeChunk: 'single',
+      runtimeChunk: 'single', //  create a runtime file to be shared for all generated chunks
+      moduleIds: 'deterministic', // avoid changing module.id of vendor bundles: https://webpack.js.org/guides/caching/#module-identifiers
       splitChunks: {
-        chunks: 'all',
+        chunks: 'all', // https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks
         maxInitialRequests: Infinity,
         minSize: 0,
         cacheGroups: {
@@ -145,9 +146,12 @@ module.exports = env => {
       ]
     },
     output: {
-      filename: '[name].bundle.js',
+      filename: '[name].[contenthash].bundle.js',
+      chunkFilename: '[name].[contenthash].bundle.js', // lazy-load modules
+      hashFunction: "xxhash64",
       path: path.resolve(__dirname, 'dist'),
       publicPath: ASSET_PATH,
+      clean: true
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.jsx'],

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -21,9 +21,9 @@ module.exports = (env) => {
       }),
       new PreloadWebpackPlugin({
         rel: 'prefetch',
-        include: 'all',
-        // exlude initial chunk, npm chunks, css sheets and sourcemaps.
-        fileBlacklist: [/\.css$/, /\.map/, /^(app|npm)(\.[\w-]+)+\.bundle\.js$/]
+        include: [/\.js$/], // lazy-load chunks to prefetch
+        // exlude initial chunk, npm chunks
+        fileBlacklist: [/^(app|npm)(\.[\w-]+)+\.bundle\.js$/]
       })
     ],
     // https://medium.com/hackernoon/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -147,7 +147,7 @@ module.exports = (env) => {
     },
     output: {
       filename: '[name].[contenthash].bundle.js',
-      chunkFilename: '[name].[contenthash].bundle.js', // lazy-load modules
+      chunkFilename: '[id].[contenthash].bundle.js', // lazy-load modules
       hashFunction: "xxhash64",
       path: path.resolve(__dirname, 'dist'),
       publicPath: ASSET_PATH,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -21,7 +21,8 @@ module.exports = (env) => {
       }),
       new PreloadWebpackPlugin({
         rel: 'prefetch',
-        include: 'all'
+        include: 'all',
+        fileBlacklist: [/\.css$/, /\.map/]
       })
     ],
     // https://medium.com/hackernoon/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -22,7 +22,8 @@ module.exports = (env) => {
       new PreloadWebpackPlugin({
         rel: 'prefetch',
         include: 'all',
-        fileBlacklist: [/\.css$/, /\.map/]
+        // exlude initial chunk, npm chunks, css sheets and sourcemaps.
+        fileBlacklist: [/\.css$/, /\.map/, /^(app|npm)(\.[\w-]+)+\.bundle\.js$/]
       })
     ],
     // https://medium.com/hackernoon/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -20,11 +20,6 @@ module.exports = merge(common('development'), {
   plugins: [
     new DotenvPlugin(),
   ],
-  output: {
-    filename: '[name].bundle.js',
-    path: path.resolve(__dirname, 'dist'), 
-    hashFunction: "xxhash64",
-  },
   module: {
     rules: [
       {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -21,18 +21,13 @@ module.exports = merge(common('production'), {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: '[name].css',
-      chunkFilename: '[name].bundle.css'
+      filename: '[name].[contenthash].bundle.css',
+      chunkFilename: '[name].[contenthash].bundle.css' // lazy-load css
     }),
     new DotenvPlugin({
       path: './.env.prod',
     }),
   ],
-  output: {
-    // filename: '[name].[contenthash].bundle.js',
-    // path: path.resolve(__dirname, 'dist'),
-    hashFunction: "xxhash64",
-  },
   module: {
     rules: [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1416,6 +1416,11 @@
     "@typescript-eslint/types" "4.32.0"
     eslint-visitor-keys "^2.0.0"
 
+"@vue/preload-webpack-plugin@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@vue/preload-webpack-plugin/-/preload-webpack-plugin-2.0.0.tgz#a43bfc087e91f7d0efb0086100148f4b16437b68"
+  integrity sha512-RoorRB50WehYbsiWu497q8egZBYlrvOo9KBUG41uth4O023Cbs+7POLm9uw2CAiViBAIhvpw1Y4w4i+MZxOfXw==
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz"


### PR DESCRIPTION
Fixes #563 
Fixes #587 

- Added configurations to add content-hash to output files and passed the bundle directory to analyzer.

- Applied route-based code splitting: https://reactjs.org/docs/code-splitting.html#route-based-code-splitting. Below is the graph for output bundles sizes:

![Screenshot from 2022-10-28 06-07-43](https://user-images.githubusercontent.com/68053619/198562481-dddd4074-d534-49f5-a7bc-2345897e2221.png)
