### PR TITLE
fix(agent): add margin bottom for probe template table

### DIFF
--- a/src/app/Agent/AgentProbeTemplates.tsx
+++ b/src/app/Agent/AgentProbeTemplates.tsx
@@ -323,7 +323,7 @@ export const AgentProbeTemplates: React.FunctionComponent<AgentProbeTemplatesPro
   } else {
     return (
       <>
-        <Stack hasGutter style={{ marginTop: '1em' }}>
+        <Stack hasGutter style={{ marginTop: '1em', marginBottom: '1.5em' }}>
           <StackItem>
             <Card>
               <CardHeader>

--- a/src/test/Agent/__snapshots__/AgentProbeTemplates.test.tsx.snap
+++ b/src/test/Agent/__snapshots__/AgentProbeTemplates.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`<AgentProbeTemplates /> renders correctly 1`] = `
   className="pf-l-stack pf-m-gutter"
   style={
     Object {
+      "marginBottom": "1.5em",
       "marginTop": "1em",
     }
   }


### PR DESCRIPTION
Related to #583
Related to #584 

As a temporary solution, the Probe Template table now has a margin bottom to allow the action menu of the last row to be in viewport. 

I used `1.5em` for bottom, just enough to get the menu in viewport but still looks symmetric with top padding/margin.

![Screenshot from 2022-10-28 13-19-45](https://user-images.githubusercontent.com/68053619/198696973-57cfd7e9-bbce-4e53-b1c8-c0d390dbb8e6.png)

Looks like if the xml spans more than 3 rows, the out-of-view-port is not an issue anymore.

![Screenshot from 2022-10-28 13-21-38](https://user-images.githubusercontent.com/68053619/198697637-435b6aaa-e3ca-46f9-90f3-bdc7e87f31dc.png)




