### PR TITLE
chore(events): use empty state if table is empty

### DIFF
--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -54,6 +54,9 @@ import {
   TextVariants,
   Stack,
   StackItem,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
 } from '@patternfly/react-core';
 import {
   Table,
@@ -70,6 +73,7 @@ import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView
 import { EventProbe } from '@app/Shared/Services/Api.service';
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
 import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { SearchIcon } from '@patternfly/react-icons';
 
 export interface AgentLiveProbesProps {}
 
@@ -221,7 +225,7 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
     setFilteredProbes([...filtered]);
   }, [filterText, probes, sortBy, setFilteredProbes]);
 
-  const displayTemplates = React.useMemo(
+  const displayProbes = React.useMemo(
     () => filteredProbes.map((t: EventProbe) => [t.id, t.name, t.clazz, t.description, t.methodName]),
     [filteredProbes]
   );
@@ -262,11 +266,11 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
                 <ToolbarGroup variant="filter-group">
                   <ToolbarItem>
                     <TextInput
-                      name="templateFilter"
-                      id="templateFilter"
+                      name="activeProbeFilter"
+                      id="activeProbeFilter"
                       type="search"
                       placeholder="Filter..."
-                      aria-label="Probe template filter"
+                      aria-label="Active probe filter"
                       onChange={setFilterText}
                     />
                   </ToolbarItem>
@@ -291,16 +295,25 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
                 onClose={handleWarningModalClose}
               />
             </Toolbar>
-            <Table
-              aria-label="Active Probes"
-              variant={TableVariant.compact}
-              cells={tableColumns}
-              rows={displayTemplates}
-              onSort={handleSort}
-            >
-              <TableHeader />
-              <TableBody />
-            </Table>
+            {displayProbes.length ? (
+              <Table
+                aria-label="Active Probes"
+                variant={TableVariant.compact}
+                cells={tableColumns}
+                rows={displayProbes}
+                onSort={handleSort}
+              >
+                <TableHeader />
+                <TableBody />
+              </Table>
+            ) : (
+              <EmptyState>
+                <EmptyStateIcon icon={SearchIcon} />
+                <Title headingLevel="h4" size="lg">
+                  No Active Probes
+                </Title>
+              </EmptyState>
+            )}
           </StackItem>
         </Stack>
       </>

--- a/src/app/Agent/AgentProbeTemplates.tsx
+++ b/src/app/Agent/AgentProbeTemplates.tsx
@@ -60,8 +60,11 @@ import {
   TextVariants,
   StackItem,
   Stack,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
 } from '@patternfly/react-core';
-import { UploadIcon } from '@patternfly/react-icons';
+import { SearchIcon, UploadIcon } from '@patternfly/react-icons';
 import {
   Table,
   TableBody,
@@ -370,18 +373,27 @@ export const AgentProbeTemplates: React.FunctionComponent<AgentProbeTemplatesPro
                 />
               </ToolbarContent>
             </Toolbar>
-            <Table
-              aria-label="Probe Templates Table"
-              variant={TableVariant.compact}
-              cells={tableColumns}
-              rows={displayTemplates}
-              actionResolver={actionResolver}
-              sortBy={sortBy}
-              onSort={handleSort}
-            >
-              <TableHeader />
-              <TableBody />
-            </Table>
+            {displayTemplates.length ? (
+              <Table
+                aria-label="Probe Templates Table"
+                variant={TableVariant.compact}
+                cells={tableColumns}
+                rows={displayTemplates}
+                actionResolver={actionResolver}
+                sortBy={sortBy}
+                onSort={handleSort}
+              >
+                <TableHeader />
+                <TableBody />
+              </Table>
+            ) : (
+              <EmptyState>
+                <EmptyStateIcon icon={SearchIcon} />
+                <Title headingLevel="h4" size="lg">
+                  No Probe Templates
+                </Title>
+              </EmptyState>
+            )}
             <Modal
               isOpen={modalOpen}
               variant={ModalVariant.large}

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -54,8 +54,11 @@ import {
   ToolbarGroup,
   ToolbarItem,
   TextInput,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
 } from '@patternfly/react-core';
-import { UploadIcon } from '@patternfly/react-icons';
+import { SearchIcon, UploadIcon } from '@patternfly/react-icons';
 import {
   Table,
   TableBody,
@@ -75,7 +78,9 @@ import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView
 import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
 
-export const EventTemplates = () => {
+export interface EventTemplatesProps {}
+
+export const EventTemplates: React.FunctionComponent<EventTemplatesProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const history = useHistory();
 
@@ -361,40 +366,6 @@ export const EventTemplates = () => {
     setWarningModalOpen(false);
   }, [setWarningModalOpen]);
 
-  const toolbar: JSX.Element = (
-    <>
-      <Toolbar id="event-templates-toolbar">
-        <ToolbarContent>
-          <ToolbarGroup variant="filter-group">
-            <ToolbarItem>
-              <TextInput
-                name="templateFilter"
-                id="templateFilter"
-                type="search"
-                placeholder="Filter..."
-                aria-label="Event template filter"
-                onChange={setFilterText}
-              />
-            </ToolbarItem>
-          </ToolbarGroup>
-          <ToolbarGroup variant="icon-button-group">
-            <ToolbarItem>
-              <Button key="upload" variant="secondary" onClick={handleModalToggle}>
-                <UploadIcon />
-              </Button>
-            </ToolbarItem>
-          </ToolbarGroup>
-          <DeleteWarningModal
-            warningType={DeleteWarningType.DeleteEventTemplates}
-            visible={warningModalOpen}
-            onAccept={handleWarningModalAccept}
-            onClose={handleWarningModalClose}
-          />
-        </ToolbarContent>
-      </Toolbar>
-    </>
-  );
-
   const authRetry = React.useCallback(() => {
     context.target.setAuthRetry();
   }, [context.target, context.target.setAuthRetry]);
@@ -408,29 +379,61 @@ export const EventTemplates = () => {
       />
     );
   } else if (isLoading) {
-    return (
-      <>
-        {toolbar}
-        <LoadingView />
-      </>
-    );
+    return <LoadingView />;
   } else {
     return (
       <>
-        {toolbar}
-        <Table
-          aria-label="Event Templates table"
-          variant={TableVariant.compact}
-          cells={tableColumns}
-          rows={displayTemplates}
-          actionResolver={actionResolver}
-          sortBy={sortBy}
-          onSort={handleSort}
-        >
-          <TableHeader />
-          <TableBody />
-        </Table>
-
+        <Toolbar id="event-templates-toolbar">
+          <ToolbarContent>
+            <ToolbarGroup variant="filter-group">
+              <ToolbarItem>
+                <TextInput
+                  name="templateFilter"
+                  id="templateFilter"
+                  type="search"
+                  placeholder="Filter..."
+                  aria-label="Event template filter"
+                  onChange={setFilterText}
+                  isDisabled={errorMessage != ''}
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup variant="icon-button-group">
+              <ToolbarItem>
+                <Button key="upload" variant="secondary" onClick={handleModalToggle} isDisabled={errorMessage != ''}>
+                  <UploadIcon />
+                </Button>
+              </ToolbarItem>
+            </ToolbarGroup>
+            <DeleteWarningModal
+              warningType={DeleteWarningType.DeleteEventTemplates}
+              visible={warningModalOpen}
+              onAccept={handleWarningModalAccept}
+              onClose={handleWarningModalClose}
+            />
+          </ToolbarContent>
+        </Toolbar>
+        {displayTemplates.length ? (
+          <Table
+            aria-label="Event Templates table"
+            variant={TableVariant.compact}
+            cells={tableColumns}
+            rows={displayTemplates}
+            actionResolver={actionResolver}
+            sortBy={sortBy}
+            onSort={handleSort}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+        ) : (
+          <EmptyState>
+            <EmptyStateIcon icon={SearchIcon} />
+            <Title headingLevel="h4" size="lg">
+              No Event Templates
+            </Title>
+          </EmptyState>
+        )}
         <Modal
           isOpen={modalOpen}
           variant={ModalVariant.large}

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -46,11 +46,15 @@ import {
   ToolbarItemVariant,
   Pagination,
   TextInput,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
 } from '@patternfly/react-core';
 import { expandable, Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import { concatMap, filter, first } from 'rxjs/operators';
 import { LoadingView } from '@app/LoadingView/LoadingView';
 import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
+import { SearchIcon } from '@patternfly/react-icons';
 
 export interface EventType {
   name: string;
@@ -77,7 +81,9 @@ const getCategoryString = (eventType: EventType): string => {
   return eventType.category.join(', ').trim();
 };
 
-export const EventTypes = () => {
+export interface EventTypesProps {}
+
+export const EventTypes: React.FunctionComponent<EventTypesProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
 
@@ -256,6 +262,7 @@ export const EventTypes = () => {
                 placeholder="Filter..."
                 aria-label="Event filter"
                 onChange={setFilterText}
+                isDisabled={errorMessage != ''}
               />
             </ToolbarItem>
             <ToolbarItem variant={ToolbarItemVariant.pagination}>
@@ -271,16 +278,25 @@ export const EventTypes = () => {
             </ToolbarItem>
           </ToolbarContent>
         </Toolbar>
-        <Table
-          aria-label="Event Types table"
-          cells={tableColumns}
-          rows={displayedTypes}
-          onCollapse={onCollapse}
-          variant={TableVariant.compact}
-        >
-          <TableHeader />
-          <TableBody />
-        </Table>
+        {displayedTypes.length ? (
+          <Table
+            aria-label="Event Types table"
+            cells={tableColumns}
+            rows={displayedTypes}
+            onCollapse={onCollapse}
+            variant={TableVariant.compact}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+        ) : (
+          <EmptyState>
+            <EmptyStateIcon icon={SearchIcon} />
+            <Title headingLevel="h4" size="lg">
+              No Event Types
+            </Title>
+          </EmptyState>
+        )}
       </>
     );
   }

--- a/src/test/Agent/AgentLiveProbes.test.tsx
+++ b/src/test/Agent/AgentLiveProbes.test.tsx
@@ -246,4 +246,24 @@ describe('<AgentLiveProbes />', () => {
 
     expect(deleteRequestSpy).toBeCalledTimes(1);
   });
+
+  it('should shown empty state when table is empty', () => {
+    render(
+      <ServiceContext.Provider value={defaultServices}>
+        <AgentLiveProbes />
+      </ServiceContext.Provider>
+    );
+
+    const filterInput = screen.getByLabelText('Active probe filter');
+    expect(filterInput).toBeInTheDocument();
+    expect(filterInput).toBeVisible();
+
+    userEvent.type(filterInput, 'someveryoddname');
+
+    expect(screen.queryByText('some_name')).not.toBeInTheDocument();
+
+    const hintText = screen.getByText('No Active Probes');
+    expect(hintText).toBeInTheDocument();
+    expect(hintText).toBeVisible();
+  });
 });

--- a/src/test/Agent/AgentProbeTemplates.test.tsx
+++ b/src/test/Agent/AgentProbeTemplates.test.tsx
@@ -330,4 +330,24 @@ describe('<AgentProbeTemplates />', () => {
     expect(insertButton).toBeVisible();
     expect(insertButton.getAttribute('aria-disabled')).toBe('true');
   });
+
+  it('should shown empty state when table is empty', () => {
+    render(
+      <ServiceContext.Provider value={defaultServices}>
+        <AgentProbeTemplates agentDetected={false} />
+      </ServiceContext.Provider>
+    );
+
+    const filterInput = screen.getByLabelText('Probe template filter');
+    expect(filterInput).toBeInTheDocument();
+    expect(filterInput).toBeVisible();
+
+    userEvent.type(filterInput, 'someveryoddname');
+
+    expect(screen.queryByText('someProbeTemplate')).not.toBeInTheDocument();
+
+    const hintText = screen.getByText('No Probe Templates');
+    expect(hintText).toBeInTheDocument();
+    expect(hintText).toBeVisible();
+  });
 });

--- a/src/test/Agent/__snapshots__/AgentLiveProbes.test.tsx.snap
+++ b/src/test/Agent/__snapshots__/AgentLiveProbes.test.tsx.snap
@@ -67,14 +67,14 @@ exports[`<AgentLiveProbes /> renders correctly 1`] = `
             >
               <input
                 aria-invalid={false}
-                aria-label="Probe template filter"
+                aria-label="Active probe filter"
                 className="pf-c-form-control"
                 data-ouia-component-id="OUIA-Generated-TextInputBase-1"
                 data-ouia-component-type="PF4/TextInput"
                 data-ouia-safe={true}
                 disabled={false}
-                id="templateFilter"
-                name="templateFilter"
+                id="activeProbeFilter"
+                name="activeProbeFilter"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onFocus={[Function]}

--- a/src/test/Events/EventTemplates.test.tsx
+++ b/src/test/Events/EventTemplates.test.tsx
@@ -272,4 +272,24 @@ describe('<EventTemplates />', () => {
     expect(retryButton).toBeInTheDocument();
     expect(retryButton).toBeVisible();
   });
+
+  it('should shown empty state when table is empty', () => {
+    render(
+      <ServiceContext.Provider value={defaultServices}>
+        <EventTemplates />
+      </ServiceContext.Provider>
+    );
+
+    const filterInput = screen.getByLabelText('Event template filter');
+    expect(filterInput).toBeInTheDocument();
+    expect(filterInput).toBeVisible();
+
+    userEvent.type(filterInput, 'someveryoddname');
+
+    expect(screen.queryByText('someEventTemplate')).not.toBeInTheDocument();
+
+    const hintText = screen.getByText('No Event Templates');
+    expect(hintText).toBeInTheDocument();
+    expect(hintText).toBeVisible();
+  });
 });

--- a/src/test/Events/EventTypes.test.tsx
+++ b/src/test/Events/EventTypes.test.tsx
@@ -43,6 +43,7 @@ import { of, Subject } from 'rxjs';
 import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/Services';
 import { TargetService } from '@app/Shared/Services/Target.service';
 import { EventType, EventTypes } from '@app/Events/EventTypes';
+import userEvent from '@testing-library/user-event';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };
@@ -102,5 +103,25 @@ describe('<EventTypes />', () => {
     const retryButton = screen.getByText('Retry');
     expect(retryButton).toBeInTheDocument();
     expect(retryButton).toBeVisible();
+  });
+
+  it('should shown empty state when table is empty', () => {
+    render(
+      <ServiceContext.Provider value={defaultServices}>
+        <EventTypes />
+      </ServiceContext.Provider>
+    );
+
+    const filterInput = screen.getByLabelText('Event filter');
+    expect(filterInput).toBeInTheDocument();
+    expect(filterInput).toBeVisible();
+
+    userEvent.type(filterInput, 'someveryoddname');
+
+    expect(screen.queryByText('Some Event')).not.toBeInTheDocument();
+
+    const hintText = screen.getByText('No Event Types');
+    expect(hintText).toBeInTheDocument();
+    expect(hintText).toBeVisible();
   });
 });


### PR DESCRIPTION
Fixes #598 
Related to #601 

For consistency, if the table is empty, show an empty state instead of an empty table. Also, rename labels/ids for active probe filters.