### PR TITLE
fix(recordings): correctly update recording tables on errors

### DIFF
--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -160,8 +160,9 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
     (error) => {
       setIsLoading(false);
       setErrorMessage(error.message);
+      setRecordings([]);
     },
-    [setIsLoading, setErrorMessage]
+    [setIsLoading, setErrorMessage, setRecordings]
   );
 
   const refreshRecordingList = React.useCallback(() => {
@@ -258,8 +259,13 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
   }, [addSubscription, context, context.notificationChannel, setRecordings]);
 
   React.useEffect(() => {
-    addSubscription(context.target.authFailure().subscribe(() => setErrorMessage(authFailMessage)));
-  }, [context, context.target, setErrorMessage, addSubscription]);
+    addSubscription(
+      context.target.authFailure().subscribe(() => {
+        setErrorMessage(authFailMessage);
+        setRecordings([]);
+      })
+    );
+  }, [context, context.target, setErrorMessage, addSubscription, setRecordings]);
 
   React.useEffect(() => {
     addSubscription(

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -647,4 +647,26 @@ describe('<ArchivedRecordingsTable />', () => {
     expect(uploadSpy).toHaveBeenCalled();
     expect(uploadSpy).toHaveBeenCalledWith(mockFileUpload, mockUploadedRecordingLabels, expect.anything());
   });
+
+  it('should show error view if failing to retrieve recordings', async () => {
+    jest.spyOn(defaultServices.api, 'graphql').mockImplementationOnce((query) => {
+      throw new Error('Something wrong');
+    });
+
+    renderWithServiceContextAndReduxStoreWithRouter(
+      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
+
+    const failTitle = screen.getByText('Error retrieving recordings');
+    expect(failTitle).toBeInTheDocument();
+    expect(failTitle).toBeVisible();
+
+    const authFailText = screen.getByText('Something wrong');
+    expect(authFailText).toBeInTheDocument();
+    expect(authFailText).toBeVisible();
+  });
 });


### PR DESCRIPTION
Fixes #600 
Fixes #603
Related to #605

**Fixes**
- Clean up recording states if there is an error.
- Added an error handler for ArchivedRecordingTable to avoid getting stuck in loading state.

**Chore**
- Remove call to `refreshRecordings` in ArchivedRecording upload table as notifications will handle update.
