### PR TITLE
chore(toolbar): hide toolbar on errors

### DIFF
--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -715,7 +715,11 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
   }, [warningModalOpen, props.handleDeleteRecordings, handleWarningModalClose]);
 
   return (
-    <Toolbar id="active-recordings-toolbar" clearAllFilters={props.handleClearFilters}>
+    <Toolbar
+      id="active-recordings-toolbar"
+      aria-label="active-recording-toolbar"
+      clearAllFilters={props.handleClearFilters}
+    >
       <ToolbarContent>
         <RecordingFilters
           target={props.target}

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -35,43 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-/*
- * Copyright The Cryostat Authors
- *
- * The Universal Permissive License (UPL), Version 1.0
- *
- * Subject to the condition set forth below, permission is hereby granted to any
- * person obtaining a copy of this software, associated documentation and/or data
- * (collectively the "Software"), free of charge and under any and all copyright
- * rights in the Software, and any and all patent rights owned or freely
- * licensable by each licensor hereunder covering either (i) the unmodified
- * Software as contributed to or provided by such licensor, or (ii) the Larger
- * Works (as defined below), to deal in both
- *
- * (a) the Software, and
- * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
- * one is included with the Software (each a "Larger Work" to which the Software
- * is contributed by such licensors),
- 
- * without restriction, including without limitation the rights to copy, create
- * derivative works of, display, perform, and distribute the Software and make,
- * use, sell, offer for sale, import, export, have made, and have sold the
- * Software and the Larger Work(s), and to sublicense the foregoing rights on
- * either these or other terms.
- *
- * This license is subject to the following condition:
- * The above copyright notice and either this complete permission notice or at
- * a minimum a reference to the UPL must be included in all copies or
- * substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+
 import * as React from 'react';
 import { ArchivedRecording, RecordingDirectory, UPLOADS_SUBDIRECTORY } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -35,6 +35,43 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ 
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 import * as React from 'react';
 import { ArchivedRecording, RecordingDirectory, UPLOADS_SUBDIRECTORY } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
@@ -52,7 +89,7 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { Tbody, Tr, Td, ExpandableRowContent, TableComposable } from '@patternfly/react-table';
-import { PlusIcon } from '@patternfly/react-icons';
+import { UploadIcon } from '@patternfly/react-icons';
 import { RecordingActions } from './RecordingActions';
 import { RecordingsTable } from './RecordingsTable';
 import { ReportFrame } from './ReportFrame';
@@ -655,7 +692,11 @@ const ArchivedRecordingsToolbar: React.FunctionComponent<ArchivedRecordingsToolb
   }, [warningModalOpen, props.handleDeleteRecordings, handleWarningModalClose]);
 
   return (
-    <Toolbar id="archived-recordings-toolbar" clearAllFilters={props.handleClearFilters}>
+    <Toolbar
+      id="archived-recordings-toolbar"
+      aria-label="archived-recording-toolbar"
+      clearAllFilters={props.handleClearFilters}
+    >
       <ToolbarContent>
         <RecordingFilters
           target={props.target}
@@ -685,8 +726,8 @@ const ArchivedRecordingsToolbar: React.FunctionComponent<ArchivedRecordingsToolb
         {props.isUploadsTable ? (
           <ToolbarGroup variant="icon-button-group">
             <ToolbarItem>
-              <Button variant="plain" aria-label="add" onClick={props.handleShowUploadModal}>
-                <PlusIcon />
+              <Button variant="secondary" aria-label="upload-recording" onClick={props.handleShowUploadModal}>
+                <UploadIcon />
               </Button>
             </ToolbarItem>
           </ToolbarGroup>

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -74,7 +74,9 @@ export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (p
     context.target.setAuthRetry();
   }, [context.target, context.target.setAuthRetry]);
 
-  if (props.errorMessage != '') {
+  const isError = React.useMemo(() => props.errorMessage != '', [props.errorMessage]);
+
+  if (isError) {
     view = (
       <>
         <ErrorView
@@ -151,7 +153,7 @@ export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (p
   return (
     <>
       <OuterScrollContainer className="recording-table-container">
-        {props.toolbar}
+        {isError ? null : props.toolbar}
         <InnerScrollContainer>{view}</InnerScrollContainer>
         {props.tableFooter}
       </OuterScrollContainer>

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -484,5 +484,8 @@ describe('<ActiveRecordingsTable />', () => {
     const retryButton = screen.getByText('Retry');
     expect(retryButton).toBeInTheDocument();
     expect(retryButton).toBeVisible();
+
+    const toolbar = screen.queryByLabelText('active-recording-toolbar');
+    expect(toolbar).not.toBeInTheDocument();
   });
 });

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -427,7 +427,7 @@ describe('<ArchivedRecordingsTable />', () => {
 
     expect(screen.getByText('someRecording')).toBeInTheDocument();
 
-    const uploadButton = screen.getByLabelText('add');
+    const uploadButton = screen.getByLabelText('upload-recording');
     expect(uploadButton).toHaveAttribute('type', 'button');
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -450,7 +450,7 @@ describe('<ArchivedRecordingsTable />', () => {
       }
     );
 
-    userEvent.click(screen.getByLabelText('add'));
+    userEvent.click(screen.getByLabelText('upload-recording'));
 
     const modal = await screen.findByRole('dialog');
 
@@ -506,7 +506,7 @@ describe('<ArchivedRecordingsTable />', () => {
       }
     );
 
-    userEvent.click(screen.getByLabelText('add'));
+    userEvent.click(screen.getByLabelText('upload-recording'));
 
     const modal = await screen.findByRole('dialog');
 
@@ -583,7 +583,7 @@ describe('<ArchivedRecordingsTable />', () => {
       }
     );
 
-    userEvent.click(screen.getByLabelText('add'));
+    userEvent.click(screen.getByLabelText('upload-recording'));
 
     const modal = await screen.findByRole('dialog');
 
@@ -668,5 +668,8 @@ describe('<ArchivedRecordingsTable />', () => {
     const authFailText = screen.getByText('Something wrong');
     expect(authFailText).toBeInTheDocument();
     expect(authFailText).toBeVisible();
+
+    const toolbar = screen.queryByLabelText('archived-recording-toolbar');
+    expect(toolbar).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes #601 

Hide all toolbars and only show the error view if an error occurs.

For consistency, use upload icon instead of plus icon in upload table.