### PR TITLE
chore(loadingview): add descriptive texts for loading spinner

### DIFF
--- a/src/test/LoadingView/LoadingView.test.tsx
+++ b/src/test/LoadingView/LoadingView.test.tsx
@@ -35,26 +35,30 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 import * as React from 'react';
-import { Bullseye, EmptyState, EmptyStateIcon, Spinner, Title } from '@patternfly/react-core';
+import renderer, { act } from 'react-test-renderer';
+import { render, screen } from '@testing-library/react';
+import LoadingView from '@app/LoadingView/LoadingView';
 
-export interface LoadingViewProps {
-  title?: string;
-}
+describe('<LoadingView />', () => {
+  it('renders correctly', async () => {
+    let tree;
+    await act(async () => {
+      tree = renderer.create(<LoadingView></LoadingView>);
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
 
-export const LoadingView: React.FunctionComponent<LoadingViewProps> = (props) => {
-  return (
-    <>
-      <Bullseye>
-        <EmptyState>
-          <EmptyStateIcon variant="container" component={Spinner} />
-          <Title size="lg" headingLevel="h2">
-            {props.title || 'Loading'}
-          </Title>
-        </EmptyState>
-      </Bullseye>
-    </>
-  );
-};
+  it('should show spinner and title', () => {
+    render(<LoadingView title="Progressing"></LoadingView>);
 
-export default LoadingView;
+    const title = screen.getByText('Progressing');
+    expect(title).toBeInTheDocument();
+    expect(title).toBeVisible();
+
+    const spinner = screen.getByRole('progressbar');
+    expect(spinner).toBeInTheDocument();
+    expect(spinner).toBeVisible();
+  });
+});

--- a/src/test/LoadingView/__snapshots__/LoadingView.test.tsx.snap
+++ b/src/test/LoadingView/__snapshots__/LoadingView.test.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LoadingView /> renders correctly 1`] = `
+<div
+  className="pf-l-bullseye"
+>
+  <div
+    className="pf-c-empty-state"
+  >
+    <div
+      className="pf-c-empty-state__content"
+    >
+      <div
+        className="pf-c-empty-state__icon"
+      >
+        <span
+          aria-label="Contents"
+          aria-valuetext="Loading..."
+          className="pf-c-spinner pf-m-xl"
+          role="progressbar"
+        >
+          <span
+            className="pf-c-spinner__clipper"
+          />
+          <span
+            className="pf-c-spinner__lead-ball"
+          />
+          <span
+            className="pf-c-spinner__tail-ball"
+          />
+        </span>
+      </div>
+      <h2
+        className="pf-c-title pf-m-lg"
+        data-ouia-component-id="OUIA-Generated-Title-1"
+        data-ouia-component-type="PF4/Title"
+        data-ouia-safe={true}
+      >
+        Loading
+      </h2>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Fixes #621 

- Added a way to include a descriptive text for spinner. This way, if animations break or using screen reader, users can still see that UI is loading.

- Added a missing unit test for `LoadingView` component.