### PR TITLE
fix(label-upload): add error handler for metadata uploads

### DIFF
--- a/src/app/Archives/ArchiveUploadModal.tsx
+++ b/src/app/Archives/ArchiveUploadModal.tsx
@@ -46,7 +46,6 @@ import {
   FormGroup,
   Modal,
   ModalVariant,
-  Popover,
   Text,
   Tooltip,
   ValidatedOptions,
@@ -58,28 +57,6 @@ import { CancelUploadModal } from '@app/Modal/CancelUploadModal';
 import { RecordingLabelFields } from '@app/RecordingMetadata/RecordingLabelFields';
 import { HelpIcon } from '@patternfly/react-icons';
 import { RecordingLabel } from '@app/RecordingMetadata/RecordingLabel';
-import { from, Observable } from 'rxjs';
-
-export const parseLabels = (file: File): Observable<RecordingLabel[]> => {
-  return from(
-    file
-      .text()
-      .then(JSON.parse)
-      .then((obj) => {
-        const labels: RecordingLabel[] = [];
-        const labelObj = obj['labels'];
-        if (labelObj) {
-          Object.keys(labelObj).forEach((key) => {
-            labels.push({
-              key: key,
-              value: labelObj[key],
-            });
-          });
-        }
-        return labels;
-      })
-  );
-};
 
 export interface ArchiveUploadModalProps {
   visible: boolean;

--- a/src/app/RecordingMetadata/RecordingLabel.tsx
+++ b/src/app/RecordingMetadata/RecordingLabel.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 
-import { from, Observable } from "rxjs";
+import { from, Observable } from 'rxjs';
 
 export interface RecordingLabel {
   key: string;
@@ -69,10 +69,8 @@ export const parseLabelsFromFile = (file: File): Observable<RecordingLabel[]> =>
         }
         return labels;
       })
-      .catch((_) => [])
   );
 };
-
 
 export const includesLabel = (arr: RecordingLabel[], searchLabel: RecordingLabel) => {
   return arr.some((l) => isEqualLabel(searchLabel, l));

--- a/src/app/RecordingMetadata/RecordingLabel.tsx
+++ b/src/app/RecordingMetadata/RecordingLabel.tsx
@@ -36,18 +36,43 @@
  * SOFTWARE.
  */
 
+import { from, Observable } from "rxjs";
+
 export interface RecordingLabel {
   key: string;
   value: string;
 }
 
-export const parseLabels = (jsonLabels) => {
+export const parseLabels = (jsonLabels: Object) => {
   if (!jsonLabels) return [];
 
   return Object.entries(jsonLabels).map(([k, v]) => {
     return { key: k, value: v } as RecordingLabel;
   });
 };
+
+export const parseLabelsFromFile = (file: File): Observable<RecordingLabel[]> => {
+  return from(
+    file
+      .text()
+      .then(JSON.parse)
+      .then((obj) => {
+        const labels: RecordingLabel[] = [];
+        const labelObj = obj['labels'];
+        if (labelObj) {
+          Object.keys(labelObj).forEach((key) => {
+            labels.push({
+              key: key,
+              value: labelObj[key],
+            });
+          });
+        }
+        return labels;
+      })
+      .catch((_) => [])
+  );
+};
+
 
 export const includesLabel = (arr: RecordingLabel[], searchLabel: RecordingLabel) => {
   return arr.some((l) => isEqualLabel(searchLabel, l));

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -204,10 +204,12 @@ export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsP
             headerIcon={<ExclamationCircleIcon />}
             bodyContent={
               <>
-              <Text component='h4'>Invalid metadata files:</Text>
+                <Text component="h4">Invalid metadata files:</Text>
                 <List>
                   {invalidUploads.map((uploadName) => (
-                    <ListItem key={uploadName} icon={<FileIcon/>}>{uploadName}</ListItem>
+                    <ListItem key={uploadName} icon={<FileIcon />}>
+                      {uploadName}
+                    </ListItem>
                   ))}
                 </List>
               </>

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -48,8 +48,7 @@ import {
   TextInput,
   ValidatedOptions,
 } from '@patternfly/react-core';
-import { RecordingLabel } from '@app/RecordingMetadata/RecordingLabel';
-import { parseLabels } from '@app/Archives/ArchiveUploadModal';
+import { parseLabelsFromFile, RecordingLabel } from '@app/RecordingMetadata/RecordingLabel';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { LoadingView } from '@app/LoadingView/LoadingView';
 import { Observable, zip } from 'rxjs';
@@ -108,11 +107,6 @@ export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsP
     [props.labels, props.setLabels]
   );
 
-  const handleLabelUpload = React.useCallback(
-    (labels: RecordingLabel[]) => props.setLabels([...props.labels, ...labels]),
-    [props.setLabels, props.labels]
-  );
-
   const isLabelValid = React.useCallback(matchesLabelSyntax, [matchesLabelSyntax]);
 
   const isDuplicateKey = React.useCallback((key: string, labels: RecordingLabel[]) => {
@@ -160,7 +154,7 @@ export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsP
         const tasks: Observable<RecordingLabel[]>[] = [];
         setLoading(true);
         for (const labelFile of e.target.files) {
-          tasks.push(parseLabels(labelFile));
+          tasks.push(parseLabelsFromFile(labelFile));
         }
         addSubscription(
           zip(tasks).subscribe((labelArrays: RecordingLabel[][]) => {

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -204,9 +204,9 @@ export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsP
             headerIcon={<ExclamationCircleIcon />}
             bodyContent={
               <>
-                <Text component="h4">{
-                  `The following file${invalidUploads.length > 1? 's': ''} did not contain valid recording metadata:`
-                }</Text>
+                <Text component="h4">{`The following file${
+                  invalidUploads.length > 1 ? 's' : ''
+                } did not contain valid recording metadata:`}</Text>
                 <List>
                   {invalidUploads.map((uploadName) => (
                     <ListItem key={uploadName} icon={<FileIcon />}>

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -198,13 +198,13 @@ export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsP
             isVisible={!!invalidUploads.length}
             aria-label="uploading warning"
             alertSeverityVariant="danger"
-            headerContent="Invalid metadata content"
+            headerContent="Invalid Selection"
             headerComponent="h1"
             shouldClose={closeWarningPopover}
             headerIcon={<ExclamationCircleIcon />}
             bodyContent={
               <>
-                <Text component="h4">Invalid metadata files:</Text>
+                <Text component="h4">The following files did not contain valid recording metadata:</Text>
                 <List>
                   {invalidUploads.map((uploadName) => (
                     <ListItem key={uploadName} icon={<FileIcon />}>

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -204,7 +204,9 @@ export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsP
             headerIcon={<ExclamationCircleIcon />}
             bodyContent={
               <>
-                <Text component="h4">The following files did not contain valid recording metadata:</Text>
+                <Text component="h4">{
+                  `The following file${invalidUploads.length > 1? 's': ''} did not contain valid recording metadata:`
+                }</Text>
                 <List>
                   {invalidUploads.map((uploadName) => (
                     <ListItem key={uploadName} icon={<FileIcon />}>

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -709,7 +709,7 @@ describe('<ArchivedRecordingsTable />', () => {
     expect(labelUploadInput.files).not.toBe(null);
     expect(labelUploadInput.files![0]).toStrictEqual(invalidMetadataFile);
 
-    const warningTitle = screen.getByText('Invalid metadata content');
+    const warningTitle = screen.getByText('Invalid Selection');
     expect(warningTitle).toBeInTheDocument();
     expect(warningTitle).toBeVisible();
 

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -690,14 +690,8 @@ describe('<ArchivedRecordingsTable />', () => {
     userEvent.click(metadataEditorToggle);
 
     const invalidMetadataFileName = 'invalid.metadata.json';
-    const invalidMetadataFile = new File(
-      ["asdfg"],
-      invalidMetadataFileName,
-      { type: 'json' }
-    );
-    invalidMetadataFile.text = jest.fn(
-      () => new Promise((resolve, _) => resolve("asdfg"))
-    );
+    const invalidMetadataFile = new File(['asdfg'], invalidMetadataFileName, { type: 'json' });
+    invalidMetadataFile.text = jest.fn(() => new Promise((resolve, _) => resolve('asdfg')));
 
     const uploadeLabelButton = await within(modal).findByRole('button', { name: 'Upload Labels' });
     expect(uploadeLabelButton).toBeInTheDocument();


### PR DESCRIPTION
Fixes #623 

Handled parsing error if user uploads invalid metadata label files. The invalid files are shown in a popover on top of the button since inline texts are taking quite some spaces and misaligned. In the background, invalid file contents are ignored (i.e. return empty []).

![Screenshot from 2022-11-09 18-11-06](https://user-images.githubusercontent.com/68053619/200964615-284d873e-74b2-4024-a1a0-a1adf2993957.png)
