### PR TITLE
build(deps): remove unused express dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@patternfly/react-table": "^4.93.1",
     "@reduxjs/toolkit": "^1.8.5",
     "@types/lodash": "^4.14.175",
-    "express": "^4.17.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^8.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3305,7 +3305,7 @@ expect@^27.2.4:
     jest-message-util "^27.2.4"
     jest-regex-util "^27.0.6"
 
-express@^4.17.1, express@^4.17.3:
+express@^4.17.3:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.1.tgz"
   integrity sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==


### PR DESCRIPTION
Related to #629

Remove unused dependency. Express is a web framework for server-side (Node) applications. This project is only built to static assets to be served by the Cryostat backend and we never use Express for anything.
