### PR TITLE
fix(credentials): set backend storage as default

### DIFF
--- a/src/app/Settings/CredentialsStorage.tsx
+++ b/src/app/Settings/CredentialsStorage.tsx
@@ -39,7 +39,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Select, SelectOption, SelectVariant, Text } from '@patternfly/react-core';
-
 import { UserSetting } from './Settings';
 import { getFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
 
@@ -69,12 +68,12 @@ const getLocation = (key: string): Location => {
       return l;
     }
   }
-  return Locations.BROWSER_SESSION;
+  return Locations.BACKEND;
 };
 
 const Component = () => {
   const [isExpanded, setExpanded] = React.useState(false);
-  const [selection, setSelection] = React.useState(Locations.BROWSER_SESSION.key);
+  const [selection, setSelection] = React.useState(Locations.BACKEND.key);
 
   const handleSelect = React.useCallback(
     (_, selection) => {
@@ -87,7 +86,7 @@ const Component = () => {
   );
 
   React.useEffect(() => {
-    handleSelect(undefined, getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BROWSER_SESSION.key));
+    handleSelect(undefined, getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BACKEND.key));
   }, [handleSelect, getFromLocalStorage]);
 
   return (

--- a/src/app/Shared/Services/JmxCredentials.service.tsx
+++ b/src/app/Shared/Services/JmxCredentials.service.tsx
@@ -52,7 +52,7 @@ export class JmxCredentials {
   constructor(private readonly api: () => ApiService) {}
 
   setCredential(targetId: string, username: string, password: string): Observable<boolean> {
-    let location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BROWSER_SESSION.key);
+    let location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BACKEND.key);
     switch (location) {
       case Locations.BACKEND.key:
         return this.api().postCredentials(`target.connectUrl == "${targetId}"`, username, password);
@@ -66,7 +66,7 @@ export class JmxCredentials {
   }
 
   getCredential(targetId: string): Observable<Credential | undefined> {
-    let location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BROWSER_SESSION.key);
+    let location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BACKEND.key);
     switch (location) {
       case Locations.BACKEND.key:
         // if this is stored on the backend then Cryostat should be using those and not prompting us to request from the user

--- a/src/test/Settings/CredentialsStorage.test.tsx
+++ b/src/test/Settings/CredentialsStorage.test.tsx
@@ -37,7 +37,7 @@
  */
 import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { render, cleanup, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, screen, waitFor, within } from '@testing-library/react';
 import { renderDefault } from '../Common';
 import { CredentialsStorage } from '@app/Settings/CredentialsStorage';
 import { getFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
@@ -73,15 +73,15 @@ describe('<CredentialsStorage/>', () => {
     expect(tree.toJSON()).toMatchSnapshot();
   });
 
-  it('defaults to Session storage', async () => {
+  it('defaults to Backend storage', async () => {
     renderDefault(React.createElement(CredentialsStorage.content, null));
 
     expect(getFromLocalStorage).toHaveBeenCalledTimes(1);
     expect(saveToLocalStorage).toHaveBeenCalledTimes(1);
-    expect(saveToLocalStorage).lastCalledWith(storageKey, sessionStorageValue);
+    expect(saveToLocalStorage).lastCalledWith(storageKey, backendStorageValue);
 
-    expect(screen.getByText(sessionStorageValue)).toBeVisible();
-    expect(screen.queryByText(backendStorageValue)).toBeFalsy();
+    expect(screen.getByText(backendStorageValue)).toBeVisible();
+    expect(screen.queryByText(sessionStorageValue)).toBeFalsy();
   });
 
   it('sets value to local storage when dropdown is clicked', async () => {
@@ -89,23 +89,23 @@ describe('<CredentialsStorage/>', () => {
 
     expect(getFromLocalStorage).toHaveBeenCalledTimes(1);
     expect(saveToLocalStorage).toHaveBeenCalledTimes(1);
-    expect(saveToLocalStorage).lastCalledWith(storageKey, sessionStorageValue);
+    expect(saveToLocalStorage).lastCalledWith(storageKey, backendStorageValue);
 
     await user.click(screen.getByRole('button'));
 
-    // as in the other test, the default is Session storage. click the dropdown and select Backend to change selection
+    // the default is Backend storage. Click the dropdown and select Session (Browser Memory) to change selection
     const ul = await screen.findByRole('listbox');
-    const backend = within(ul).getByText(backendStorageValue);
+    const backend = within(ul).getByText(sessionStorageValue);
     await user.click(backend);
 
     await waitFor(() => expect(ul).not.toBeVisible()); // expect selection menu to close after user clicks an option
 
     // expect the selection to be visible, the other not
-    expect(screen.getByText(backendStorageValue)).toBeVisible();
-    expect(screen.queryByText(sessionStorageValue)).toBeFalsy();
+    expect(screen.getByText(sessionStorageValue)).toBeVisible();
+    expect(screen.queryByText(backendStorageValue)).toBeFalsy();
 
     expect(getFromLocalStorage).toHaveBeenCalledTimes(1);
     expect(saveToLocalStorage).toHaveBeenCalledTimes(2);
-    expect(saveToLocalStorage).lastCalledWith(storageKey, backendStorageValue);
+    expect(saveToLocalStorage).lastCalledWith(storageKey, sessionStorageValue);
   });
 });

--- a/src/test/Settings/__snapshots__/CredentialsStorage.test.tsx.snap
+++ b/src/test/Settings/__snapshots__/CredentialsStorage.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<CredentialsStorage/> renders correctly 1`] = `
       <span
         className="pf-c-select__toggle-text"
       >
-        Session (Browser Memory)
+        Backend
       </span>
     </div>
     <span


### PR DESCRIPTION
Related to #656 

Use Backend storage as default. This does not fix the issue but just switch it default Backend.


