### PR TITLE
chore(auth): refactor auth form to avoid promise updates

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -147,6 +147,11 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
     setShowAuthModal(false);
   }, [setShowAuthModal]);
 
+  const authModalOnSave = React.useCallback(() => {
+    serviceContext.target.setAuthRetry();
+    dismissAuthModal();
+  }, [serviceContext.target, dismissAuthModal]);
+
   const handleMarkNotificationRead = React.useCallback(
     (key) => notificationsContext.setRead(key, true),
     [notificationsContext.setRead]
@@ -357,7 +362,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
       >
         {children}
       </Page>
-      <AuthModal visible={showAuthModal} onDismiss={dismissAuthModal} onSave={dismissAuthModal} />
+      <AuthModal visible={showAuthModal} onDismiss={dismissAuthModal} onSave={authModalOnSave} />
       <SslErrorModal visible={showSslErrorModal} onDismiss={dismissSslErrorModal} />
     </>
   );

--- a/src/app/AppLayout/JmxAuthForm.tsx
+++ b/src/app/AppLayout/JmxAuthForm.tsx
@@ -37,33 +37,22 @@
  */
 import * as React from 'react';
 import { ActionGroup, Button, Form, FormGroup, TextInput } from '@patternfly/react-core';
-import { ServiceContext } from '@app/Shared/Services/Services';
 import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 
 export interface JmxAuthFormProps {
   onDismiss: () => void;
-  onSave: (username: string, password: string) => Promise<void>;
+  onSave: (username: string, password: string) => void;
   focus?: boolean;
+  loading?: boolean;
 }
 
 export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) => {
-  const context = React.useContext(ServiceContext);
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');
-  const [loading, setLoading] = React.useState(false);
 
   const handleSave = React.useCallback(() => {
-    setLoading(true);
-    props
-      .onSave(username, password)
-      .then(() => {
-        // Do not set state as form is unmounted after successful submission
-        context.target.setAuthRetry();
-      })
-      .catch((_) => {
-        setLoading(false);
-      });
-  }, [context.target, setLoading, props.onSave, username, password]);
+    props.onSave(username, password);
+  }, [props.onSave, username, password]);
 
   const handleDismiss = React.useCallback(() => {
     // Do not set state as form is unmounted after cancel
@@ -84,9 +73,9 @@ export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) =>
       ({
         spinnerAriaValueText: 'Saving',
         spinnerAriaLabel: 'saving-jmx-credentials',
-        isLoading: loading,
+        isLoading: props.loading,
       } as LoadingPropsType),
-    [loading]
+    [props.loading]
   );
 
   return (
@@ -95,7 +84,7 @@ export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) =>
       <FormGroup isRequired label="Username" fieldId="username">
         <TextInput
           value={username}
-          isDisabled={loading}
+          isDisabled={props.loading}
           isRequired
           type="text"
           id="username"
@@ -107,7 +96,7 @@ export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) =>
       <FormGroup isRequired label="Password" fieldId="password">
         <TextInput
           value={password}
-          isDisabled={loading}
+          isDisabled={props.loading}
           isRequired
           type="password"
           id="password"
@@ -120,11 +109,11 @@ export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) =>
           variant="primary"
           onClick={handleSave}
           {...saveButtonLoadingProps}
-          isDisabled={loading || username === '' || password === ''}
+          isDisabled={props.loading || username === '' || password === ''}
         >
-          {loading ? 'Saving' : 'Save'}
+          {props.loading ? 'Saving' : 'Save'}
         </Button>
-        <Button variant="secondary" onClick={handleDismiss} isDisabled={loading}>
+        <Button variant="secondary" onClick={handleDismiss} isDisabled={props.loading}>
           Cancel
         </Button>
       </ActionGroup>

--- a/src/app/SecurityPanel/Credentials/StoreJmxCredentials.tsx
+++ b/src/app/SecurityPanel/Credentials/StoreJmxCredentials.tsx
@@ -452,7 +452,11 @@ export const StoreJmxCredentials = () => {
     <>
       <TargetCredentialsToolbar />
       {content}
-      <CreateJmxCredentialModal visible={showAuthModal} onClose={handleAuthModalClose} />
+      <CreateJmxCredentialModal
+        visible={showAuthModal}
+        onDismiss={handleAuthModalClose}
+        onSave={handleAuthModalClose}
+      />
     </>
   );
 };

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -260,6 +260,7 @@ export class ApiService {
           body: form,
         }).pipe(
           map((resp) => resp.ok),
+          catchError((_) => of(false)),
           first()
         )
       )
@@ -281,6 +282,7 @@ export class ApiService {
             }
           }),
           map((resp) => resp.status == 200),
+          catchError((_) => of(false)),
           first()
         )
       )
@@ -826,6 +828,7 @@ export class ApiService {
       body,
     }).pipe(
       map((resp) => resp.ok),
+      catchError((_) => of(false)),
       first()
     );
   }

--- a/src/test/SecurityPanel/Credentials/StoreJmxCredentials.test.tsx
+++ b/src/test/SecurityPanel/Credentials/StoreJmxCredentials.test.tsx
@@ -49,6 +49,7 @@ import { Target } from '@app/Shared/Services/Target.service';
 import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 
 import { renderWithServiceContext } from '../../Common';
+import { CreateJmxCredentialModalProps } from '@app/SecurityPanel/Credentials/CreateJmxCredentialModal';
 
 const mockCredential: StoredCredential = {
   id: 0,
@@ -95,13 +96,13 @@ const mockFoundTargetNotification = {
 
 jest.mock('@app/SecurityPanel/Credentials/CreateJmxCredentialModal', () => {
   return {
-    CreateJmxCredentialModal: jest.fn((props) => {
+    CreateJmxCredentialModal: jest.fn((props: CreateJmxCredentialModalProps) => {
       return (
         <Modal
           isOpen={props.visible}
           variant={ModalVariant.large}
           showClose={true}
-          onClose={props.onClose}
+          onClose={props.onDismiss}
           title="CreateJmxCredentialModal"
         >
           Jmx Auth Form


### PR DESCRIPTION
Related to #640 

- Refactored auth form to avoid using promise (previously used for updating form states).
- Added error handlers for recording creation form (was accidentally not committed in #640).
