### PR TITLE
chore(context): add notification context provider

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -44,16 +44,19 @@ import '@app/app.css';
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { Provider } from 'react-redux';
 import { store } from '@app/Shared/Redux/ReduxStore';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const App: React.FunctionComponent = () => (
   <ServiceContext.Provider value={defaultServices}>
-    <Provider store={store}>
-      <Router>
-        <AppLayout>
-          <AppRoutes />
-        </AppLayout>
-      </Router>
-    </Provider>
+    <NotificationsContext.Provider value={NotificationsInstance}>
+      <Provider store={store}>
+        <Router>
+          <AppLayout>
+            <AppRoutes />
+          </AppLayout>
+        </Router>
+      </Provider>
+    </NotificationsContext.Provider>
   </ServiceContext.Provider>
 );
 

--- a/src/test/Agent/AgentLiveProbes.test.tsx
+++ b/src/test/Agent/AgentLiveProbes.test.tsx
@@ -51,6 +51,7 @@ import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { DeleteActiveProbes } from '@app/Modal/DeleteWarningUtils';
 import { AgentLiveProbes } from '@app/Agent/AgentLiveProbes';
 import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };
@@ -142,7 +143,9 @@ describe('<AgentLiveProbes />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <AgentLiveProbes />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <AgentLiveProbes />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Agent/AgentProbeTemplates.test.tsx
+++ b/src/test/Agent/AgentProbeTemplates.test.tsx
@@ -51,6 +51,7 @@ import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { DeleteProbeTemplates } from '@app/Modal/DeleteWarningUtils';
 import { AgentProbeTemplates } from '@app/Agent/AgentProbeTemplates';
 import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockMessageType = { type: 'application', subtype: 'json' } as MessageType;
 
@@ -126,7 +127,9 @@ describe('<AgentProbeTemplates />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <AgentProbeTemplates agentDetected={true} />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <AgentProbeTemplates agentDetected={true} />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Archives/AllArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllArchivedRecordingsTable.test.tsx
@@ -45,6 +45,7 @@ import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.se
 import { AllArchivedRecordingsTable } from '@app/Archives/AllArchivedRecordingsTable';
 import { ArchivedRecording, RecordingDirectory } from '@app/Shared/Services/Api.service';
 import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl1 = 'service:jmx:rmi://someUrl1';
 const mockJvmId1 = 'fooJvmId1';
@@ -184,7 +185,9 @@ describe('<AllArchivedRecordingsTable />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <AllArchivedRecordingsTable />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <AllArchivedRecordingsTable />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
@@ -45,6 +45,7 @@ import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.se
 import { AllTargetsArchivedRecordingsTable } from '@app/Archives/AllTargetsArchivedRecordingsTable';
 import { Target } from '@app/Shared/Services/Target.service';
 import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl1 = 'service:jmx:rmi://someUrl1';
 const mockAlias1 = 'fooTarget1';
@@ -234,7 +235,9 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <AllTargetsArchivedRecordingsTable />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <AllTargetsArchivedRecordingsTable />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Archives/Archives.test.tsx
+++ b/src/test/Archives/Archives.test.tsx
@@ -44,6 +44,7 @@ import { of } from 'rxjs';
 import { Archives } from '@app/Archives/Archives';
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 jest.mock('@app/Recordings/ArchivedRecordingsTable', () => {
   return {
@@ -142,7 +143,9 @@ describe('<Archives />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <Archives />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <Archives />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Common.tsx
+++ b/src/test/Common.tsx
@@ -41,6 +41,7 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { setupStore } from '@app/Shared/Redux/ReduxStore';
 import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
 // userEvent functions are recommended to be called in tests (i.e it()).
@@ -51,10 +52,14 @@ export const renderDefault = (
   ui: React.ReactElement,
   {
     user = userEvent.setup(), // Create a default user session
+    notifications = NotificationsInstance,
     ...renderOptions
   } = {}
 ) => {
-  return { user, ...render(ui, { ...renderOptions }) };
+  const Wrapper = ({ children }: PropsWithChildren<{}>) => {
+    return <NotificationsContext.Provider value={notifications}>{children}</NotificationsContext.Provider>;
+  };
+  return { user, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
 };
 
 export const renderWithReduxStore = (
@@ -63,11 +68,16 @@ export const renderWithReduxStore = (
     preloadState = {},
     store = setupStore(preloadState), // Create a new store instance if no store was passed in
     user = userEvent.setup(), // Create a default user session
+    notifications = NotificationsInstance,
     ...renderOptions
   } = {}
 ) => {
   const Wrapper = ({ children }: PropsWithChildren<{}>) => {
-    return <Provider store={store}>{children}</Provider>;
+    return (
+      <NotificationsContext.Provider value={notifications}>
+        <Provider store={store}>{children}</Provider>
+      </NotificationsContext.Provider>
+    );
   };
   return { store, user, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
 };
@@ -76,12 +86,17 @@ export const renderWithServiceContext = (
   ui: React.ReactElement,
   {
     services = defaultServices,
+    notifications = NotificationsInstance,
     user = userEvent.setup(), // Create a default user session
     ...renderOptions
   } = {}
 ) => {
   const Wrapper = ({ children }: PropsWithChildren<{}>) => {
-    return <ServiceContext.Provider value={services}>{children}</ServiceContext.Provider>;
+    return (
+      <ServiceContext.Provider value={services}>
+        <NotificationsContext.Provider value={notifications}>{children}</NotificationsContext.Provider>
+      </ServiceContext.Provider>
+    );
   };
   return { user, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
 };
@@ -91,14 +106,17 @@ export const renderWithRouter = (
   {
     history = createMemoryHistory({ initialEntries: ['/'] }),
     user = userEvent.setup(), // Create a default user session
+    notifications = NotificationsInstance,
     ...renderOptions
   } = {}
 ) => {
   const Wrapper = ({ children }: PropsWithChildren<{}>) => {
     return (
-      <Router location={history.location} history={history}>
-        {children}
-      </Router>
+      <NotificationsContext.Provider value={notifications}>
+        <Router location={history.location} history={history}>
+          {children}
+        </Router>
+      </NotificationsContext.Provider>
     );
   };
   return { user, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
@@ -110,6 +128,7 @@ export const renderWithServiceContextAndReduxStore = (
     preloadState = {},
     store = setupStore(preloadState), // Create a new store instance if no store was passed in
     services = defaultServices,
+    notifications = NotificationsInstance,
     user = userEvent.setup(), // Create a default user session
     ...renderOptions
   } = {}
@@ -117,7 +136,9 @@ export const renderWithServiceContextAndReduxStore = (
   const Wrapper = ({ children }: PropsWithChildren<{}>) => {
     return (
       <ServiceContext.Provider value={services}>
-        <Provider store={store}>{children}</Provider>
+        <NotificationsContext.Provider value={notifications}>
+          <Provider store={store}>{children}</Provider>
+        </NotificationsContext.Provider>
       </ServiceContext.Provider>
     );
   };
@@ -128,6 +149,7 @@ export const renderWithServiceContextAndRouter = (
   ui: React.ReactElement,
   {
     services = defaultServices,
+    notifications = NotificationsInstance,
     user = userEvent.setup(), // Create a default user session
     history = createMemoryHistory({ initialEntries: ['/'] }),
     ...renderOptions
@@ -136,9 +158,11 @@ export const renderWithServiceContextAndRouter = (
   const Wrapper = ({ children }: PropsWithChildren<{}>) => {
     return (
       <ServiceContext.Provider value={services}>
-        <Router location={history.location} history={history}>
-          {children}
-        </Router>
+        <NotificationsContext.Provider value={notifications}>
+          <Router location={history.location} history={history}>
+            {children}
+          </Router>
+        </NotificationsContext.Provider>
       </ServiceContext.Provider>
     );
   };
@@ -151,6 +175,7 @@ export const renderWithServiceContextAndReduxStoreWithRouter = (
     preloadState = {},
     store = setupStore(preloadState), // Create a new store instance if no store was passed in
     services = defaultServices,
+    notifications = NotificationsInstance,
     user = userEvent.setup(), // Create a default user session
     history = createMemoryHistory({ initialEntries: ['/'] }),
     ...renderOptions
@@ -159,11 +184,13 @@ export const renderWithServiceContextAndReduxStoreWithRouter = (
   const Wrapper = ({ children }: PropsWithChildren<{}>) => {
     return (
       <ServiceContext.Provider value={services}>
-        <Provider store={store}>
-          <Router location={history.location} history={history}>
-            {children}
-          </Router>
-        </Provider>
+        <NotificationsContext.Provider value={notifications}>
+          <Provider store={store}>
+            <Router location={history.location} history={history}>
+              {children}
+            </Router>
+          </Provider>
+        </NotificationsContext.Provider>
       </ServiceContext.Provider>
     );
   };

--- a/src/test/CreateRecording/CustomRecordingForm.test.tsx
+++ b/src/test/CreateRecording/CustomRecordingForm.test.tsx
@@ -53,6 +53,7 @@ jest.mock('@patternfly/react-core', () => ({
 }));
 
 import { CustomRecordingForm } from '@app/CreateRecording/CustomRecordingForm';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };
@@ -102,7 +103,9 @@ describe('<CustomRecordingForm />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <CustomRecordingForm />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <CustomRecordingForm />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Dashboard/Dashboard.test.tsx
+++ b/src/test/Dashboard/Dashboard.test.tsx
@@ -42,6 +42,7 @@ import React from 'react';
 import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
 import { Target } from '@app/Shared/Services/Target.service';
 import { of } from 'rxjs';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockFooConnectUrl = 'service:jmx:rmi://someFooUrl';
 // Test fails if new Map([['REALM', 'Custom Targets']]) is used, most likely since 'cryostat' Map is not being utilized
@@ -70,7 +71,9 @@ describe('<Dashboard />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <Dashboard></Dashboard>
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <Dashboard />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Dashboard/Dashboard.test.tsx
+++ b/src/test/Dashboard/Dashboard.test.tsx
@@ -45,13 +45,13 @@ import { of } from 'rxjs';
 import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockFooConnectUrl = 'service:jmx:rmi://someFooUrl';
-// Test fails if new Map([['REALM', 'Custom Targets']]) is used, most likely since 'cryostat' Map is not being utilized
+
 const mockFooTarget: Target = {
   connectUrl: mockFooConnectUrl,
   alias: 'fooTarget',
   annotations: {
-    cryostat: new Map(),
-    platform: new Map(),
+    cryostat: {},
+    platform: {},
   },
 };
 

--- a/src/test/Events/EventTemplates.test.tsx
+++ b/src/test/Events/EventTemplates.test.tsx
@@ -47,6 +47,7 @@ import { EventTemplates } from '@app/Events/EventTemplates';
 import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
 import { TargetService } from '@app/Shared/Services/Target.service';
 import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };
@@ -123,7 +124,9 @@ describe('<EventTemplates />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <EventTemplates />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <EventTemplates />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Events/EventTypes.test.tsx
+++ b/src/test/Events/EventTypes.test.tsx
@@ -44,6 +44,7 @@ import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/
 import { TargetService } from '@app/Shared/Services/Target.service';
 import { EventType, EventTypes } from '@app/Events/EventTypes';
 import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };
@@ -68,7 +69,9 @@ describe('<EventTypes />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <EventTypes />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <EventTypes />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/RecordingMetadata.tsx/BulkEditLabels.test.tsx
+++ b/src/test/RecordingMetadata.tsx/BulkEditLabels.test.tsx
@@ -45,6 +45,7 @@ import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { ActiveRecording, ArchivedRecording, RecordingState } from '@app/Shared/Services/Api.service';
 import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
 import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 jest.mock('@patternfly/react-core', () => ({
   ...jest.requireActual('@patternfly/react-core'),
@@ -144,7 +145,9 @@ describe('<BulkEditLabels />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <BulkEditLabels checkedIndices={activeCheckedIndices} isTargetRecording={true} />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <BulkEditLabels checkedIndices={activeCheckedIndices} isTargetRecording={true} />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Recordings/Recordings.test.tsx
+++ b/src/test/Recordings/Recordings.test.tsx
@@ -44,6 +44,7 @@ import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { Recordings } from '@app/Recordings/Recordings';
 import { Target } from '@app/Shared/Services/Target.service';
 import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 jest.mock('@app/Recordings/ActiveRecordingsTable', () => {
   return {
@@ -149,7 +150,9 @@ describe('<Recordings />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <Recordings />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <Recordings />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -49,6 +49,7 @@ import { EventTemplate } from '@app/CreateRecording/CreateRecording';
 import { Target, TargetService } from '@app/Shared/Services/Target.service';
 import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
 import { renderWithServiceContextAndReduxStoreWithRouter, renderWithServiceContextAndRouter } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const escapeKeyboardInput = (value: string) => {
   return value.replace(/[{[]/g, '$&$&');
@@ -121,9 +122,11 @@ describe('<CreateRule />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <Router location={history.location} history={history}>
-            <CreateRule />
-          </Router>
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <Router location={history.location} history={history}>
+              <CreateRule />
+            </Router>
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -52,6 +52,7 @@ import {
 } from '@app/Shared/Services/NotificationChannel.service';
 import { DeleteAutomatedRules, DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
 import { renderWithServiceContextAndRouter } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockRule: Rule = {
   name: 'mockRule',
@@ -137,9 +138,11 @@ describe('<Rules />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <Router location={history.location} history={history}>
-            <Rules />
-          </Router>
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <Router location={history.location} history={history}>
+              <Rules />
+            </Router>
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/SecurityPanel/Credentials/StoreJmxCredentials.test.tsx
+++ b/src/test/SecurityPanel/Credentials/StoreJmxCredentials.test.tsx
@@ -50,6 +50,7 @@ import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 
 import { renderWithServiceContext } from '../../Common';
 import { CreateJmxCredentialModalProps } from '@app/SecurityPanel/Credentials/CreateJmxCredentialModal';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockCredential: StoredCredential = {
   id: 0,
@@ -198,7 +199,9 @@ describe('<StoreJmxCredentials />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <StoreJmxCredentials />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <StoreJmxCredentials />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Settings/CredentialsStorage.test.tsx
+++ b/src/test/Settings/CredentialsStorage.test.tsx
@@ -95,8 +95,8 @@ describe('<CredentialsStorage/>', () => {
 
     // the default is Backend storage. Click the dropdown and select Session (Browser Memory) to change selection
     const ul = await screen.findByRole('listbox');
-    const backend = within(ul).getByText(sessionStorageValue);
-    await user.click(backend);
+    const browserSession = within(ul).getByText(sessionStorageValue);
+    await user.click(browserSession);
 
     await waitFor(() => expect(ul).not.toBeVisible()); // expect selection menu to close after user clicks an option
 

--- a/src/test/TargetSelect/TargetSelect.test.tsx
+++ b/src/test/TargetSelect/TargetSelect.test.tsx
@@ -45,6 +45,7 @@ import { CUSTOM_TARGETS_REALM, TargetSelect } from '@app/TargetSelect/TargetSele
 import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
 import { Target } from '@app/Shared/Services/Target.service';
 import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockFooConnectUrl = 'service:jmx:rmi://someFooUrl';
 const mockBarConnectUrl = 'service:jmx:rmi://someBarUrl';
@@ -121,7 +122,9 @@ describe('<TargetSelect />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <TargetSelect />
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <TargetSelect />
+          </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );
     });


### PR DESCRIPTION
Fixes #610 

Added Notification context provider so that `useContext` will pull from there. For tests, custom render functions are now wrapped in this provider.