### PR TITLE
fix(create-recordings): add error-views and refactor target listener

### DIFF
--- a/src/app/ErrorView/ErrorView.tsx
+++ b/src/app/ErrorView/ErrorView.tsx
@@ -49,6 +49,9 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 export const authFailMessage = 'Auth failure';
+
+export const missingSSLMessage = 'Missing SSL Certificates';
+
 export const isAuthFail = (message: string) => message === authFailMessage;
 export interface ErrorViewProps {
   title: string | React.ReactNode;

--- a/src/app/ErrorView/ErrorView.tsx
+++ b/src/app/ErrorView/ErrorView.tsx
@@ -50,7 +50,7 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 export const authFailMessage = 'Auth failure';
 
-export const missingSSLMessage = 'Missing SSL Certificates';
+export const missingSSLMessage = 'Bad Gateway';
 
 export const isAuthFail = (message: string) => message === authFailMessage;
 export interface ErrorViewProps {

--- a/src/test/CreateRecording/SnapshotRecordingForm.test.tsx
+++ b/src/test/CreateRecording/SnapshotRecordingForm.test.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import * as React from 'react';
+import { createMemoryHistory } from 'history';
+import { screen, cleanup, act as doAct } from '@testing-library/react';
+import renderer, { act } from 'react-test-renderer';
+import { ServiceContext, Services } from '@app/Shared/Services/Services';
+import { defaultServices } from '@app/Shared/Services/Services';
+import { of, Subject } from 'rxjs';
+import { renderWithServiceContext } from '../Common';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
+import { TargetService } from '@app/Shared/Services/Target.service';
+import { SnapshotRecordingForm } from '@app/CreateRecording/SnapshotRecordingForm';
+
+const mockConnectUrl = 'service:jmx:rmi://someUrl';
+const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };
+
+const history = createMemoryHistory({ initialEntries: ['/recordings/create'] });
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useRouteMatch: () => ({ url: history.location.pathname }),
+  useHistory: () => history,
+}));
+
+jest.spyOn(defaultServices.target, 'authFailure').mockReturnValue(of());
+jest.spyOn(defaultServices.target, 'target').mockReturnValue(of(mockTarget));
+jest.spyOn(defaultServices.target, 'sslFailure').mockReturnValue(of());
+jest.spyOn(defaultServices.target, 'authRetry').mockReturnValue(of());
+
+describe('<SnapshotRecordingForm />', () => {
+  beforeEach(() => {
+    history.go(-history.length);
+  });
+
+  afterEach(cleanup);
+
+  it('renders correctly', async () => {
+    let tree;
+    await act(async () => {
+      tree = renderer.create(
+        <ServiceContext.Provider value={defaultServices}>
+          <NotificationsContext.Provider value={NotificationsInstance}>
+            <SnapshotRecordingForm />
+          </NotificationsContext.Provider>
+        </ServiceContext.Provider>
+      );
+    });
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  it('should create recording when create is clicked', async () => {
+    const onCreateSpy = jest.spyOn(defaultServices.api, 'createSnapshot').mockReturnValue(of(true));
+    const { user } = renderWithServiceContext(<SnapshotRecordingForm />);
+
+    const createButton = screen.getByText('Create');
+    expect(createButton).toBeInTheDocument();
+    expect(createButton).toBeVisible();
+
+    await user.click(createButton);
+
+    expect(onCreateSpy).toHaveBeenCalledTimes(1);
+    expect(history.entries.map((entry) => entry.pathname)).toStrictEqual(['/recordings/create', '/recordings']);
+  });
+
+  it('should show error view if failing to retrieve templates or recording options', async () => {
+    const authSubj = new Subject<void>();
+    const mockTargetSvc = {
+      ...defaultServices.target,
+      authFailure: () => authSubj.asObservable(),
+    } as TargetService;
+    const services: Services = {
+      ...defaultServices,
+      target: mockTargetSvc,
+    };
+    renderWithServiceContext(<SnapshotRecordingForm />, { services: services });
+
+    await doAct(async () => authSubj.next());
+
+    const failTitle = screen.getByText('Error displaying recording creation form');
+    expect(failTitle).toBeInTheDocument();
+    expect(failTitle).toBeVisible();
+
+    const authFailText = screen.getByText('Auth failure');
+    expect(authFailText).toBeInTheDocument();
+    expect(authFailText).toBeVisible();
+
+    const retryButton = screen.getByText('Retry');
+    expect(retryButton).toBeInTheDocument();
+    expect(retryButton).toBeVisible();
+  });
+});

--- a/src/test/CreateRecording/__snapshots__/SnapshotRecordingForm.test.tsx.snap
+++ b/src/test/CreateRecording/__snapshots__/SnapshotRecordingForm.test.tsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SnapshotRecordingForm /> renders correctly 1`] = `
+<form
+  className="pf-c-form pf-m-horizontal"
+  noValidate={true}
+>
+  <p
+    className=""
+    data-ouia-component-id="OUIA-Generated-Text-1"
+    data-ouia-component-type="PF4/Text"
+    data-ouia-safe={true}
+    data-pf-content={true}
+  >
+    A Snapshot recording is one which contains all information about all events that have been captured in the current session by 
+    <i>
+      other,  non-Snapshot
+    </i>
+     recordings. Snapshots do not themselves define which events are enabled, their thresholds, or any other options. A Snapshot is only ever in the STOPPED state from the moment it is created.
+  </p>
+  <div
+    className="pf-c-form__group pf-m-action"
+  >
+    <div
+      className="pf-c-form__group-control"
+    >
+      <div
+        className="pf-c-form__actions"
+      >
+        <button
+          aria-disabled={false}
+          aria-label={null}
+          className="pf-c-button pf-m-primary pf-m-progress"
+          data-ouia-component-id="OUIA-Generated-Button-primary-1"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe={true}
+          disabled={false}
+          onClick={[Function]}
+          role={null}
+          type="button"
+        >
+          Create
+        </button>
+        <button
+          aria-disabled={false}
+          aria-label={null}
+          className="pf-c-button pf-m-secondary"
+          data-ouia-component-id="OUIA-Generated-Button-secondary-1"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe={true}
+          disabled={false}
+          onClick={[Function]}
+          role={null}
+          type="button"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+</form>
+`;


### PR DESCRIPTION
Fixed #673 
Fixed #686 

The following fixes were applied:

- [x] Add a missing error view to `CustomRecordingForm`.
- [x] Add a missing error view to `SnapShotRecordingForm` (only auth failure and ssl error will show).
- [x] Refactor target selection listener of `CustomRecordingForm` to update UI when the target selection is changed.

Others:
- [x] Add unit tests for `SnapShotRecordingForm`.