### PR TITLE
feat(uploads): allow users to upload multiple files

### DIFF
--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -146,17 +146,14 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
       };
     });
     addSubscription(
-      context.api
-        .removeProbes()
-        .pipe(first())
-        .subscribe(() => {
-          setActionLoadings((old) => {
-            return {
-              ...old,
-              REMOVE: false,
-            };
-          });
-        })
+      context.api.removeProbes().subscribe(() => {
+        setActionLoadings((old) => {
+          return {
+            ...old,
+            REMOVE: false,
+          };
+        });
+      })
     );
   }, [addSubscription, context.api, setActionLoadings]);
 

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -35,53 +35,53 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { ServiceContext } from '@app/Shared/Services/Services';
+import { CreateRecordingProps } from '@app/CreateRecording/CreateRecording';
+import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
+import { LoadingView } from '@app/LoadingView/LoadingView';
+import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
+import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { FUpload, MultiFileUpload, UploadCallbacks } from '@app/Shared/FileUploads';
+import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 import { EventTemplate } from '@app/Shared/Services/Api.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   ActionGroup,
   Button,
-  FileUpload,
+  EmptyState,
+  EmptyStateIcon,
   Form,
   FormGroup,
   Modal,
   ModalVariant,
+  TextInput,
+  Title,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  TextInput,
-  EmptyState,
-  EmptyStateIcon,
-  Title,
 } from '@patternfly/react-core';
 import { SearchIcon, UploadIcon } from '@patternfly/react-icons';
 import {
-  TableVariant,
+  ActionsColumn,
   IAction,
   ISortBy,
   SortByDirection,
   TableComposable,
-  Thead,
+  TableVariant,
   Tbody,
-  Tr,
-  Th,
-  ThProps,
   Td,
-  ActionsColumn,
+  Th,
+  Thead,
+  ThProps,
+  Tr,
 } from '@patternfly/react-table';
+import * as React from 'react';
 import { useHistory } from 'react-router-dom';
-import { concatMap, filter, first } from 'rxjs/operators';
-import { LoadingView } from '@app/LoadingView/LoadingView';
-import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
-import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
-import { NotificationsContext } from '@app/Notifications/Notifications';
-import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
-import { CreateRecordingProps } from '@app/CreateRecording/CreateRecording';
+import { forkJoin, Observable, of } from 'rxjs';
+import { catchError, concatMap, defaultIfEmpty, filter, first, tap } from 'rxjs/operators';
 
 export interface EventTemplatesProps {}
 
@@ -361,6 +361,7 @@ export const EventTemplates: React.FunctionComponent<EventTemplatesProps> = (pro
               <ToolbarItem>
                 <Button
                   key="upload"
+                  aria-label="Upload"
                   variant="secondary"
                   onClick={handleUploadModalOpen}
                   isDisabled={errorMessage != ''}
@@ -410,61 +411,80 @@ export interface EventTemplatesUploadModalProps {
 }
 
 export const EventTemplatesUploadModal: React.FunctionComponent<EventTemplatesUploadModalProps> = (props) => {
-  const [uploadFile, setUploadFile] = React.useState<File | undefined>(undefined);
-  const [uploadFilename, setUploadFilename] = React.useState('');
-  const [uploading, setUploading] = React.useState(false);
-  const [fileRejected, setFileRejected] = React.useState(false);
   const addSubscription = useSubscriptions();
   const context = React.useContext(ServiceContext);
-  const notifications = React.useContext(NotificationsContext);
+  const submitRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to submit trigger div
+  const abortRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to abort trigger div
+
+  const [numOfFiles, setNumOfFiles] = React.useState(0);
+  const [allOks, setAllOks] = React.useState(false);
+  const [uploading, setUploading] = React.useState(false);
 
   const reset = React.useCallback(() => {
-    setUploadFile(undefined);
-    setUploadFilename('');
+    setNumOfFiles(0);
     setUploading(false);
-    setFileRejected(false);
-  }, [setUploadFile, setUploadFilename, setUploading, setFileRejected]);
+  }, [setNumOfFiles, setUploading]);
 
   const handleClose = React.useCallback(() => {
-    reset();
-    props.onClose();
-  }, [reset, props.onClose]);
+    if (uploading) {
+      abortRef.current && abortRef.current.click();
+    } else {
+      reset();
+      props.onClose();
+    }
+  }, [uploading, abortRef.current, reset, props.onClose]);
 
-  const handleFileRejected = React.useCallback(() => {
-    setFileRejected(true);
-  }, [setFileRejected]);
+  const onFileSubmit = React.useCallback(
+    (fileUploads: FUpload[], { getProgressUpdateCallback, onSingleSuccess, onSingleFailure }: UploadCallbacks) => {
+      setUploading(true);
 
-  const handleFileChange = React.useCallback(
-    (file, filename) => {
-      setFileRejected(false);
-      setUploadFile(file);
-      setUploadFilename(filename);
+      const tasks: Observable<boolean>[] = [];
+
+      fileUploads.forEach((fileUpload) => {
+        tasks.push(
+          context.api
+            .addCustomEventTemplate(
+              fileUpload.file,
+              getProgressUpdateCallback(fileUpload.file.name),
+              fileUpload.abortSignal
+            )
+            .pipe(
+              tap({
+                next: (_) => {
+                  onSingleSuccess(fileUpload.file.name);
+                },
+                error: (err) => {
+                  onSingleFailure(fileUpload.file.name, err);
+                },
+              }),
+              catchError((_) => of(false))
+            )
+        );
+      });
+
+      addSubscription(
+        forkJoin(tasks)
+          .pipe(defaultIfEmpty([true]))
+          .subscribe((oks) => {
+            setUploading(false);
+            setAllOks(oks.reduce((prev, curr, _) => prev && curr, true));
+          })
+      );
     },
-    [setFileRejected, setUploadFile, setUploadFilename]
+    [setUploading, addSubscription, context.api, handleClose, setAllOks]
   );
 
-  const handleUploadSubmit = React.useCallback(() => {
-    if (fileRejected) {
-      notifications.warning('File format is not compatible');
-      return;
-    }
-    if (!uploadFile) {
-      notifications.warning('Attempted to submit template upload without a file selected');
-      return;
-    }
-    setUploading(true);
-    addSubscription(
-      context.api
-        .addCustomEventTemplate(uploadFile)
-        .pipe(first())
-        .subscribe((success) => {
-          setUploading(false);
-          if (success) {
-            handleClose();
-          }
-        })
-    );
-  }, [fileRejected, uploadFile, window.console, setUploading, addSubscription, context.api, handleClose]);
+  const handleSubmit = React.useCallback(() => {
+    submitRef.current && submitRef.current.click();
+  }, [submitRef.current]);
+
+  const onFilesChange = React.useCallback(
+    (fileUploads: FUpload[]) => {
+      setAllOks(!fileUploads.some((f) => !f.progress || f.progress.progressVariant !== 'success'));
+      setNumOfFiles(fileUploads.length);
+    },
+    [setNumOfFiles, setAllOks]
+  );
 
   const submitButtonLoadingProps = React.useMemo(
     () =>
@@ -480,39 +500,42 @@ export const EventTemplatesUploadModal: React.FunctionComponent<EventTemplatesUp
     <Modal
       isOpen={props.isOpen}
       variant={ModalVariant.large}
-      showClose={!uploading}
+      showClose={true}
       onClose={handleClose}
       title="Create Custom Event Template"
       description="Create a customized event template. This is a specialized XML file with the extension .jfc, typically created using JDK Mission Control, which defines a set of events and their options to configure. Not all customized templates are applicable to all targets -- a template may specify a custom application event type, which is only available in targets running the associated application."
     >
       <Form>
-        <FormGroup label="Template XML" isRequired fieldId="template" validated={fileRejected ? 'error' : 'default'}>
-          <FileUpload
-            id="template-file-upload"
-            value={uploadFile}
-            filename={uploadFilename}
-            onChange={handleFileChange}
-            isDisabled={uploading}
-            isLoading={uploading}
-            validated={fileRejected ? 'error' : 'default'}
-            dropzoneProps={{
-              accept: '.xml,.jfc',
-              onDropRejected: handleFileRejected,
-            }}
+        <FormGroup label="Template XML" isRequired fieldId="template">
+          <MultiFileUpload
+            submitRef={submitRef}
+            abortRef={abortRef}
+            uploading={uploading}
+            displayAccepts={['XML', 'JFC']}
+            onFileSubmit={onFileSubmit}
+            onFilesChange={onFilesChange}
           />
         </FormGroup>
         <ActionGroup>
-          <Button
-            variant="primary"
-            onClick={handleUploadSubmit}
-            isDisabled={!uploadFilename || uploading}
-            {...submitButtonLoadingProps}
-          >
-            {uploading ? 'Submitting' : 'Submit'}
-          </Button>
-          <Button variant="link" onClick={handleClose} isDisabled={uploading}>
-            Cancel
-          </Button>
+          {allOks && numOfFiles ? (
+            <Button variant="primary" onClick={handleClose}>
+              Close
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="primary"
+                onClick={handleSubmit}
+                isDisabled={!numOfFiles || uploading}
+                {...submitButtonLoadingProps}
+              >
+                {uploading ? 'Submitting' : 'Submit'}
+              </Button>
+              <Button variant="link" onClick={handleClose}>
+                Cancel
+              </Button>
+            </>
+          )}
         </ActionGroup>
       </Form>
     </Modal>

--- a/src/app/Modal/CancelUploadModal.tsx
+++ b/src/app/Modal/CancelUploadModal.tsx
@@ -56,10 +56,10 @@ export const CancelUploadModal: React.FunctionComponent<CancelUploadModalProps> 
       onClose={props.onNo}
       title={props.title}
       actions={[
-        <Button variant="primary" onClick={props.onYes}>
+        <Button key={'Yes'} variant="primary" onClick={props.onYes}>
           Yes
         </Button>,
-        <Button variant="secondary" onClick={props.onNo}>
+        <Button key={'No'} variant="secondary" onClick={props.onNo}>
           No
         </Button>,
       ]}

--- a/src/app/Shared/FileUploads.tsx
+++ b/src/app/Shared/FileUploads.tsx
@@ -1,0 +1,328 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { CancelUploadModal } from '@app/Modal/CancelUploadModal';
+import { NotificationsContext } from '@app/Notifications/Notifications';
+import {
+  MultipleFileUpload,
+  MultipleFileUploadMain,
+  MultipleFileUploadStatus,
+  MultipleFileUploadStatusItem,
+} from '@patternfly/react-core';
+import { InProgressIcon, UploadIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { Prompt } from 'react-router-dom';
+import { Subject } from 'rxjs';
+
+export type ProgressVariant = 'success' | 'danger' | 'warning';
+
+export interface FUpload {
+  file: File;
+  abortSignal: Subject<void>;
+  progress?: {
+    progressValue: number;
+    progressVariant: ProgressVariant;
+  };
+  helperText?: string;
+  error?: Error; // error.message take precedence over helperText
+}
+
+export interface UploadCallbacks {
+  getProgressUpdateCallback: (filename: string) => (progress: number | string) => void;
+  onSingleSuccess: (filename: string) => void;
+  onSingleFailure: (filename: string, error: Error) => void;
+}
+
+export interface MultiFileUploadProps {
+  submitRef?: React.RefObject<HTMLDivElement>;
+  abortRef?: React.RefObject<HTMLDivElement>;
+  uploading: boolean;
+  displayAccepts: String[];
+  dropZoneAccepts?: String[]; // Infer from displayAccepts, if not specified
+  onFilesChange?: (files: FUpload[]) => void;
+  onFileSubmit: (fileUploads: FUpload[], uploadCallbacks: UploadCallbacks) => void;
+  titleIcon?: React.ReactNode;
+  titleText?: React.ReactNode;
+  titleTextSeparator?: React.ReactNode;
+  infoText?: React.ReactNode;
+}
+
+export const MultiFileUpload: React.FunctionComponent<MultiFileUploadProps> = ({
+  titleIcon,
+  titleText,
+  titleTextSeparator,
+  infoText,
+  displayAccepts,
+  dropZoneAccepts,
+  onFileSubmit,
+  uploading,
+  onFilesChange,
+  submitRef,
+  abortRef,
+}) => {
+  const notifications = React.useContext(NotificationsContext);
+  const [fileUploads, setFileUploads] = React.useState<FUpload[]>([]);
+  const [showCancelPrompt, setShowCancelPrompt] = React.useState(false);
+
+  const dzAccept = React.useMemo(() => {
+    if (dropZoneAccepts && dropZoneAccepts.length) {
+      return dropZoneAccepts.join(',');
+    }
+    return displayAccepts.map((t) => `.${t.toLocaleLowerCase()}`).join(',');
+  }, [dropZoneAccepts, displayAccepts]);
+
+  const handleFileDrop = React.useCallback(
+    (droppedFiles: File[]) => {
+      setFileUploads((old) => {
+        // Check for re-uploads
+        const currentFilenames = old.map((fileUpload) => fileUpload.file.name);
+        const reUploadFilenames = droppedFiles.filter((f) => currentFilenames.includes(f.name)).map((f) => f.name);
+
+        const newFileUploads = [
+          ...old.filter((fileUpload) => !reUploadFilenames.includes(fileUpload.file.name)),
+          ...droppedFiles.map(
+            (f) =>
+              ({
+                file: f,
+                abortSignal: new Subject<void>(),
+              } as FUpload)
+          ),
+        ];
+        onFilesChange && onFilesChange(newFileUploads);
+        return newFileUploads;
+      });
+    },
+    [setFileUploads, onFilesChange]
+  );
+
+  const handleFileReject = React.useCallback(
+    (rejectedFiles: File[]) => {
+      rejectedFiles.forEach((f) => {
+        if (!dzAccept.includes(f.type) || f.type === '') {
+          const message = `Expected file format: ${dzAccept}, but received ${
+            f.type === '' ? 'unknown type' : f.type
+          } for ${f.name}`;
+          notifications.warning(`Incompatible file format`, message);
+        } else {
+          notifications.warning(`Failed to load file`, f.name);
+        }
+      });
+    },
+    [notifications, dzAccept]
+  );
+
+  const handleFileRemove = React.useCallback(
+    (removedFilename: string, abort = false) => {
+      if (abort) {
+        const fileToAbort = fileUploads.find((fileUpload) => fileUpload.file.name === removedFilename);
+        fileToAbort?.abortSignal.next();
+      } else {
+        setFileUploads((old) => {
+          const newFileUploads = old.filter((fileUpload) => fileUpload.file.name !== removedFilename);
+          onFilesChange && onFilesChange(newFileUploads);
+          return newFileUploads;
+        });
+      }
+    },
+    [fileUploads, setFileUploads, onFilesChange]
+  );
+
+  const getProgressUpdateCallback = React.useCallback(
+    (filename: string) => {
+      return (progress: string | number) => {
+        setFileUploads((old) => {
+          const match = old.find((f) => f.file.name === filename);
+          if (match) {
+            return [
+              ...old.filter((f) => f.file.name !== filename),
+              {
+                ...match,
+                progress: {
+                  progressValue: progress,
+                  progressVariant: `${progress}` == '100' ? 'success' : undefined,
+                },
+              } as FUpload,
+            ];
+          }
+          return old;
+        });
+      };
+    },
+    [setFileUploads]
+  );
+
+  const onSingleFailure = React.useCallback(
+    (filename: string, error: Error) => {
+      setFileUploads((old) => {
+        const match = old.find((f) => f.file.name === filename);
+        if (match) {
+          return [
+            ...old.filter((f) => f.file.name !== filename),
+            {
+              ...match,
+              progress: {
+                progressValue: match.progress?.progressValue || 0,
+                progressVariant: 'danger',
+              },
+              error: error,
+            } as FUpload,
+          ];
+        }
+        return old;
+      });
+    },
+    [setFileUploads]
+  );
+
+  const onSingleSuccess = React.useCallback(
+    (filename: String) => {
+      setFileUploads((old) => {
+        const match = old.find((f) => f.file.name === filename);
+        if (match) {
+          return [
+            ...old.filter((f) => f.file.name !== filename),
+            {
+              ...match,
+              progress: {
+                progressValue: 100,
+                progressVariant: 'success',
+              },
+            } as FUpload,
+          ];
+        }
+        return old;
+      });
+    },
+    [setFileUploads]
+  );
+
+  const handleSubmit = React.useCallback(() => {
+    setFileUploads((old) => {
+      const toUploads = old.filter((f) => f.error || !f.progress); // Failed or newly uploaded
+      onFileSubmit(toUploads, { getProgressUpdateCallback, onSingleSuccess, onSingleFailure });
+
+      const newFileUploads = old.map(
+        (f) =>
+          ({
+            ...f,
+            error: undefined,
+            progress: f.progress?.progressVariant === 'success' ? f.progress : undefined,
+            helperText: f.progress?.progressVariant === 'success' ? 'Already uploaded' : undefined,
+          } as FUpload)
+      );
+      return newFileUploads;
+    });
+  }, [onFileSubmit, getProgressUpdateCallback, onSingleSuccess, onSingleFailure]);
+
+  const handleCloseCancelModal = React.useCallback(() => setShowCancelPrompt(false), [setShowCancelPrompt]);
+
+  const handleOpenCancelModal = React.useCallback(() => setShowCancelPrompt(true), [setShowCancelPrompt]);
+
+  const handleAbortAll = React.useCallback(() => {
+    fileUploads
+      .filter((fileUpload) => !fileUpload.progress?.progressVariant)
+      .map((fileUpload) => {
+        fileUpload.abortSignal.next(); // trigger abort
+      });
+
+    handleCloseCancelModal();
+  }, [fileUploads, handleCloseCancelModal]);
+
+  const handleCancel = React.useCallback(() => {
+    if (uploading) {
+      handleOpenCancelModal();
+    }
+  }, [handleOpenCancelModal, uploading]);
+
+  const numOfSuccessUploads = React.useMemo(() => {
+    return fileUploads.filter((fUpload) => fUpload.progress && fUpload.progress.progressVariant === 'success').length;
+  }, [fileUploads]);
+
+  const sortedFileUploads = React.useMemo(() => {
+    return fileUploads.sort((a, b) => a.file.name.localeCompare(b.file.name, undefined, { numeric: true }));
+  }, [fileUploads]);
+
+  return (
+    <>
+      <Prompt when={uploading} message="Are you sure you wish to cancel the file upload?" />
+      <CancelUploadModal
+        visible={showCancelPrompt}
+        title="Upload in Progress"
+        message="Are you sure you wish to cancel the file uploads? Successfully uploaded files won't be aborted."
+        onYes={handleAbortAll}
+        onNo={handleCloseCancelModal}
+      />
+      <MultipleFileUpload
+        onFileDrop={handleFileDrop}
+        dropzoneProps={{
+          accept: dzAccept,
+          onDropRejected: handleFileReject,
+        }}
+        disabled={uploading}
+      >
+        <MultipleFileUploadMain
+          titleIcon={titleIcon || <UploadIcon />}
+          titleText={titleText || 'Drag and drop files here'}
+          titleTextSeparator={titleTextSeparator || 'or'}
+          infoText={infoText || `Accepted file types: ${displayAccepts.join(', ')}`}
+        />
+        {fileUploads.length ? (
+          <MultipleFileUploadStatus
+            statusToggleText={`${numOfSuccessUploads} of ${fileUploads.length} files uploaded`}
+            statusToggleIcon={<InProgressIcon />}
+          >
+            {sortedFileUploads.map((fileUpload) => (
+              <MultipleFileUploadStatusItem
+                file={fileUpload.file}
+                key={fileUpload.file.name}
+                onClearClick={() => handleFileRemove(fileUpload.file.name, uploading)}
+                customFileHandler={(_) => {}} // To disable built-in file reader and default styling
+                progressValue={fileUpload.progress?.progressValue}
+                progressVariant={fileUpload.progress?.progressVariant}
+                progressHelperText={fileUpload.error?.message || fileUpload.helperText}
+              />
+            ))}
+          </MultipleFileUploadStatus>
+        ) : undefined}
+      </MultipleFileUpload>
+      {/* fake action buttons */}
+      <div ref={submitRef} id={'start-upload-files'} hidden onClick={handleSubmit} />
+      <div ref={abortRef} id={'abort-upload-files'} hidden onClick={handleCancel} />
+    </>
+  );
+};

--- a/src/test/Events/__snapshots__/EventTemplates.test.tsx.snap
+++ b/src/test/Events/__snapshots__/EventTemplates.test.tsx.snap
@@ -49,7 +49,7 @@ Array [
           >
             <button
               aria-disabled={false}
-              aria-label={null}
+              aria-label="Upload"
               className="pf-c-button pf-m-secondary"
               data-ouia-component-id="OUIA-Generated-Button-secondary-1"
               data-ouia-component-type="PF4/Button"


### PR DESCRIPTION
Fixes #613 
Partially solved #651 
Related to #607 
Depends on #684 (need that refactoring of upload modals)
Depends on #708 (refresh causes modal to close unexpectedly)
Depends on https://github.com/cryostatio/cryostat/pull/1273 (backend for #708)


The following upload modals now allow multiple uploads. Each file initiates a separate api request.

- [x] Automatic Rules
- [x] Event Templates
- [x] Agent Templates
- [x] Archives
- [x] SSL Certificates
- [x] Metadata Files (fixed in #607)

One issue is that fetch API does not have support for upload progress yet (or only certain browser versions have support). To work around this, I "mirrored" the current `sendRequest` to one that uses `XMLHttpRequest`. This way we can take advantage of upload progress and guarantee support from most browsers. 

Also, by using XMLHttpRequest, we can no longer use `AbortController` for aborting. Aborting mechanisms need investigating and adding back in #651 

**Other fixes and chores**
- [x] Use forkJoin to join multiple api calls instead of zip (will be deprecated later).
- [x] Clean up api call handlers (i.e. internally calls first(), remove unneeded notification, add missing error catch).
- [x] Add missing tests for uploading custom event template.

**How it looks**

![multi-file-upload-demo](https://user-images.githubusercontent.com/68053619/204058875-b0d7af01-652d-4c33-a7ed-fcc8f240b1fe.png)

