### PR TITLE
chore(mergify): revert mergify to stop automatically adding needs-triage label

### DIFF
--- a/.github/.labeler.yml
+++ b/.github/.labeler.yml
@@ -1,0 +1,2 @@
+needs-triage:
+- '*'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,15 @@
+name: Label pull request
+
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,3 +13,4 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,11 +9,3 @@ pull_request_rules:
           - cryostat-v2.2
         assignees:
           - "{{ author }}"
-
-  - name: auto label PRs from non-reviewers
-    conditions:
-      - author!=@reviewers
-    actions:
-      label:
-        add:
-          - needs-triage


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #696

## Description of the change:
This change reverts mergify from adding the needs triage label to pull requests.

## Motivation for the change:
Mergify kept adding the label, which failed the CI, but removing the label would cause Mergify to add it back.

## How to manually test:
1. Start a pull request as a non-cryostat-reviewer. 
2. Notice that mergify doesn't add the label anymore.
