### PR TITLE
chore(requests): allow skipping status code check

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -866,7 +866,8 @@ export class ApiService {
     apiVersion: ApiVersion,
     path: string,
     config?: RequestInit,
-    suppressNotifications = false
+    suppressNotifications = false,
+    skipStatusCheck = false
   ): Observable<Response> {
     const req = () =>
       this.login.getHeaders().pipe(
@@ -892,7 +893,12 @@ export class ApiService {
           if (resp.ok) return resp;
           throw new HttpError(resp);
         }),
-        catchError((err) => this.handleError<Response>(err, req, suppressNotifications))
+        catchError((err) => {
+          if (skipStatusCheck) {
+            throw err;
+          }
+          return this.handleError<Response>(err, req, suppressNotifications);
+        })
       );
     return req();
   }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/pull/1257
Depends on #699 (updating ci)

## Description of the change:

This added a parameter to `sendRequest` function in Api.services to allow skipping status code check (i.e. internal error handler).

## Motivation for the change:

Since https://github.com/cryostatio/cryostat/pull/1257, target creation now allows `dryrun`. Auth failure (i.e. status 427) during `dryrun` should not trigger Auth modal, which is the default behaviour. This flag will allow disable this behaviour if needed.

## How to manually test:

Not yet used anywhere until #592.