### PR TITLE
fix(ci): add new workflow which checks if needs-triage is not present

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,18 @@
+name: Check labels not applied
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+
+jobs:
+  check-needs-triage-not-applied:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if needs-triage label applied
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'needs-triage')}}
+        run: exit 1
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   build:
+    needs: [check-labels]
 
     runs-on: ubuntu-latest
 
@@ -24,9 +25,6 @@ jobs:
         node-version: [14.x]
 
     steps:
-    - name: Fail if needs-triage label applied
-      if: ${{ contains(github.event.pull_request.labels.*.name, 'needs-triage')}}
-      run: exit 1
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ on:
 
 jobs:
   build:
-    needs: [check-labels]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #696 

## Description of the change:
Puts label check in separate workflow.

## Motivation for the change:
GitHub CI notice changes in labels until seemingly being notified from the `labeled` event.

## How to manually test:
https://github.com/maxcao13/cryostat-web/pull/5

## Notes:
This will result in the CI tests to still run if the label is present or not. 
