### PR TITLE
feat(api): include sourceTarget details in download requests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 package.json
+.build_cache/**/*
+node_modules/**/*
+dist/**/*

--- a/license-config.json
+++ b/license-config.json
@@ -24,6 +24,8 @@
     ".github/**/*",
     "build-i18n.bash",
     "src/app/assets/*",
-    "src/test/**/*.snap"
+    "src/test/**/*.snap",
+    "dist/**/*",
+    ".build_cache/**/*"
   ]
 }

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -54,8 +54,8 @@ import {
 import { ActiveRecording, RecordingState } from '@app/Shared/Services/Api.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { useDayjs } from '@app/utils/useDayjs';
+import { NO_TARGET, Target } from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   Button,
@@ -92,6 +92,7 @@ export enum PanelContent {
 const tableColumns: string[] = ['Name', 'Start Time', 'Duration', 'State', 'Labels'];
 
 export interface ActiveRecordingsTableProps {
+  target: Observable<Target>;
   archiveEnabled: boolean;
 }
 
@@ -801,6 +802,7 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
         <RecordingActions
           index={index}
           recording={recording}
+          sourceTarget={currentSelectedTargetURL}
           uploadFn={() => context.api.uploadActiveRecordingToGrafana(recording.name)}
         />
       </Tr>

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -733,15 +733,17 @@ export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
         </Td>
         {propsDirectory ? (
           <RecordingActions
+            sourceTarget={currentSelectedTargetURL}
             recording={recording}
             index={index}
             uploadFn={() => context.api.uploadArchivedRecordingToGrafanaFromPath(propsDirectory.jvmId, recording.name)}
           />
         ) : (
           <RecordingActions
+            sourceTarget={currentSelectedTargetURL}
             recording={recording}
             index={index}
-            uploadFn={() => context.api.uploadArchivedRecordingToGrafana(sourceTarget, recording.name)}
+            uploadFn={() => context.api.uploadArchivedRecordingToGrafana(currentSelectedTargetURL, recording.name)}
           />
         )}
       </Tr>

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -38,7 +38,6 @@
 import { NotificationsContext } from '@app/Notifications/Notifications';
 import { Recording } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { Target } from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { Td } from '@patternfly/react-table';
@@ -54,8 +53,8 @@ export interface RowAction {
 
 export interface RecordingActionsProps {
   index: number;
+  sourceTarget: string;
   recording: Recording;
-  sourceTarget?: Observable<Target>;
   uploadFn: () => Observable<boolean>;
 }
 
@@ -95,11 +94,11 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
   }, [addSubscription, notifications, props, context.api]);
 
   const handleDownloadRecording = React.useCallback(() => {
-    context.api.downloadRecording(props.recording);
+    context.api.downloadRecording(props.sourceTarget, props.recording)
   }, [context.api, props.recording]);
 
   const handleViewReport = React.useCallback(() => {
-    context.api.downloadReport(props.recording);
+    context.api.downloadReport(props.sourceTarget, props.recording)
   }, [context.api, props.recording]);
 
   const actionItems = React.useMemo(() => {

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -94,11 +94,11 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
   }, [addSubscription, notifications, props, context.api]);
 
   const handleDownloadRecording = React.useCallback(() => {
-    context.api.downloadRecording(props.sourceTarget, props.recording)
+    context.api.downloadRecording(props.sourceTarget, props.recording);
   }, [context.api, props.recording]);
 
   const handleViewReport = React.useCallback(() => {
-    context.api.downloadReport(props.sourceTarget, props.recording)
+    context.api.downloadReport(props.sourceTarget, props.recording);
   }, [context.api, props.recording]);
 
   const actionItems = React.useMemo(() => {

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -63,7 +63,7 @@ export const Recordings: React.FunctionComponent<RecordingsProps> = (_) => {
     return archiveEnabled ? (
       <Tabs id="recordings" activeKey={activeTab} onSelect={onTabSelect}>
         <Tab id="active-recordings" eventKey={0} title={<TabTitleText>Active Recordings</TabTitleText>}>
-          <ActiveRecordingsTable archiveEnabled={true} />
+          <ActiveRecordingsTable target={context.target.target()} archiveEnabled={true} />
         </Tab>
         <Tab id="archived-recordings" eventKey={1} title={<TabTitleText>Archived Recordings</TabTitleText>}>
           <ArchivedRecordingsTable target={targetAsObs} isUploadsTable={false} isNestedTable={false} />
@@ -72,7 +72,7 @@ export const Recordings: React.FunctionComponent<RecordingsProps> = (_) => {
     ) : (
       <>
         <CardTitle>Active Recordings</CardTitle>
-        <ActiveRecordingsTable archiveEnabled={false} />
+        <ActiveRecordingsTable archiveEnabled={false} target={context.target.target()} />
       </>
     );
   }, [archiveEnabled, activeTab, onTabSelect, targetAsObs]);

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -78,6 +78,7 @@ import { RuleUploadModal } from './RulesUploadModal';
 
 export interface Rule {
   name: string;
+  contexts: string[];
   description: string;
   matchExpression: string;
   enabled: boolean;
@@ -97,6 +98,7 @@ export interface RuleTableHeader {
 
 export const ruleObjKeys = [
   'name',
+  'context',
   'description',
   'matchExpression',
   'enabled',
@@ -142,6 +144,7 @@ export const Rules: React.FC<RulesProps> = (_) => {
     () =>
       [
         { title: 'Enabled' },
+        { title: 'Context', sortable: true },
         {
           title: 'Name',
           sortable: true,
@@ -363,6 +366,7 @@ export const Rules: React.FC<RulesProps> = (_) => {
     if (typeof index === 'number') {
       const keys = [
         'enabled',
+        'context',
         'name',
         'description',
         'matchExpression',
@@ -387,31 +391,34 @@ export const Rules: React.FC<RulesProps> = (_) => {
             onChange={(state) => handleToggle(r, state)}
           />
         </Td>
-        <Td key={`automatic-rule-name-${index}`} dataLabel={tableColumns[1].title}>
+        <Td key={`automatic-rule-context-${index}`} dataLabel={tableColumns[1].title}>
+          {r.contexts?.join(',')}
+        </Td>
+        <Td key={`automatic-rule-name-${index}`} dataLabel={tableColumns[2].title}>
           {r.name}
         </Td>
-        <Td key={`automatic-rule-description-${index}`} dataLabel={tableColumns[2].title}>
+        <Td key={`automatic-rule-description-${index}`} dataLabel={tableColumns[3].title}>
           {r.description}
         </Td>
-        <Td key={`automatic-rule-matchExpression-${index}`} dataLabel={tableColumns[3].title}>
+        <Td key={`automatic-rule-matchExpression-${index}`} dataLabel={tableColumns[4].title}>
           {r.matchExpression}
         </Td>
-        <Td key={`automatic-rule-eventSpecifier-${index}`} dataLabel={tableColumns[4].title}>
+        <Td key={`automatic-rule-eventSpecifier-${index}`} dataLabel={tableColumns[5].title}>
           {r.eventSpecifier}
         </Td>
-        <Td key={`automatic-rule-archivalPeriodSeconds-${index}`} dataLabel={tableColumns[5].title}>
+        <Td key={`automatic-rule-archivalPeriodSeconds-${index}`} dataLabel={tableColumns[6].title}>
           {r.archivalPeriodSeconds}
         </Td>
-        <Td key={`automatic-rule-initialDelaySeconds-${index}`} dataLabel={tableColumns[6].title}>
+        <Td key={`automatic-rule-initialDelaySeconds-${index}`} dataLabel={tableColumns[7].title}>
           {r.initialDelaySeconds}
         </Td>
-        <Td key={`automatic-rule-preservedArchives-${index}`} dataLabel={tableColumns[7].title}>
+        <Td key={`automatic-rule-preservedArchives-${index}`} dataLabel={tableColumns[8].title}>
           {r.preservedArchives}
         </Td>
-        <Td key={`automatic-rule-maxAgeSeconds-${index}`} dataLabel={tableColumns[8].title}>
+        <Td key={`automatic-rule-maxAgeSeconds-${index}`} dataLabel={tableColumns[9].title}>
           {r.maxAgeSeconds}
         </Td>
-        <Td key={`automatic-rule-maxSizeBytes-${index}`} dataLabel={tableColumns[9].title}>
+        <Td key={`automatic-rule-maxSizeBytes-${index}`} dataLabel={tableColumns[10].title}>
           {r.maxSizeBytes}
         </Td>
         <Td key={`automatic-rule-action-${index}`} isActionCell style={{ paddingRight: '0' }}>

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -766,12 +766,12 @@ export class ApiService {
       .target()
       .pipe(
         first(),
-        map(
-          (target) => [target.connectUrl,
-            `${this.login.authority}/api/v2.1/targets/${encodeURIComponent(
-              target.connectUrl
-            )}/templates/${encodeURIComponent(template.name)}/type/${encodeURIComponent(template.type)}`
-          ])
+        map((target) => [
+          target.connectUrl,
+          `${this.login.authority}/api/v2.1/targets/${encodeURIComponent(
+            target.connectUrl
+          )}/templates/${encodeURIComponent(template.name)}/type/${encodeURIComponent(template.type)}`,
+        ])
       )
       .subscribe((parts) => {
         const body = new window.FormData();

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -48,7 +48,7 @@ import { AuthMethod, LoginService, SessionState } from './Login.service';
 import { NotificationCategory } from './NotificationChannel.service';
 import { NO_TARGET, Target, TargetService } from './Target.service';
 
-type ApiVersion = 'v1' | 'v2' | 'v2.1' | 'v2.2' | 'beta';
+type ApiVersion = 'v1' | 'v2' | 'v2.1' | 'v2.2' | 'v2.3' | 'beta';
 
 export class HttpError extends Error {
   readonly httpResponse: Response;
@@ -473,7 +473,7 @@ export class ApiService {
         method: 'POST',
       }
     ).pipe(
-    map((resp) => resp.ok),
+      map((resp) => resp.ok),
       first()
     );
   }

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -474,7 +474,7 @@ describe('<ActiveRecordingsTable />', () => {
     const downloadRequestSpy = jest.spyOn(defaultServices.api, 'downloadRecording');
 
     expect(downloadRequestSpy).toHaveBeenCalledTimes(1);
-    expect(downloadRequestSpy).toBeCalledWith(mockRecording);
+    expect(downloadRequestSpy).toBeCalledWith(mockTarget, mockRecording);
   });
 
   it('displays the automated analysis report when View Report is clicked', async () => {

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -217,7 +217,7 @@ describe('<ActiveRecordingsTable />', () => {
   afterEach(cleanup);
 
   it('renders the recording table correctly', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -271,7 +271,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('adds a recording after receiving a notification', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -280,7 +280,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('updates the recording labels after receiving a notification', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -289,7 +289,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('stops a recording after receiving a notification', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -298,7 +298,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('removes a recording after receiving a notification', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -306,7 +306,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('displays the toolbar buttons', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -319,7 +319,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('routes to the Create Flight Recording form when Create is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -330,7 +330,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('archives the selected recording when Archive is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -347,7 +347,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('stops the selected recording when Stop is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -364,7 +364,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('opens the labels drawer when Edit Labels is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -377,7 +377,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('shows a popup when Delete is clicked and then deletes the recording after clicking confirmation Delete', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -404,7 +404,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('deletes the recording when Delete is clicked w/o popup warning', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -422,7 +422,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('downloads a recording when Download Recording is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -439,7 +439,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('displays the automated analysis report when View Report is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -455,7 +455,7 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('uploads a recording to Grafana when View in Grafana is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
     });
@@ -482,7 +482,7 @@ describe('<ActiveRecordingsTable />', () => {
       target: mockTargetSvc,
     };
 
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
+    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
       preloadState: preloadedState,
       history: history,
       services,

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -217,10 +217,13 @@ describe('<ActiveRecordingsTable />', () => {
   afterEach(cleanup);
 
   it('renders the recording table correctly', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     ['Create', 'Edit Labels', 'Stop', 'Delete'].map((text) => {
       const button = screen.getByText(text);
@@ -271,45 +274,60 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('adds a recording after receiving a notification', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
     expect(screen.getByText('someRecording')).toBeInTheDocument();
     expect(screen.getByText('anotherRecording')).toBeInTheDocument();
   });
 
   it('updates the recording labels after receiving a notification', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
     expect(screen.getByText('someLabel: someUpdatedValue')).toBeInTheDocument();
     expect(screen.queryByText('someLabel: someValue')).not.toBeInTheDocument();
   });
 
   it('stops a recording after receiving a notification', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
     expect(screen.getByText('STOPPED')).toBeInTheDocument();
     expect(screen.queryByText('RUNNING')).not.toBeInTheDocument();
   });
 
   it('removes a recording after receiving a notification', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
     expect(screen.queryByText('someRecording')).not.toBeInTheDocument();
   });
 
   it('displays the toolbar buttons', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     expect(screen.getByText('Create')).toBeInTheDocument();
     expect(screen.getByText('Archive')).toBeInTheDocument();
@@ -319,10 +337,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('routes to the Create Flight Recording form when Create is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     await user.click(screen.getByText('Create'));
 
@@ -330,10 +351,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('archives the selected recording when Archive is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -347,10 +371,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('stops the selected recording when Stop is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -364,10 +391,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('opens the labels drawer when Edit Labels is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -377,10 +407,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('shows a popup when Delete is clicked and then deletes the recording after clicking confirmation Delete', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -404,10 +437,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('deletes the recording when Delete is clicked w/o popup warning', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -422,10 +458,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('downloads a recording when Download Recording is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     await act(async () => {
       await user.click(screen.getByLabelText('Actions'));
@@ -439,10 +478,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('displays the automated analysis report when View Report is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     await act(async () => {
       await user.click(screen.getByLabelText('Actions'));
@@ -455,10 +497,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('uploads a recording to Grafana when View in Grafana is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     await act(async () => {
       await user.click(screen.getByLabelText('Actions'));
@@ -482,11 +527,14 @@ describe('<ActiveRecordingsTable />', () => {
       target: mockTargetSvc,
     };
 
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />, {
-      preloadState: preloadedState,
-      history: history,
-      services,
-    });
+    renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} target={of(mockTarget)} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+        services,
+      }
+    );
 
     await act(async () => subj.next());
 

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -387,7 +387,7 @@ describe('<ArchivedRecordingsTable />', () => {
     const downloadRequestSpy = jest.spyOn(defaultServices.api, 'downloadRecording');
 
     expect(downloadRequestSpy).toHaveBeenCalledTimes(1);
-    expect(downloadRequestSpy).toBeCalledWith(mockRecording);
+    expect(downloadRequestSpy).toBeCalledWith(mockTarget, mockRecording);
   });
 
   it('displays the automated analysis report when View Report is clicked', async () => {

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -69,6 +69,7 @@ const mockEventTemplate: EventTemplate = {
 };
 const mockRule: Rule = {
   name: 'mockRule',
+  contexts: ['myns'],
   description: 'A mock rule',
   matchExpression: "target.alias == 'io.cryostat.Cryostat' || target.annotations.cryostat['PORT'] == 9091",
   enabled: true,

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -55,6 +55,7 @@ import { renderWithServiceContextAndRouter } from '../Common';
 
 const mockRule: Rule = {
   name: 'mockRule',
+  contexts: ['myns'],
   description: 'A mock rule',
   matchExpression: "target.alias == 'io.cryostat.Cryostat' || target.annotations.cryostat['PORT'] == 9091",
   enabled: true,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/issues/760

## Description of the change:
This adds some form fields to API requests to generate JWT tokens for downloading recordings and reports.
These details are embedded in the request URL and are not so easy for the backend's abstract base class to figure out,
so the frontend provides them again as form parameters here.

## Motivation for the change:
The backend should verify that the provided form parameters actually match (are present within) the request URL, that
they are not blank, and that they correspond to actually known resources.

These details are useful for the backend to know so that it can perform further checks and actions when these JWT
download requests are made.

## How to manually test:
1. Check out https://github.com/cryostatio/cryostat/pull/1188
2. Update `web-client` submodule to the latest from this PR
3. `mvn package` to build a new container image with backend and frontend changes
4. Tag the image, push it to `quay.io`, and then deploy this in OpenShift using the Cryostat Operator
5. Open the Cryostat web UI as usual and click around
