### PR TITLE
chore(agent): use notification message to patch template table

### DIFF
--- a/src/app/Agent/AgentProbeTemplates.tsx
+++ b/src/app/Agent/AgentProbeTemplates.tsx
@@ -229,7 +229,6 @@ export const AgentProbeTemplates: React.FunctionComponent<AgentProbeTemplatesPro
   React.useEffect(() => {
     addSubscription(
       context.notificationChannel.messages(NotificationCategory.ProbeTemplateUploaded).subscribe((event) => {
-        console.log(event);
         setTemplates((old) => {
           return [
             ...old,

--- a/src/app/Agent/AgentProbeTemplates.tsx
+++ b/src/app/Agent/AgentProbeTemplates.tsx
@@ -228,19 +228,28 @@ export const AgentProbeTemplates: React.FunctionComponent<AgentProbeTemplatesPro
 
   React.useEffect(() => {
     addSubscription(
-      context.notificationChannel
-        .messages(NotificationCategory.ProbeTemplateUploaded)
-        .subscribe((v) => refreshTemplates())
+      context.notificationChannel.messages(NotificationCategory.ProbeTemplateUploaded).subscribe((event) => {
+        console.log(event);
+        setTemplates((old) => {
+          return [
+            ...old,
+            {
+              name: event.message.templateName,
+              xml: event.message.templateContent,
+            } as ProbeTemplate,
+          ];
+        });
+      })
     );
-  }, [addSubscription, context.notificationChannel, refreshTemplates]);
+  }, [addSubscription, context.notificationChannel, setTemplates]);
 
   React.useEffect(() => {
     addSubscription(
-      context.notificationChannel
-        .messages(NotificationCategory.ProbeTemplateDeleted)
-        .subscribe((v) => refreshTemplates())
+      context.notificationChannel.messages(NotificationCategory.ProbeTemplateDeleted).subscribe((event) => {
+        setTemplates((old) => old.filter((t) => t.name !== event.message.probeTemplate));
+      })
     );
-  }, [addSubscription, context.notificationChannel, refreshTemplates]);
+  }, [addSubscription, context.notificationChannel, setTemplates]);
 
   React.useEffect(() => {
     let filtered: ProbeTemplate[];

--- a/src/test/Agent/AgentProbeTemplates.test.tsx
+++ b/src/test/Agent/AgentProbeTemplates.test.tsx
@@ -73,7 +73,9 @@ const mockCreateTemplateNotification = {
     type: mockMessageType,
   } as MessageMeta,
   message: {
-    template: mockAnotherProbeTemplate,
+    templateName: mockAnotherProbeTemplate.name,
+    templateContent: mockAnotherProbeTemplate.xml,
+    probeTemplate: 'files-uploads/abcdfg',
   },
 } as NotificationMessage;
 
@@ -83,7 +85,7 @@ const mockDeleteTemplateNotification = {
     type: mockMessageType,
   },
   message: {
-    template: mockProbeTemplate,
+    probeTemplate: mockProbeTemplate.name,
   },
 } as NotificationMessage;
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #586 
Depends on https://github.com/cryostatio/cryostat/pull/1273

## Description of the change:

This change clean up notification handling in the AgenTemplate table to use notification message and patch the table without refreshing.

## Motivation for the change:

- Avoid unncessary api requests and allow smoother UI.
- Upload modal is uncessarily unmounted due to refeshing causes loading view to render. This fix will avoid this, allowing the modal to keep local states (to display failed files).

## How to manually test:

1. Start the backend with latest changes from https://github.com/cryostatio/cryostat/pull/1273. For example:
    ```
    $ CRYOSTAT_IMAGE=ghcr.io/cryostatio/cryostat:pr-1273-254d0939d87cfa7940d734311b06d959f58d7cdc sh smoketest.sh
    ```
3. Delete or add templates. 
4. All functionality should remain the same. 
5. UI should not enter loading state if agent-template-related notifications are received.
