### PR TITLE
perf(agent-probe): patch state with notification and add spinner

### DIFF
--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -206,10 +206,10 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
     addSubscription(
       context.notificationChannel.messages(NotificationCategory.ProbeTemplateApplied).subscribe((e) => {
         setProbes((old) => {
-          const probes = e.message.events;
+          const probes = e.message.events as EventProbe[];
+          const probeIds = probes.map((p) => p.id);
           if (probes?.length > 0) {
-            const newProbe = probes[0] as EventProbe;
-            return [...old.filter((probe) => probe.id !== newProbe.id), newProbe];
+            return [...old.filter((probe) => !probeIds.includes(probe.id)), ...probes];
           }
           return old;
         });

--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -204,9 +204,18 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
 
   React.useEffect(() => {
     addSubscription(
-      context.notificationChannel.messages(NotificationCategory.ProbeTemplateApplied).subscribe((_) => refreshProbes())
+      context.notificationChannel.messages(NotificationCategory.ProbeTemplateApplied).subscribe((e) => {
+        setProbes((old) => {
+          const probes = e.message.events;
+          if (probes?.length > 0) {
+            const newProbe = probes[0] as EventProbe;
+            return [...old.filter((probe) => probe.id !== newProbe.id), newProbe];
+          }
+          return old;
+        });
+      })
     );
-  }, [addSubscription, context, context.notificationChannel, refreshProbes]);
+  }, [addSubscription, context, context.notificationChannel, setProbes]);
 
   React.useEffect(() => {
     addSubscription(

--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -72,6 +72,9 @@ import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
 import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
 import { SearchIcon } from '@patternfly/react-icons';
 import { AboutAgentCard } from './AboutAgentCard';
+import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
+
+export type LiveProbeActions = 'REMOVE';
 
 export interface AgentLiveProbesProps {}
 
@@ -86,6 +89,7 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
   const [isLoading, setIsLoading] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState('');
   const [warningModalOpen, setWarningModalOpen] = React.useState(false);
+  const [actionLoadings, setActionLoadings] = React.useState<Record<LiveProbeActions, boolean>>({ REMOVE: false });
 
   const tableColumns = ['ID', 'Name', 'Class', 'Description', 'Method'];
 
@@ -135,15 +139,26 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
   }, [context.target, context.target.setAuthRetry]);
 
   const handleDeleteAllProbes = React.useCallback(() => {
+    setActionLoadings((old) => {
+      return {
+        ...old,
+        REMOVE: true,
+      };
+    });
     addSubscription(
       context.api
         .removeProbes()
         .pipe(first())
         .subscribe(() => {
-          // do nothing - notification updates state
+          setActionLoadings((old) => {
+            return {
+              ...old,
+              REMOVE: false,
+            };
+          });
         })
     );
-  }, [addSubscription, context.api]);
+  }, [addSubscription, context.api, setActionLoadings]);
 
   const handleWarningModalAccept = React.useCallback(() => handleDeleteAllProbes(), [handleDeleteAllProbes]);
 
@@ -248,6 +263,17 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
     [filteredProbes]
   );
 
+  const actionLoadingProps = React.useMemo<Record<LiveProbeActions, LoadingPropsType>>(
+    () => ({
+      REMOVE: {
+        spinnerAriaValueText: 'Removing',
+        spinnerAriaLabel: 'removing-all-probes',
+        isLoading: actionLoadings['REMOVE'],
+      } as LoadingPropsType,
+    }),
+    [actionLoadings]
+  );
+
   if (errorMessage != '') {
     return (
       <ErrorView
@@ -286,9 +312,10 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
                       key="delete"
                       variant="danger"
                       onClick={handleDeleteButton}
-                      isDisabled={!filteredProbes.length}
+                      isDisabled={!filteredProbes.length || actionLoadings['REMOVE']}
+                      {...actionLoadingProps['REMOVE']}
                     >
-                      Remove All Probes
+                      {actionLoadings['REMOVE'] ? 'Removing' : 'Remove'} All Probes
                     </Button>
                   </ToolbarItem>
                 </ToolbarGroup>

--- a/src/app/Agent/AgentProbeTemplates.tsx
+++ b/src/app/Agent/AgentProbeTemplates.tsx
@@ -507,7 +507,14 @@ export const AgentTemplateAction: React.FunctionComponent<AgentTemplateActionPro
       position={DropdownPosition.right}
       isFlipEnabled
       dropdownItems={actionItems.map((action) => (
-        <DropdownItem key={action.key} onClick={action.onClick} isDisabled={action.isDisabled}>
+        <DropdownItem
+          key={action.key}
+          onClick={() => {
+            setIsOpen(false);
+            action.onClick();
+          }}
+          isDisabled={action.isDisabled}
+        >
           {action.title}
         </DropdownItem>
       ))}

--- a/src/app/Agent/AgentProbeTemplates.tsx
+++ b/src/app/Agent/AgentProbeTemplates.tsx
@@ -279,7 +279,7 @@ export const AgentProbeTemplates: React.FunctionComponent<AgentProbeTemplatesPro
           </Tr>
         );
       }),
-    [filteredTemplates]
+    [filteredTemplates, props.agentDetected, handleInsertAction, handleDeleteAction]
   );
 
   if (errorMessage != '') {

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -708,7 +708,7 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
   }, [deletionDialogsEnabled, setWarningModalOpen, props.handleDeleteRecordings]);
 
   const isStopDisabled = React.useMemo(() => {
-    if (!props.checkedIndices.length) {
+    if (!props.checkedIndices.length || props.actionLoadings['STOP']) {
       return true;
     }
     const filtered = props.filteredRecordings.filter((r) => props.checkedIndices.includes(r.id));
@@ -749,7 +749,7 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
           key="archive"
           variant="secondary"
           onClick={props.handleArchiveRecordings}
-          isDisabled={!props.checkedIndices.length}
+          isDisabled={!props.checkedIndices.length || props.actionLoadings['ARCHIVE']}
           {...actionLoadingProps['ARCHIVE']}
         >
           {props.actionLoadings['ARCHIVE'] ? 'Archiving' : 'Archive'}
@@ -779,7 +779,7 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
         key="delete"
         variant="danger"
         onClick={handleDeleteButton}
-        isDisabled={!props.checkedIndices.length}
+        isDisabled={!props.checkedIndices.length || props.actionLoadings['DELETE']}
         {...actionLoadingProps['DELETE']}
       >
         {props.actionLoadings['DELETE'] ? 'Deleting' : 'Delete'}

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -733,7 +733,7 @@ const ArchivedRecordingsToolbar: React.FunctionComponent<ArchivedRecordingsToolb
             <Button
               variant="danger"
               onClick={handleDeleteButton}
-              isDisabled={!props.checkedIndices.length}
+              isDisabled={!props.checkedIndices.length || props.actionLoadings['DELETE']}
               {...actionLoadingProps['DELETE']}
             >
               {props.actionLoadings['DELETE'] ? 'Deleting' : 'Delete'}

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -440,7 +440,8 @@ export class ApiService {
   isProbeEnabled(): Observable<boolean> {
     return this.getActiveProbes(true).pipe(
       concatMap((_) => of(true)),
-      catchError((_) => of(false))
+      catchError((_) => of(false)),
+      first()
     );
   }
 

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -477,12 +477,8 @@ export class ApiService {
         this.sendRequest('v2', `targets/${encodeURIComponent(target.connectUrl)}/probes`, {
           method: 'DELETE',
         }).pipe(
-          tap((resp) => {
-            if (resp.status == 400) {
-              this.notifications.warning('Failed to remove Probes', 'The probes failed to be removed from the target');
-            }
-          }),
-          map((resp) => resp.status == 200),
+          map((resp) => resp.ok),
+          catchError(() => of(false)),
           first()
         )
       )

--- a/src/test/Agent/AgentLiveProbes.test.tsx
+++ b/src/test/Agent/AgentLiveProbes.test.tsx
@@ -86,7 +86,8 @@ const mockApplyTemplateNotification = {
     type: mockMessageType,
   } as MessageMeta,
   message: {
-    template: mockProbe,
+    targetId: mockConnectUrl,
+    events: [mockAnotherProbe],
   },
 } as NotificationMessage;
 
@@ -115,7 +116,6 @@ jest
   .mockReturnValueOnce(of([])) // should disable remove button if there is no probe
 
   .mockReturnValueOnce(of([mockProbe])) // should add a probe after receiving a notification
-  .mockReturnValueOnce(of([mockProbe, mockAnotherProbe]))
 
   .mockReturnValue(of([mockProbe])); // All other tests
 

--- a/src/test/Agent/__snapshots__/AgentLiveProbes.test.tsx.snap
+++ b/src/test/Agent/__snapshots__/AgentLiveProbes.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`<AgentLiveProbes /> renders correctly 1`] = `
               <button
                 aria-disabled={false}
                 aria-label={null}
-                className="pf-c-button pf-m-danger"
+                className="pf-c-button pf-m-danger pf-m-progress"
                 data-ouia-component-id="OUIA-Generated-Button-danger-1"
                 data-ouia-component-type="PF4/Button"
                 data-ouia-safe={true}
@@ -90,7 +90,8 @@ exports[`<AgentLiveProbes /> renders correctly 1`] = `
                 role={null}
                 type="button"
               >
-                Remove All Probes
+                Remove
+                 All Probes
               </button>
             </div>
           </div>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #640 
Related to #586 
Related to #584 
Depends on https://github.com/cryostatio/cryostat/pull/1280

## Description of the change:

- [x] Added spinner to `Remove All Probes` action buttons.
- [x] Disabled all action buttons (i.e. on toolbar) when in progress.
- [x] Notifications about new probes can be used to patch state.
- [x] Close action menu on selection (Agent Template table).
- [x] Added missing hook deps that causes the `Insert Probe` remains disabled.

## Motivation for the change:

The Active Probe table's action buttons do not have spinner added. Must have been left out previously. Action buttons should all be disabled when in progress.

Also, this includes the final piece of clean up for notifications handling for agent UI.

## How to manually test:
1. Run Cryostat backend with a jmc agent attached.
2. Go to Events -> Agent Template/Live Configurations table.
