### PR TITLE
feat(dashboard): card configuration

### DIFF
--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -115,7 +115,6 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
   const handleAdd = React.useCallback(() => {
     setShowWizard(false);
     const cardTitle = getConfigByTitle(selection).component.name;
-    console.info('creating card', { cardTitle, ...propsConfig });
     dispatch(addCardIntent(cardTitle, propsConfig));
   }, [setShowWizard, dispatch, addCardIntent, selection, propsConfig]);
 

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -153,7 +153,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
     <>
       <Card isRounded isLarge>
         {showWizard ? (
-          <Wizard onClose={handleStop} onSave={handleAdd} height={640} nav={customNav}>
+          <Wizard onClose={handleStop} onSave={handleAdd} height={'30rem'} nav={customNav}>
             <WizardStep
               id="card-type-select"
               name="Card Type"
@@ -305,9 +305,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
           );
           break;
         case 'select':
-          input = (
-            <SelectControl handleChange={handleChange(ctrl.key)} config={props.config[ctrl.key]} control={ctrl} />
-          );
+          input = <SelectControl handleChange={handleChange(ctrl.key)} config={props.config} control={ctrl} />;
           break;
         default:
           input = <Text>Bad config</Text>;

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -269,12 +269,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
       switch (ctrl.kind) {
         case 'boolean':
           input = (
-            <Switch
-              label="On"
-              labelOff="Off"
-              isChecked={props.config[ctrl.key]}
-              onChange={handleChange(ctrl.key)}
-            />
+            <Switch label="On" labelOff="Off" isChecked={props.config[ctrl.key]} onChange={handleChange(ctrl.key)} />
           );
           break;
         case 'number':

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -138,6 +138,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
             <WizardStep id="card-props-config" name="Configuration" footer={{ nextButtonText: 'Finish' }}>
               {selection ? (
                 <PropsConfigForm
+                  cardTitle={selection}
                   initialState={propsConfig}
                   controls={getConfigByTitle(selection).propControls}
                   onChange={setPropsConfig}
@@ -170,6 +171,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
 };
 
 interface PropsConfigFormProps {
+  cardTitle: string;
   controls: PropControl[];
   initialState: any;
   onChange: ({}) => void;
@@ -268,7 +270,9 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
     <>
       {props.controls.length > 0 ? (
         <Form>
-          <FormGroup label="Configure the card">{props.controls.map((ctrl) => createControl(ctrl))}</FormGroup>
+          <FormGroup label={`Configure the ${props.cardTitle} card`}>
+            {props.controls.map((ctrl) => createControl(ctrl))}
+          </FormGroup>
         </Form>
       ) : (
         <Text>No configuration required.</Text>

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -124,7 +124,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
     <>
       <Card isRounded isLarge>
         {showWizard ? (
-          <Wizard onClose={handleStop} onSave={handleAdd} height={400}>
+          <Wizard onClose={handleStop} onSave={handleAdd} height={500}>
             <WizardStep id="card-type-select" name="Card Type" footer={{ isNextDisabled: !selection }}>
               <Form>
                 <FormGroup label="Select a card type" isRequired isStack>

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -251,60 +251,63 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
     [props, props.onChange, setPropsConfig]
   );
 
-  const createControl = React.useCallback((ctrl: PropControl): JSX.Element => {
-    let input: JSX.Element;
-    switch (ctrl.kind) {
-      case 'boolean':
-        input = <Switch label={ctrl.name} isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />;
-        break;
-      case 'number':
-        input = (
-          <NumberInput
-            inputName={ctrl.name}
-            inputAriaLabel={`${ctrl.name} input`}
-            value={propsConfig[ctrl.key]}
-            onChange={handleNumeric(ctrl.key)}
-            onPlus={handleNumericStep(ctrl.key, 1)}
-            onMinus={handleNumericStep(ctrl.key, -1)}
-          />
-        );
-        break;
-      case 'string':
-        input = (
-          <TextInput
-            type="text"
-            aria-label={`${ctrl.key} input`}
-            value={propsConfig[ctrl.key]}
-            onChange={handleChange(ctrl.key)}
-          />
-        );
-        break;
-      case 'text':
-        input = (
-          <TextArea
-            type="text"
-            aria-label={`${ctrl.key} input`}
-            value={propsConfig[ctrl.key]}
-            onChange={handleChange(ctrl.key)}
-          />
-        );
-        break;
-      default:
-        input = <Text>Bad config</Text>;
-        break;
-    }
-    return (
-      <FormGroup
-        key={`${ctrl.key}}`}
-        label={ctrl.kind == 'number' ? ctrl.name : undefined}
-        helperText={ctrl.description}
-        isInline
-        isStack
-      >
-        {input}
-      </FormGroup>
-    );
-  }, [propsConfig, handleChange, handleNumeric, handleNumericStep]);
+  const createControl = React.useCallback(
+    (ctrl: PropControl): JSX.Element => {
+      let input: JSX.Element;
+      switch (ctrl.kind) {
+        case 'boolean':
+          input = <Switch label={ctrl.name} isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />;
+          break;
+        case 'number':
+          input = (
+            <NumberInput
+              inputName={ctrl.name}
+              inputAriaLabel={`${ctrl.name} input`}
+              value={propsConfig[ctrl.key]}
+              onChange={handleNumeric(ctrl.key)}
+              onPlus={handleNumericStep(ctrl.key, 1)}
+              onMinus={handleNumericStep(ctrl.key, -1)}
+            />
+          );
+          break;
+        case 'string':
+          input = (
+            <TextInput
+              type="text"
+              aria-label={`${ctrl.key} input`}
+              value={propsConfig[ctrl.key]}
+              onChange={handleChange(ctrl.key)}
+            />
+          );
+          break;
+        case 'text':
+          input = (
+            <TextArea
+              type="text"
+              aria-label={`${ctrl.key} input`}
+              value={propsConfig[ctrl.key]}
+              onChange={handleChange(ctrl.key)}
+            />
+          );
+          break;
+        default:
+          input = <Text>Bad config</Text>;
+          break;
+      }
+      return (
+        <FormGroup
+          key={`${ctrl.key}}`}
+          label={ctrl.kind == 'number' ? ctrl.name : undefined}
+          helperText={ctrl.description}
+          isInline
+          isStack
+        >
+          {input}
+        </FormGroup>
+      );
+    },
+    [propsConfig, handleChange, handleNumeric, handleNumericStep]
+  );
 
   return (
     <>

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -55,7 +55,14 @@ import {
   TextInput,
   Title,
 } from '@patternfly/react-core';
-import { Wizard, WizardStep } from '@patternfly/react-core/dist/js/next';
+import {
+  CustomWizardNavFunction,
+  Wizard,
+  WizardControlStep,
+  WizardNav,
+  WizardNavItem,
+  WizardStep,
+} from '@patternfly/react-core/dist/js/next';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useDispatch } from 'react-redux';
 import { StateDispatch } from '@app/Shared/Redux/ReduxStore';
@@ -121,12 +128,38 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
     setShowWizard(false);
   }, [setShowWizard]);
 
+  // custom nav for disabling subsequent steps (ex. configuration) if a card type hasn't been selected first
+  const customNav: CustomWizardNavFunction = React.useCallback(
+    (
+      isExpanded: boolean,
+      steps: WizardControlStep[],
+      activeStep: WizardControlStep,
+      goToStepByIndex: (index: number) => void
+    ) => {
+      return (
+        <WizardNav isExpanded={isExpanded}>
+          {steps.map((step, idx) => (
+            <WizardNavItem
+              key={step.id}
+              id={step.id}
+              content={step.name}
+              isCurrent={activeStep.id === step.id}
+              isDisabled={step.isDisabled || (idx > 0 && !selection)}
+              stepIndex={step.index}
+              onNavItemClick={goToStepByIndex}
+            />
+          ))}
+        </WizardNav>
+      );
+    },
+    [selection]
+  );
+
   return (
-    // FIXME wizard navigation by clicking left-side step names should be disabled if the first step selection is empty
     <>
       <Card isRounded isLarge>
         {showWizard ? (
-          <Wizard isStepVisitRequired onClose={handleStop} onSave={handleAdd} height={500}>
+          <Wizard isStepVisitRequired onClose={handleStop} onSave={handleAdd} height={500} nav={customNav}>
             <WizardStep id="card-type-select" name="Card Type" footer={{ isNextDisabled: !selection }}>
               <Form>
                 <FormGroup label="Select a card type" isRequired isStack>

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -78,16 +78,6 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
   const [selectOpen, setSelectOpen] = React.useState(false);
   const dispatch = useDispatch<StateDispatch>();
 
-  React.useEffect(() => {
-    const c = {};
-    if (selection) {
-      for (const ctrl of getConfigByTitle(selection).propControls) {
-        c[ctrl.key] = ctrl.defaultValue;
-      }
-    }
-    setPropsConfig(c);
-  }, [getConfigByTitle, selection, setPropsConfig]);
-
   const options = React.useMemo(() => {
     return [
       <SelectOption key={0} value={'None'} isPlaceholder />,
@@ -108,8 +98,16 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
     (_, selection, isPlaceholder) => {
       setSelection(isPlaceholder ? '' : selection);
       setSelectOpen(false);
+
+      const c = {};
+      if (selection) {
+        for (const ctrl of getConfigByTitle(selection).propControls) {
+          c[ctrl.key] = ctrl.defaultValue;
+        }
+      }
+      setPropsConfig(c);
     },
-    [setSelection, setSelectOpen]
+    [setSelection, setSelectOpen, getConfigByTitle, setPropsConfig]
   );
 
   const handleAdd = React.useCallback(() => {
@@ -196,7 +194,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
               {selection && (
                 <PropsConfigForm
                   cardTitle={selection}
-                  selectedPropConfig={propsConfig}
+                  config={propsConfig}
                   controls={getConfigByTitle(selection).propControls}
                   onChange={setPropsConfig}
                 />
@@ -237,37 +235,37 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
 interface PropsConfigFormProps {
   cardTitle: string;
   controls: PropControl[];
-  selectedPropConfig: any;
+  config: any;
   onChange: ({}) => void;
 }
 
 const PropsConfigForm = (props: PropsConfigFormProps) => {
   const handleChange = React.useCallback(
     (k) => (e) => {
-      const copy = { ...props.selectedPropConfig };
+      const copy = { ...props.config };
       copy[k] = e;
       props.onChange(copy);
     },
-    [props.selectedPropConfig, props.onChange]
+    [props.config, props.onChange]
   );
 
   const handleNumeric = React.useCallback(
     (k) => (e) => {
       const value = (e.target as HTMLInputElement).value;
-      const copy = { ...props.selectedPropConfig };
+      const copy = { ...props.config };
       copy[k] = value;
       props.onChange(copy);
     },
-    [props.selectedPropConfig, props.onChange]
+    [props.config, props.onChange]
   );
 
   const handleNumericStep = React.useCallback(
     (k, v) => (e) => {
-      const copy = { ...props.selectedPropConfig };
-      copy[k] = props.selectedPropConfig[k] + v;
+      const copy = { ...props.config };
+      copy[k] = props.config[k] + v;
       props.onChange(copy);
     },
-    [props.selectedPropConfig, props.onChange]
+    [props.config, props.onChange]
   );
 
   const createControl = React.useCallback(
@@ -277,9 +275,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
         case 'boolean':
           input = (
             <Switch
-              label={ctrl.name}
-              isReversed
-              isChecked={props.selectedPropConfig[ctrl.key]}
+              isChecked={props.config[ctrl.key]}
               onChange={handleChange(ctrl.key)}
             />
           );
@@ -289,7 +285,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
             <NumberInput
               inputName={ctrl.name}
               inputAriaLabel={`${ctrl.name} input`}
-              value={props.selectedPropConfig[ctrl.key]}
+              value={props.config[ctrl.key]}
               onChange={handleNumeric(ctrl.key)}
               onPlus={handleNumericStep(ctrl.key, 1)}
               onMinus={handleNumericStep(ctrl.key, -1)}
@@ -301,7 +297,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
             <TextInput
               type="text"
               aria-label={`${ctrl.key} input`}
-              value={props.selectedPropConfig[ctrl.key]}
+              value={props.config[ctrl.key]}
               onChange={handleChange(ctrl.key)}
             />
           );
@@ -311,7 +307,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
             <TextArea
               type="text"
               aria-label={`${ctrl.key} input`}
-              value={props.selectedPropConfig[ctrl.key]}
+              value={props.config[ctrl.key]}
               onChange={handleChange(ctrl.key)}
             />
           );
@@ -323,7 +319,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
       return (
         <FormGroup
           key={`${ctrl.key}}`}
-          label={ctrl.kind !== 'boolean' ? ctrl.name : undefined}
+          label={ctrl.name}
           helperText={ctrl.description}
           isInline
           isStack
@@ -332,7 +328,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
         </FormGroup>
       );
     },
-    [props.selectedPropConfig, handleChange, handleNumeric, handleNumericStep]
+    [props.config, handleChange, handleNumeric, handleNumericStep]
   );
 
   return (

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -57,7 +57,7 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { useDispatch } from 'react-redux';
 import { StateDispatch } from '@app/Shared/Redux/ReduxStore';
 import { addCardIntent } from '@app/Shared/Redux/DashboardConfigActions';
-import { DashboardCards, getConfigByTitle, PropControl, PropKind } from './Dashboard';
+import { DashboardCards, getConfigByTitle, PropControl } from './Dashboard';
 
 interface AddCardProps {}
 
@@ -189,7 +189,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
 
   const createControl = (ctrl: PropControl): JSX.Element => {
     switch (ctrl.kind) {
-      case PropKind.BOOLEAN:
+      case 'boolean':
         return (
           <FormGroup key={`${ctrl.key}}`} helperText={ctrl.description} isInline isStack>
             <Switch label={ctrl.name} isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -119,7 +119,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
     setShowWizard(false);
     setSelection('');
     setPropsConfig({});
-  }, [setSelection, setShowWizard]);
+  }, [setSelection, setShowWizard, setPropsConfig]);
 
   // custom nav for disabling subsequent steps (ex. configuration) if a card type hasn't been selected first
   const customNav: CustomWizardNavFunction = React.useCallback(

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -94,7 +94,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
 
   const handleAdd = React.useCallback(() => {
     setShowWizard(false);
-    dispatch(addCardIntent(getConfigByTitle(selection).component.name));
+    dispatch(addCardIntent(getConfigByTitle(selection).component.name, {}));
   }, [dispatch, selection]);
 
   const handleStart = React.useCallback(() => {

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -281,7 +281,12 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
         break;
       case 'text':
         input = (
-          <TextArea aria-label={`${ctrl.key} input`} value={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />
+          <TextArea
+            type="text"
+            aria-label={`${ctrl.key} input`}
+            value={propsConfig[ctrl.key]}
+            onChange={handleChange(ctrl.key)}
+          />
         );
         break;
       default:

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -285,7 +285,9 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
       let input: JSX.Element;
       switch (ctrl.kind) {
         case 'boolean':
-          input = <Switch label={ctrl.name} isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />;
+          input = (
+            <Switch label={ctrl.name} isReversed isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />
+          );
           break;
         case 'number':
           input = (
@@ -326,7 +328,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
       return (
         <FormGroup
           key={`${ctrl.key}}`}
-          label={ctrl.kind == 'number' ? ctrl.name : undefined}
+          label={ctrl.kind !== 'boolean' ? ctrl.name : undefined}
           helperText={ctrl.description}
           isInline
           isStack

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -121,7 +121,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
     <>
       <Card isRounded isLarge>
         {showWizard ? (
-          <Wizard onClose={handleStop} onSave={handleAdd} height={300}>
+          <Wizard onClose={handleStop} onSave={handleAdd} height={400}>
             <WizardStep id="card-type-select" name="Card Type" footer={{ isNextDisabled: !selection }}>
               <Form>
                 <FormGroup label="Select a card type" isRequired isStack>
@@ -202,9 +202,13 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
 
   return (
     <>
-      <Form>
-        <FormGroup label="Configure the card">{props.controls.map((ctrl) => createControl(ctrl))}</FormGroup>
-      </Form>
+      {props.controls.length > 0 ? (
+        <Form>
+          <FormGroup label="Configure the card">{props.controls.map((ctrl) => createControl(ctrl))}</FormGroup>
+        </Form>
+      ) : (
+        <Text>No configuration required.</Text>
+      )}
     </>
   );
 };

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -86,7 +86,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
       }
     }
     setPropsConfig(c);
-  }, [props, getConfigByTitle, selection, setPropsConfig]);
+  }, [getConfigByTitle, selection, setPropsConfig]);
 
   const options = React.useMemo(() => {
     return [
@@ -248,7 +248,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
         return copy;
       });
     },
-    [props, props.onChange, setPropsConfig]
+    [props.onChange, setPropsConfig]
   );
 
   const handleNumeric = React.useCallback(
@@ -261,7 +261,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
         return copy;
       });
     },
-    [props, props.onChange, setPropsConfig]
+    [props.onChange, setPropsConfig]
   );
 
   const handleNumericStep = React.useCallback(
@@ -273,7 +273,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
         return copy;
       });
     },
-    [props, props.onChange, setPropsConfig]
+    [props.onChange, setPropsConfig]
   );
 
   const createControl = React.useCallback(

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -117,6 +117,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
   }, [setShowWizard]);
 
   const handleStop = React.useCallback(() => {
+    setSelection('');
     setShowWizard(false);
   }, [setShowWizard]);
 

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -160,7 +160,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
     <>
       <Card isRounded isLarge>
         {showWizard ? (
-          <Wizard onClose={handleStop} onSave={handleAdd} height={500} nav={customNav}>
+          <Wizard onClose={handleStop} onSave={handleAdd} height={640} nav={customNav}>
             <WizardStep
               id="card-type-select"
               name="Card Type"
@@ -208,6 +208,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
               footer={{ nextButtonText: 'Finish' }}
               isHidden={!selection || !getConfigByTitle(selection).advancedConfig}
             >
+              <Title headingLevel="h5">Provide advanced configuration for the {selection} card</Title>
               {selection && getConfigByTitle(selection).advancedConfig}
             </WizardStep>
           </Wizard>
@@ -344,9 +345,8 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
     <>
       {props.controls.length > 0 ? (
         <Form>
-          <FormGroup label={`Configure the ${props.cardTitle} card`}>
-            {props.controls.map((ctrl) => createControl(ctrl))}
-          </FormGroup>
+          <Title headingLevel={'h5'}>Configure the {props.cardTitle} card</Title>
+          {props.controls.map((ctrl) => createControl(ctrl))}
         </Form>
       ) : (
         <Text>No configuration required.</Text>

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -125,7 +125,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
   const handleStop = React.useCallback(() => {
     setSelection('');
     setShowWizard(false);
-  }, [setShowWizard]);
+  }, [setSelection, setShowWizard]);
 
   // custom nav for disabling subsequent steps (ex. configuration) if a card type hasn't been selected first
   const customNav: CustomWizardNavFunction = React.useCallback(

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -291,6 +291,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
         break;
       default:
         input = <Text>Bad config</Text>;
+        break;
     }
     return (
       <FormGroup

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -48,8 +48,6 @@ import {
   FormGroup,
   Select,
   SelectOption,
-  Stack,
-  StackItem,
   Switch,
   Text,
   Title,
@@ -126,22 +124,11 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
           <Wizard onClose={handleStop} onSave={handleAdd} height={300}>
             <WizardStep id="card-type-select" name="Card Type" footer={{ isNextDisabled: !selection }}>
               <Form>
-                <FormGroup label="Select a card type" isRequired>
-                  <Stack hasGutter>
-                    <StackItem>
-                      <Select
-                        onToggle={handleToggle}
-                        isOpen={selectOpen}
-                        onSelect={handleSelect}
-                        selections={selection}
-                      >
-                        {options}
-                      </Select>
-                    </StackItem>
-                    <StackItem>
-                      <Text>{selection && getConfigByTitle(selection).descriptionFull}</Text>
-                    </StackItem>
-                  </Stack>
+                <FormGroup label="Select a card type" isRequired isStack>
+                  <Select onToggle={handleToggle} isOpen={selectOpen} onSelect={handleSelect} selections={selection}>
+                    {options}
+                  </Select>
+                  <Text>{selection && getConfigByTitle(selection).descriptionFull}</Text>
                 </FormGroup>
               </Form>
             </WizardStep>
@@ -204,12 +191,8 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
     switch (ctrl.kind) {
       case PropKind.BOOLEAN:
         return (
-          <FormGroup key={`${ctrl.key}}`} label={ctrl.name} helperText={ctrl.description}>
-            <Stack hasGutter>
-              <StackItem>
-                <Switch label={ctrl.name} isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />
-              </StackItem>
-            </Stack>
+          <FormGroup key={`${ctrl.key}}`} helperText={ctrl.description} isInline isStack>
+            <Switch label={ctrl.name} isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />
           </FormGroup>
         );
       default:
@@ -219,7 +202,9 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
 
   return (
     <>
-      <Form>{props.controls.map((ctrl) => createControl(ctrl))}</Form>
+      <Form>
+        <FormGroup label="Configure the card">{props.controls.map((ctrl) => createControl(ctrl))}</FormGroup>
+      </Form>
     </>
   );
 };

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -175,6 +175,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
                   cardTitle={selection}
                   initialState={propsConfig}
                   controls={getConfigByTitle(selection).propControls}
+                  advancedConfig={getConfigByTitle(selection).advancedConfig}
                   onChange={setPropsConfig}
                 />
               ) : (
@@ -207,6 +208,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
 interface PropsConfigFormProps {
   cardTitle: string;
   controls: PropControl[];
+  advancedConfig?: JSX.Element;
   initialState: any;
   onChange: ({}) => void;
 }
@@ -316,6 +318,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
           <FormGroup label={`Configure the ${props.cardTitle} card`}>
             {props.controls.map((ctrl) => createControl(ctrl))}
           </FormGroup>
+          {props.advancedConfig}
         </Form>
       ) : (
         <Text>No configuration required.</Text>

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -196,7 +196,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
               {selection && (
                 <PropsConfigForm
                   cardTitle={selection}
-                  initialState={propsConfig}
+                  selectedPropConfig={propsConfig}
                   controls={getConfigByTitle(selection).propControls}
                   onChange={setPropsConfig}
                 />
@@ -237,48 +237,37 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
 interface PropsConfigFormProps {
   cardTitle: string;
   controls: PropControl[];
-  initialState: any;
+  selectedPropConfig: any;
   onChange: ({}) => void;
 }
 
 const PropsConfigForm = (props: PropsConfigFormProps) => {
-  const [propsConfig, setPropsConfig] = React.useState(props.initialState);
-
   const handleChange = React.useCallback(
     (k) => (e) => {
-      setPropsConfig((old) => {
-        const copy = { ...old };
-        copy[k] = e;
-        props.onChange(copy);
-        return copy;
-      });
+      const copy = { ...props.selectedPropConfig };
+      copy[k] = e;
+      props.onChange(copy);
     },
-    [props.onChange, setPropsConfig]
+    [props.selectedPropConfig, props.onChange]
   );
 
   const handleNumeric = React.useCallback(
     (k) => (e) => {
       const value = (e.target as HTMLInputElement).value;
-      setPropsConfig((old) => {
-        const copy = { ...old };
-        copy[k] = value;
-        props.onChange(copy);
-        return copy;
-      });
+      const copy = { ...props.selectedPropConfig };
+      copy[k] = value;
+      props.onChange(copy);
     },
-    [props.onChange, setPropsConfig]
+    [props.selectedPropConfig, props.onChange]
   );
 
   const handleNumericStep = React.useCallback(
     (k, v) => (e) => {
-      setPropsConfig((old) => {
-        const copy = { ...old };
-        copy[k] = old[k] + v;
-        props.onChange(copy);
-        return copy;
-      });
+      const copy = { ...props.selectedPropConfig };
+      copy[k] = props.selectedPropConfig[k] + v;
+      props.onChange(copy);
     },
-    [props.onChange, setPropsConfig]
+    [props.selectedPropConfig, props.onChange]
   );
 
   const createControl = React.useCallback(
@@ -287,7 +276,12 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
       switch (ctrl.kind) {
         case 'boolean':
           input = (
-            <Switch label={ctrl.name} isReversed isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />
+            <Switch
+              label={ctrl.name}
+              isReversed
+              isChecked={props.selectedPropConfig[ctrl.key]}
+              onChange={handleChange(ctrl.key)}
+            />
           );
           break;
         case 'number':
@@ -295,7 +289,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
             <NumberInput
               inputName={ctrl.name}
               inputAriaLabel={`${ctrl.name} input`}
-              value={propsConfig[ctrl.key]}
+              value={props.selectedPropConfig[ctrl.key]}
               onChange={handleNumeric(ctrl.key)}
               onPlus={handleNumericStep(ctrl.key, 1)}
               onMinus={handleNumericStep(ctrl.key, -1)}
@@ -307,7 +301,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
             <TextInput
               type="text"
               aria-label={`${ctrl.key} input`}
-              value={propsConfig[ctrl.key]}
+              value={props.selectedPropConfig[ctrl.key]}
               onChange={handleChange(ctrl.key)}
             />
           );
@@ -317,7 +311,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
             <TextArea
               type="text"
               aria-label={`${ctrl.key} input`}
-              value={propsConfig[ctrl.key]}
+              value={props.selectedPropConfig[ctrl.key]}
               onChange={handleChange(ctrl.key)}
             />
           );
@@ -338,7 +332,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
         </FormGroup>
       );
     },
-    [propsConfig, handleChange, handleNumeric, handleNumericStep]
+    [props.selectedPropConfig, handleChange, handleNumeric, handleNumericStep]
   );
 
   return (

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -252,7 +252,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
   );
 
   const createControl = (ctrl: PropControl): JSX.Element => {
-    let input;
+    let input: JSX.Element;
     switch (ctrl.kind) {
       case 'boolean':
         input = <Switch label={ctrl.name} isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />;

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -46,10 +46,13 @@ import {
   EmptyStateVariant,
   Form,
   FormGroup,
+  NumberInput,
   Select,
   SelectOption,
   Switch,
   Text,
+  TextArea,
+  TextInput,
   Title,
 } from '@patternfly/react-core';
 import { Wizard, WizardStep } from '@patternfly/react-core/dist/js/next';
@@ -187,17 +190,78 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
     [props, props.onChange, setPropsConfig]
   );
 
+  const handleNumeric = React.useCallback(
+    (k) => (e) => {
+      const value = (e.target as HTMLInputElement).value;
+      setPropsConfig((old) => {
+        const copy = { ...old };
+        copy[k] = value;
+        props.onChange(copy);
+        return copy;
+      });
+    },
+    [props, props.onChange, setPropsConfig]
+  );
+
+  const handleNumericStep = React.useCallback(
+    (k, v) => (e) => {
+      setPropsConfig((old) => {
+        const copy = { ...old };
+        copy[k] = old[k] + v;
+        props.onChange(copy);
+        return copy;
+      });
+    },
+    [props, props.onChange, setPropsConfig]
+  );
+
   const createControl = (ctrl: PropControl): JSX.Element => {
+    let input;
     switch (ctrl.kind) {
       case 'boolean':
-        return (
-          <FormGroup key={`${ctrl.key}}`} helperText={ctrl.description} isInline isStack>
-            <Switch label={ctrl.name} isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />
-          </FormGroup>
+        input = <Switch label={ctrl.name} isChecked={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />;
+        break;
+      case 'number':
+        input = (
+          <NumberInput
+            inputName={ctrl.name}
+            inputAriaLabel={`${ctrl.name} input`}
+            value={propsConfig[ctrl.key]}
+            onChange={handleNumeric(ctrl.key)}
+            onPlus={handleNumericStep(ctrl.key, 1)}
+            onMinus={handleNumericStep(ctrl.key, -1)}
+          />
         );
+        break;
+      case 'string':
+        input = (
+          <TextInput
+            type="text"
+            aria-label={`${ctrl.key} input`}
+            value={propsConfig[ctrl.key]}
+            onChange={handleChange(ctrl.key)}
+          />
+        );
+        break;
+      case 'text':
+        input = (
+          <TextArea aria-label={`${ctrl.key} input`} value={propsConfig[ctrl.key]} onChange={handleChange(ctrl.key)} />
+        );
+        break;
       default:
-        return <Text>Bad config</Text>;
+        input = <Text>Bad config</Text>;
     }
+    return (
+      <FormGroup
+        key={`${ctrl.key}}`}
+        label={ctrl.kind == 'number' ? ctrl.name : undefined}
+        helperText={ctrl.description}
+        isInline
+        isStack
+      >
+        {input}
+      </FormGroup>
+    );
   };
 
   return (

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -87,13 +87,6 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
     ];
   }, [DashboardCards]);
 
-  const handleToggle = React.useCallback(
-    (isOpen) => {
-      setSelectOpen(isOpen);
-    },
-    [setSelectOpen]
-  );
-
   const handleSelect = React.useCallback(
     (_, selection, isPlaceholder) => {
       setSelection(isPlaceholder ? '' : selection);
@@ -174,7 +167,7 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
             >
               <Form>
                 <FormGroup label="Select a card type" isRequired isStack>
-                  <Select onToggle={handleToggle} isOpen={selectOpen} onSelect={handleSelect} selections={selection}>
+                  <Select onToggle={setSelectOpen} isOpen={selectOpen} onSelect={handleSelect} selections={selection}>
                     {options}
                   </Select>
                   <Text>
@@ -273,12 +266,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
       let input: JSX.Element;
       switch (ctrl.kind) {
         case 'boolean':
-          input = (
-            <Switch
-              isChecked={props.config[ctrl.key]}
-              onChange={handleChange(ctrl.key)}
-            />
-          );
+          input = <Switch isChecked={props.config[ctrl.key]} onChange={handleChange(ctrl.key)} />;
           break;
         case 'number':
           input = (
@@ -312,18 +300,36 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
             />
           );
           break;
+        case 'select':
+          const [selectOpen, setSelectOpen] = React.useState(false);
+          const handleSelect = React.useCallback(
+            (_, selection, isPlaceholder) => {
+              if (!isPlaceholder) {
+                handleChange(ctrl.key)(selection);
+              }
+              setSelectOpen(false);
+            },
+            [handleChange, setSelectOpen]
+          );
+          const options = (ctrl?.values || []).map((choice, idx) => <SelectOption key={idx} value={choice} />);
+          input = (
+            <Select
+              onToggle={setSelectOpen}
+              isOpen={selectOpen}
+              onSelect={handleSelect}
+              selections={props.config[ctrl.key]}
+            >
+              <SelectOption key={0} value={'None'} isPlaceholder />
+              <>{options}</>
+            </Select>
+          );
+          break;
         default:
           input = <Text>Bad config</Text>;
           break;
       }
       return (
-        <FormGroup
-          key={`${ctrl.key}}`}
-          label={ctrl.name}
-          helperText={ctrl.description}
-          isInline
-          isStack
-        >
+        <FormGroup key={`${ctrl.key}}`} label={ctrl.name} helperText={ctrl.description} isInline isStack>
           {input}
         </FormGroup>
       );

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -307,7 +307,11 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
           break;
         case 'select':
           input = (
-            <SelectControl handleChange={handleChange(ctrl.key)} config={props.config[ctrl.key]} control={ctrl} />
+            <SelectControl
+              handleChange={handleChange(ctrl.key)}
+              selectedConfig={props.config[ctrl.key]}
+              control={ctrl}
+            />
           );
           break;
         default:
@@ -337,7 +341,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
   );
 };
 
-const SelectControl = (props: { handleChange: ({}) => void; control: PropControl; config: any }) => {
+const SelectControl = (props: { handleChange: ({}) => void; control: PropControl; selectedConfig: any }) => {
   const addSubscription = useSubscriptions();
 
   const [selectOpen, setSelectOpen] = React.useState(false);
@@ -381,7 +385,7 @@ const SelectControl = (props: { handleChange: ({}) => void; control: PropControl
   }, [props.control, props.control.values, of, addSubscription, setOptions, setErrored]);
 
   return (
-    <Select onToggle={setSelectOpen} isOpen={selectOpen} onSelect={handleSelect} selections={props.config}>
+    <Select onToggle={setSelectOpen} isOpen={selectOpen} onSelect={handleSelect} selections={props.selectedConfig}>
       {errored
         ? [<SelectOption key={0} value={`Load Error: ${options[0]}`} isPlaceholder isDisabled />]
         : [<SelectOption key={0} value={'None'} isPlaceholder />].concat(

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -306,7 +306,9 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
           );
           break;
         case 'select':
-          input = <SelectControl handleChange={handleChange(ctrl.key)} config={props.config} control={ctrl} />;
+          input = (
+            <SelectControl handleChange={handleChange(ctrl.key)} config={props.config[ctrl.key]} control={ctrl} />
+          );
           break;
         default:
           input = <Text>Bad config</Text>;
@@ -379,12 +381,7 @@ const SelectControl = (props: { handleChange: ({}) => void; control: PropControl
   }, [props.control, props.control.values, of, addSubscription, setOptions, setErrored]);
 
   return (
-    <Select
-      onToggle={setSelectOpen}
-      isOpen={selectOpen}
-      onSelect={handleSelect}
-      selections={props.config[props.control.key]}
-    >
+    <Select onToggle={setSelectOpen} isOpen={selectOpen} onSelect={handleSelect} selections={props.config}>
       {errored
         ? [<SelectOption key={0} value={`Load Error: ${options[0]}`} isPlaceholder isDisabled />]
         : [<SelectOption key={0} value={'None'} isPlaceholder />].concat(

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -116,8 +116,9 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
   }, [setShowWizard]);
 
   const handleStop = React.useCallback(() => {
-    setSelection('');
     setShowWizard(false);
+    setSelection('');
+    setPropsConfig({});
   }, [setSelection, setShowWizard]);
 
   // custom nav for disabling subsequent steps (ex. configuration) if a card type hasn't been selected first
@@ -366,7 +367,6 @@ const SelectControl = (props: { handleChange: ({}) => void; control: PropControl
             }
             return [...old, v];
           }),
-        complete: () => {},
       })
     );
   }, [props.control, props.control.values, of, addSubscription, setOptions]);

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -179,7 +179,11 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
                   <Select onToggle={handleToggle} isOpen={selectOpen} onSelect={handleSelect} selections={selection}>
                     {options}
                   </Select>
-                  <Text>{selection && getConfigByTitle(selection).descriptionFull}</Text>
+                  <Text>
+                    {selection
+                      ? getConfigByTitle(selection).descriptionFull
+                      : 'Choose a card type to add to your dashboard. Some cards require additional configuration.'}
+                  </Text>
                 </FormGroup>
               </Form>
             </WizardStep>

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -122,10 +122,11 @@ export const AddCard: React.FunctionComponent<AddCardProps> = (props: AddCardPro
   }, [setShowWizard]);
 
   return (
+    // FIXME wizard navigation by clicking left-side step names should be disabled if the first step selection is empty
     <>
       <Card isRounded isLarge>
         {showWizard ? (
-          <Wizard onClose={handleStop} onSave={handleAdd} height={500}>
+          <Wizard isStepVisitRequired onClose={handleStop} onSave={handleAdd} height={500}>
             <WizardStep id="card-type-select" name="Card Type" footer={{ isNextDisabled: !selection }}>
               <Form>
                 <FormGroup label="Select a card type" isRequired isStack>

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -251,7 +251,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
     [props, props.onChange, setPropsConfig]
   );
 
-  const createControl = (ctrl: PropControl): JSX.Element => {
+  const createControl = React.useCallback((ctrl: PropControl): JSX.Element => {
     let input: JSX.Element;
     switch (ctrl.kind) {
       case 'boolean':
@@ -304,7 +304,7 @@ const PropsConfigForm = (props: PropsConfigFormProps) => {
         {input}
       </FormGroup>
     );
-  };
+  }, [propsConfig, handleChange, handleNumeric, handleNumericStep]);
 
   return (
     <>

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -108,7 +108,7 @@ import {
 } from './AutomatedAnalysisFilters';
 import { clickableAutomatedAnalysisKey, ClickableAutomatedAnalysisLabel } from './ClickableAutomatedAnalysisLabel';
 import { AutomatedAnalysisScoreFilter } from './Filters/AutomatedAnalysisScoreFilter';
-import { DashboardCardProps } from '../Dashboard';
+import { DashboardCardDescriptor, DashboardCardProps, PropKind } from '../Dashboard';
 
 interface AutomatedAnalysisCardProps extends DashboardCardProps {
   isLarge?: boolean;
@@ -790,4 +790,34 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
       </CardExpandableContent>
     </Card>
   );
+};
+
+export const AutomatedAnalysisCardDescriptor: DashboardCardDescriptor = {
+  title: 'Automated Analysis',
+  description: `
+Assess common application performance and configuration issues.
+    `,
+  descriptionFull: `
+Creates a recording and periodically evalutes various common problems in application configuration and performance.
+Results are displayed with scores from 0-100 with colour coding and in groups.
+This card should be unique on a dashboard.
+      `,
+  component: AutomatedAnalysisCard,
+  propControls: [
+    {
+      name: 'Compact Style',
+      key: 'isCompact',
+      description: 'Apply PatternFly compact Card styling to reduce padding',
+      kind: PropKind.BOOLEAN,
+      defaultValue: true,
+    },
+    // TODO remove one or both of these, they are useful for development testing but not for a user
+    {
+      name: 'Large Style',
+      key: 'isLarge',
+      description: 'Apply PatternFly large Card styling',
+      kind: PropKind.BOOLEAN,
+      defaultValue: false,
+    },
+  ],
 };

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -109,6 +109,7 @@ import {
 import { clickableAutomatedAnalysisKey, ClickableAutomatedAnalysisLabel } from './ClickableAutomatedAnalysisLabel';
 import { AutomatedAnalysisScoreFilter } from './Filters/AutomatedAnalysisScoreFilter';
 import { DashboardCardDescriptor, DashboardCardProps } from '../Dashboard';
+import { AutomatedAnalysisConfigForm } from './AutomatedAnalysisConfigForm';
 
 interface AutomatedAnalysisCardProps extends DashboardCardProps {
   isLarge?: boolean;
@@ -820,4 +821,6 @@ This card should be unique on a dashboard.
       defaultValue: false,
     },
   ],
+  // FIXME this form gets embedded within a form, and should not have its own independent create/save controls
+  advancedConfig: <AutomatedAnalysisConfigForm isSettingsForm={false}></AutomatedAnalysisConfigForm>,
 };

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -108,7 +108,7 @@ import {
 } from './AutomatedAnalysisFilters';
 import { clickableAutomatedAnalysisKey, ClickableAutomatedAnalysisLabel } from './ClickableAutomatedAnalysisLabel';
 import { AutomatedAnalysisScoreFilter } from './Filters/AutomatedAnalysisScoreFilter';
-import { DashboardCardDescriptor, DashboardCardProps, PropKind } from '../Dashboard';
+import { DashboardCardDescriptor, DashboardCardProps } from '../Dashboard';
 
 interface AutomatedAnalysisCardProps extends DashboardCardProps {
   isLarge?: boolean;
@@ -808,7 +808,7 @@ This card should be unique on a dashboard.
       name: 'Compact Style',
       key: 'isCompact',
       description: 'Apply PatternFly compact Card styling to reduce padding',
-      kind: PropKind.BOOLEAN,
+      kind: 'boolean',
       defaultValue: true,
     },
     // TODO remove one or both of these, they are useful for development testing but not for a user
@@ -816,7 +816,7 @@ This card should be unique on a dashboard.
       name: 'Large Style',
       key: 'isLarge',
       description: 'Apply PatternFly large Card styling',
-      kind: PropKind.BOOLEAN,
+      kind: 'boolean',
       defaultValue: false,
     },
   ],

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -81,8 +81,6 @@ import {
   LabelGroup,
   Level,
   LevelItem,
-  Split,
-  SplitItem,
   Stack,
   StackItem,
   Text,
@@ -111,10 +109,7 @@ import { AutomatedAnalysisScoreFilter } from './Filters/AutomatedAnalysisScoreFi
 import { DashboardCardDescriptor, DashboardCardProps } from '../Dashboard';
 import { AutomatedAnalysisConfigForm } from './AutomatedAnalysisConfigForm';
 
-interface AutomatedAnalysisCardProps extends DashboardCardProps {
-  isLarge?: boolean;
-  isCompact?: boolean;
-}
+interface AutomatedAnalysisCardProps extends DashboardCardProps {}
 
 export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCardProps> = (props) => {
   const context = React.useContext(ServiceContext);
@@ -757,7 +752,7 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
   }, [usingArchivedReport, usingCachedReport, report, isLoading, errorMessage]);
 
   return (
-    <Card id="automated-analysis-card" isRounded {...props} isExpanded={isCardExpanded}>
+    <Card id="automated-analysis-card" isRounded isCompact {...props} isExpanded={isCardExpanded}>
       <CardHeader
         onExpand={onCardExpand}
         toggleButtonProps={{
@@ -804,23 +799,7 @@ Results are displayed with scores from 0-100 with colour coding and in groups.
 This card should be unique on a dashboard.
       `,
   component: AutomatedAnalysisCard,
-  propControls: [
-    {
-      name: 'Compact Style',
-      key: 'isCompact',
-      description: 'Apply PatternFly compact Card styling to reduce padding',
-      kind: 'boolean',
-      defaultValue: true,
-    },
-    // TODO remove one or both of these, they are useful for development testing but not for a user
-    {
-      name: 'Large Style',
-      key: 'isLarge',
-      description: 'Apply PatternFly large Card styling',
-      kind: 'boolean',
-      defaultValue: false,
-    },
-  ],
+  propControls: [],
   // FIXME this form gets embedded within a form, and should not have its own independent create/save controls
   advancedConfig: <AutomatedAnalysisConfigForm isSettingsForm={false}></AutomatedAnalysisConfigForm>,
 };

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -58,7 +58,8 @@ export interface PropControl {
   name: string;
   key: string;
   description: string;
-  kind: 'boolean' | 'number' | 'string' | 'text';
+  kind: 'boolean' | 'number' | 'string' | 'text' | 'select';
+  values?: any[];
   defaultValue: any;
 }
 
@@ -70,7 +71,7 @@ export interface DashboardCardProps {
 
 // TODO remove this
 const PlaceholderCard: React.FunctionComponent<
-  { title: string; message: string; count: number; toggleswitch: boolean } & DashboardCardProps
+  { title: string; message: string; count: number; toggleswitch: boolean; menu: string } & DashboardCardProps
 > = (props) => {
   return (
     <Card isRounded>
@@ -82,6 +83,7 @@ const PlaceholderCard: React.FunctionComponent<
         <Text>message: {props.message}</Text>
         <Text>count: {props.count}</Text>
         <Text>toggle: {String(props.toggleswitch)}</Text>
+        <Text>menu: {props.menu}</Text>
       </CardBody>
     </Card>
   );
@@ -115,6 +117,14 @@ export const DashboardCards: DashboardCardDescriptor[] = [
         defaultValue: 'a long text',
         description: 'a text input',
         kind: 'text',
+      },
+      {
+        name: 'menu select',
+        key: 'menu',
+        values: ['choices', 'options'],
+        defaultValue: '',
+        description: 'a selection menu',
+        kind: 'select',
       },
       {
         name: 'a switch',

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -38,7 +38,7 @@
 import * as React from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { useDispatch, useSelector } from 'react-redux';
-import { addCardIntent, deleteCardIntent } from '@app/Shared/Redux/DashboardConfigActions';
+import { deleteCardIntent } from '@app/Shared/Redux/DashboardConfigActions';
 import { TargetView } from '@app/TargetView/TargetView';
 import { AddCard } from './AddCard';
 import { DashboardCardActionMenu } from './DashboardCardActionMenu';
@@ -50,7 +50,19 @@ export interface CardDescriptor {
   description: string;
   descriptionFull: JSX.Element | string;
   component: React.FunctionComponent;
-  props?: React.PropsWithChildren<any>;
+  propControls: PropControl[];
+}
+
+export enum PropKind {
+  BOOLEAN,
+}
+
+export interface PropControl {
+  name: string;
+  key: string;
+  description: string;
+  kind: PropKind;
+  defaultValue: any;
 }
 
 export interface DashboardProps {}
@@ -71,9 +83,23 @@ Results are displayed with scores from 0-100 with colour coding and in groups.
 This card should be unique on a dashboard.
       `,
     component: AutomatedAnalysisCard,
-    props: {
-      isCompact: true,
-    },
+    propControls: [
+      {
+        name: 'Compact Style',
+        key: 'isCompact',
+        description: 'Apply PatternFly compact Card styling to reduce padding',
+        kind: PropKind.BOOLEAN,
+        defaultValue: true,
+      },
+      // TODO remove one or both of these, they are useful for development testing but not for a user
+      {
+        name: 'Large Style',
+        key: 'isLarge',
+        description: 'Apply PatternFly large Card styling',
+        kind: PropKind.BOOLEAN,
+        defaultValue: false,
+      },
+    ],
   },
 ];
 
@@ -109,17 +135,14 @@ export const Dashboard: React.FunctionComponent<DashboardProps> = (props) => {
   return (
     <TargetView pageTitle="Dashboard" compactSelect={false} hideEmptyState>
       <Stack hasGutter>
-        {cardConfigs
-          .map((card) => card.name)
-          .map(getConfigByName)
-          .map((cfg, idx) => (
-            <StackItem key={idx}>
-              {React.createElement(cfg.component, {
-                ...cfg.props,
-                actions: [<DashboardCardActionMenu onRemove={() => handleRemove(idx)} />],
-              })}
-            </StackItem>
-          ))}
+        {cardConfigs.map((cfg, idx) => (
+          <StackItem key={idx}>
+            {React.createElement(getConfigByName(cfg.name).component, {
+              ...cfg.props,
+              actions: [<DashboardCardActionMenu onRemove={() => handleRemove(idx)} />],
+            })}
+          </StackItem>
+        ))}
         <StackItem key={cardConfigs.length}>
           <AddCard />
         </StackItem>

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -51,6 +51,7 @@ export interface DashboardCardDescriptor {
   descriptionFull: JSX.Element | string;
   component: React.FunctionComponent<any>;
   propControls: PropControl[];
+  advancedConfig?: JSX.Element;
 }
 
 export interface PropControl {

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -143,8 +143,9 @@ export const DashboardCards: DashboardCardDescriptor[] = [
         values: new Observable((subscriber) => {
           let count = 0;
           const id = setInterval(() => {
-            if (count > 5) {
+            if (count > 2) {
               clearInterval(id);
+              setTimeout(() => subscriber.error('Timed Out'), 5000);
             }
             subscriber.next(`async ${count++}`);
           }, 1000);

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -44,6 +44,7 @@ import { AddCard } from './AddCard';
 import { DashboardCardActionMenu } from './DashboardCardActionMenu';
 import { AutomatedAnalysisCardDescriptor } from './AutomatedAnalysis/AutomatedAnalysisCard';
 import { RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
+import { Observable, of } from 'rxjs';
 
 export interface DashboardCardDescriptor {
   title: string;
@@ -59,7 +60,7 @@ export interface PropControl {
   key: string;
   description: string;
   kind: 'boolean' | 'number' | 'string' | 'text' | 'select';
-  values?: any[];
+  values?: any[] | Observable<any>;
   defaultValue: any;
 }
 
@@ -124,6 +125,30 @@ export const DashboardCards: DashboardCardDescriptor[] = [
         values: ['choices', 'options'],
         defaultValue: '',
         description: 'a selection menu',
+        kind: 'select',
+      },
+      {
+        name: 'menu select 2',
+        key: 'asyncmenu',
+        values: new Observable((subscriber) => {
+          let count = 0;
+          const id = setInterval(() => {
+            if (count > 5) {
+              clearInterval(id);
+            }
+            subscriber.next(`async ${count++}`);
+          }, 1000);
+        }),
+        defaultValue: '',
+        description: 'an async stream selection menu',
+        kind: 'select',
+      },
+      {
+        name: 'menu select 3',
+        key: 'asyncmenu2',
+        values: of(['arr1', 'arr2', 'arr3']),
+        defaultValue: '',
+        description: 'an async array selection menu',
         kind: 'select',
       },
       {

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 import * as React from 'react';
-import { Stack, StackItem } from '@patternfly/react-core';
+import { Card, CardActions, CardBody, CardHeader, Stack, StackItem, Text } from '@patternfly/react-core';
 import { useDispatch, useSelector } from 'react-redux';
 import { deleteCardIntent } from '@app/Shared/Redux/DashboardConfigActions';
 import { TargetView } from '@app/TargetView/TargetView';
@@ -71,6 +71,20 @@ export interface DashboardCardProps {
   actions?: JSX.Element[];
 }
 
+// TODO remove this
+const PlaceholderCard: React.FunctionComponent = (props: DashboardCardProps) => {
+  return (
+    <Card isRounded {...props}>
+      <CardHeader>
+        <CardActions>{...props.actions || []}</CardActions>
+      </CardHeader>
+      <CardBody>
+        <Text>Hello! This is a placeholder.</Text>
+      </CardBody>
+    </Card>
+  );
+};
+
 export const DashboardCards: CardDescriptor[] = [
   {
     title: 'Automated Analysis',
@@ -100,6 +114,13 @@ This card should be unique on a dashboard.
         defaultValue: false,
       },
     ],
+  },
+  {
+    title: 'Placeholder',
+    description: 'placeholder',
+    descriptionFull: 'This is a do-nothing placeholder with no config',
+    component: PlaceholderCard,
+    propControls: [],
   },
 ];
 

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -45,7 +45,7 @@ import { DashboardCardActionMenu } from './DashboardCardActionMenu';
 import { AutomatedAnalysisCard } from './AutomatedAnalysis/AutomatedAnalysisCard';
 import { RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
 
-export interface CardConfig {
+export interface CardDescriptor {
   title: string;
   description: string;
   descriptionFull: JSX.Element | string;
@@ -59,7 +59,7 @@ export interface DashboardCardProps {
   actions?: JSX.Element[];
 }
 
-export const DashboardCards: CardConfig[] = [
+export const DashboardCards: CardDescriptor[] = [
   {
     title: 'Automated Analysis',
     description: `
@@ -77,7 +77,7 @@ This card should be unique on a dashboard.
   },
 ];
 
-export function getConfigByName(name: String): CardConfig {
+export function getConfigByName(name: string): CardDescriptor {
   for (const choice of DashboardCards) {
     if (choice.component.name === name) {
       return choice;
@@ -86,7 +86,7 @@ export function getConfigByName(name: String): CardConfig {
   throw new Error(`Unknown card type selection: ${name}`);
 }
 
-export function getConfigByTitle(title: String): CardConfig {
+export function getConfigByTitle(title: string): CardDescriptor {
   for (const choice of DashboardCards) {
     if (choice.title === title) {
       return choice;
@@ -97,27 +97,30 @@ export function getConfigByTitle(title: String): CardConfig {
 
 export const Dashboard: React.FunctionComponent<DashboardProps> = (props) => {
   const dispatch = useDispatch<StateDispatch>();
-  const cardNames = useSelector((state: RootState) => state.dashboardConfigs.list);
+  const cardConfigs = useSelector((state: RootState) => state.dashboardConfigs.list);
 
   const handleRemove = React.useCallback(
     (idx: number) => {
       dispatch(deleteCardIntent(idx));
     },
-    [dispatch, cardNames]
+    [dispatch, cardConfigs]
   );
 
   return (
     <TargetView pageTitle="Dashboard" compactSelect={false} hideEmptyState>
       <Stack hasGutter>
-        {cardNames.map(getConfigByName).map((cfg, idx) => (
-          <StackItem key={idx}>
-            {React.createElement(cfg.component, {
-              ...cfg.props,
-              actions: [<DashboardCardActionMenu onRemove={() => handleRemove(idx)} />],
-            })}
-          </StackItem>
-        ))}
-        <StackItem key={cardNames.length}>
+        {cardConfigs
+          .map((card) => card.name)
+          .map(getConfigByName)
+          .map((cfg, idx) => (
+            <StackItem key={idx}>
+              {React.createElement(cfg.component, {
+                ...cfg.props,
+                actions: [<DashboardCardActionMenu onRemove={() => handleRemove(idx)} />],
+              })}
+            </StackItem>
+          ))}
+        <StackItem key={cardConfigs.length}>
           <AddCard />
         </StackItem>
       </Stack>

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -72,7 +72,15 @@ export interface DashboardCardProps {
 
 // TODO remove this
 const PlaceholderCard: React.FunctionComponent<
-  { title: string; message: string; count: number; toggleswitch: boolean; menu: string } & DashboardCardProps
+  {
+    title: string;
+    message: string;
+    count: number;
+    toggleswitch: boolean;
+    menu: string;
+    asyncmenu: string;
+    asyncmenu2: string;
+  } & DashboardCardProps
 > = (props) => {
   return (
     <Card isRounded>
@@ -85,6 +93,8 @@ const PlaceholderCard: React.FunctionComponent<
         <Text>count: {props.count}</Text>
         <Text>toggle: {String(props.toggleswitch)}</Text>
         <Text>menu: {props.menu}</Text>
+        <Text>asyncmenu: {props.asyncmenu}</Text>
+        <Text>asyncmenus: {props.asyncmenu2}</Text>
       </CardBody>
     </Card>
   );

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -131,6 +131,7 @@ export const DashboardCards: DashboardCardDescriptor[] = [
         kind: 'number',
       },
     ],
+    advancedConfig: <Text>This is an advanced configuration component</Text>,
   },
 ];
 

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -49,7 +49,7 @@ export interface DashboardCardDescriptor {
   title: string;
   description: string;
   descriptionFull: JSX.Element | string;
-  component: React.FunctionComponent;
+  component: React.FunctionComponent<any>;
   propControls: PropControl[];
 }
 
@@ -57,7 +57,7 @@ export interface PropControl {
   name: string;
   key: string;
   description: string;
-  kind: 'boolean';
+  kind: 'boolean' | 'number' | 'string' | 'text';
   defaultValue: any;
 }
 
@@ -68,14 +68,19 @@ export interface DashboardCardProps {
 }
 
 // TODO remove this
-const PlaceholderCard: React.FunctionComponent = (props: DashboardCardProps) => {
+const PlaceholderCard: React.FunctionComponent<
+  { title: string; message: string; count: number; toggleswitch: boolean } & DashboardCardProps
+> = (props) => {
   return (
-    <Card isRounded {...props}>
+    <Card isRounded>
       <CardHeader>
         <CardActions>{...props.actions || []}</CardActions>
       </CardHeader>
       <CardBody>
-        <Text>Hello! This is a placeholder.</Text>
+        <Text>title: {props.title}</Text>
+        <Text>message: {props.message}</Text>
+        <Text>count: {props.count}</Text>
+        <Text>toggle: {String(props.toggleswitch)}</Text>
       </CardBody>
     </Card>
   );
@@ -84,11 +89,47 @@ const PlaceholderCard: React.FunctionComponent = (props: DashboardCardProps) => 
 export const DashboardCards: DashboardCardDescriptor[] = [
   AutomatedAnalysisCardDescriptor,
   {
-    title: 'Placeholder',
+    title: 'None Placeholder',
     description: 'placeholder',
     descriptionFull: 'This is a do-nothing placeholder with no config',
     component: PlaceholderCard,
     propControls: [],
+  },
+  {
+    title: 'All Placeholder',
+    description: 'placeholder',
+    descriptionFull: 'This is a do-nothing placeholder with all the config',
+    component: PlaceholderCard,
+    propControls: [
+      {
+        name: 'string',
+        key: 'title',
+        defaultValue: 'a short text',
+        description: 'a string input',
+        kind: 'string',
+      },
+      {
+        name: 'text',
+        key: 'message',
+        defaultValue: 'a long text',
+        description: 'a text input',
+        kind: 'text',
+      },
+      {
+        name: 'a switch',
+        key: 'toggleswitch',
+        defaultValue: false,
+        description: 'a boolean input',
+        kind: 'boolean',
+      },
+      {
+        name: 'numeric spinner input',
+        key: 'count',
+        defaultValue: 5,
+        description: 'a number input',
+        kind: 'number',
+      },
+    ],
   },
 ];
 

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -159,7 +159,7 @@ export const Dashboard: React.FunctionComponent<DashboardProps> = (props) => {
     (idx: number) => {
       dispatch(deleteCardIntent(idx));
     },
-    [dispatch, cardConfigs]
+    [dispatch, deleteCardIntent]
   );
 
   return (

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -53,15 +53,11 @@ export interface DashboardCardDescriptor {
   propControls: PropControl[];
 }
 
-export enum PropKind {
-  BOOLEAN,
-}
-
 export interface PropControl {
   name: string;
   key: string;
   description: string;
-  kind: PropKind;
+  kind: 'boolean';
   defaultValue: any;
 }
 

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -42,10 +42,10 @@ import { deleteCardIntent } from '@app/Shared/Redux/DashboardConfigActions';
 import { TargetView } from '@app/TargetView/TargetView';
 import { AddCard } from './AddCard';
 import { DashboardCardActionMenu } from './DashboardCardActionMenu';
-import { AutomatedAnalysisCard } from './AutomatedAnalysis/AutomatedAnalysisCard';
+import { AutomatedAnalysisCardDescriptor } from './AutomatedAnalysis/AutomatedAnalysisCard';
 import { RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
 
-export interface CardDescriptor {
+export interface DashboardCardDescriptor {
   title: string;
   description: string;
   descriptionFull: JSX.Element | string;
@@ -85,36 +85,8 @@ const PlaceholderCard: React.FunctionComponent = (props: DashboardCardProps) => 
   );
 };
 
-export const DashboardCards: CardDescriptor[] = [
-  {
-    title: 'Automated Analysis',
-    description: `
-Assess common application performance and configuration issues.
-    `,
-    descriptionFull: `
-Creates a recording and periodically evalutes various common problems in application configuration and performance.
-Results are displayed with scores from 0-100 with colour coding and in groups.
-This card should be unique on a dashboard.
-      `,
-    component: AutomatedAnalysisCard,
-    propControls: [
-      {
-        name: 'Compact Style',
-        key: 'isCompact',
-        description: 'Apply PatternFly compact Card styling to reduce padding',
-        kind: PropKind.BOOLEAN,
-        defaultValue: true,
-      },
-      // TODO remove one or both of these, they are useful for development testing but not for a user
-      {
-        name: 'Large Style',
-        key: 'isLarge',
-        description: 'Apply PatternFly large Card styling',
-        kind: PropKind.BOOLEAN,
-        defaultValue: false,
-      },
-    ],
-  },
+export const DashboardCards: DashboardCardDescriptor[] = [
+  AutomatedAnalysisCardDescriptor,
   {
     title: 'Placeholder',
     description: 'placeholder',
@@ -124,7 +96,7 @@ This card should be unique on a dashboard.
   },
 ];
 
-export function getConfigByName(name: string): CardDescriptor {
+export function getConfigByName(name: string): DashboardCardDescriptor {
   for (const choice of DashboardCards) {
     if (choice.component.name === name) {
       return choice;
@@ -133,7 +105,7 @@ export function getConfigByName(name: string): CardDescriptor {
   throw new Error(`Unknown card type selection: ${name}`);
 }
 
-export function getConfigByTitle(title: string): CardDescriptor {
+export function getConfigByTitle(title: string): DashboardCardDescriptor {
   for (const choice of DashboardCards) {
     if (choice.title === title) {
       return choice;

--- a/src/app/Shared/Redux/DashboardConfigActions.tsx
+++ b/src/app/Shared/Redux/DashboardConfigActions.tsx
@@ -44,19 +44,24 @@ export enum DashboardConfigAction {
   CARD_REMOVE = 'card/remove',
 }
 
-export interface DashboardConfigActionPayload {
+export interface DashboardAddConfigActionPayload {
   name: string;
+  props: any;
+}
+
+export interface DashboardDeleteConfigActionPayload {
   idx: number;
 }
 
-export const addCardIntent = createAction(DashboardConfigAction.CARD_ADD, (name: string) => ({
+export const addCardIntent = createAction(DashboardConfigAction.CARD_ADD, (name: string, props: any) => ({
   payload: {
     name,
-  } as DashboardConfigActionPayload,
+    props,
+  } as DashboardAddConfigActionPayload,
 }));
 
 export const deleteCardIntent = createAction(DashboardConfigAction.CARD_REMOVE, (idx: number) => ({
   payload: {
     idx,
-  } as DashboardConfigActionPayload,
+  } as DashboardDeleteConfigActionPayload,
 }));

--- a/src/app/Shared/Redux/DashboardConfigReducer.tsx
+++ b/src/app/Shared/Redux/DashboardConfigReducer.tsx
@@ -53,7 +53,7 @@ const initialState = {
 export const dashboardConfigReducer = createReducer(initialState, (builder) => {
   builder
     .addCase(addCardIntent, (state, { payload }) => {
-      state.list.splice(0, 0, payload);
+      state.list.push(payload);
     })
     .addCase(deleteCardIntent, (state, { payload }) => {
       state.list.splice(payload.idx || 0, 1);

--- a/src/app/Shared/Redux/DashboardConfigReducer.tsx
+++ b/src/app/Shared/Redux/DashboardConfigReducer.tsx
@@ -40,15 +40,20 @@ import { getFromLocalStorage } from '@app/utils/LocalStorage';
 import { createReducer } from '@reduxjs/toolkit';
 import { addCardIntent, deleteCardIntent } from './DashboardConfigActions';
 
+export interface CardConfig {
+  name: string;
+  props: any;
+}
+
 // Initial states are loaded from local storage if there are any
 const initialState = {
-  list: getFromLocalStorage('DASHBOARD_CFG', []) as string[],
+  list: getFromLocalStorage('DASHBOARD_CFG', []) as CardConfig[],
 };
 
 export const dashboardConfigReducer = createReducer(initialState, (builder) => {
   builder
     .addCase(addCardIntent, (state, { payload }) => {
-      state.list.splice(payload.idx || 0, 0, payload.name);
+      state.list.splice(0, 0, payload);
     })
     .addCase(deleteCardIntent, (state, { payload }) => {
       state.list.splice(payload.idx || 0, 1);


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #727

## Description of the change:
This change adds a step to the Add card on the Dashboard. The new step builds a dynamic form for configuring
the selected card type. This form becomes `props` passed to the card(s) when created. This configuration is
stored in the Redux store and persisted to localstorage along with the previous implementation's simple linear
layout of card names, so the configuration props are also persistent.

## Motivation for the change:
This allows more flexibility for card implementations with multiple instances since the instances can be
distinguished simply by props rather than needing to implement more complex partitioning of the Redux store.
This will also be useful for configuration of card sizes in the dynamic grid layout. For the Grafana cards
we have discussed, this system could be used for configuring which specific Grafana chart should be displayed
within the card.

![image](https://user-images.githubusercontent.com/3787464/207123280-038eaf12-1853-4537-a820-d285f0cccd36.png)

![image](https://user-images.githubusercontent.com/3787464/207123323-379bbdbf-055a-4f3f-80fc-dd75f87f6ab0.png)
