### PR TITLE
fix(ci): small ci fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     labels:
       - "dependencies"
       - "chore"
+      - "safe-to-test"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,10 @@
 name: Label pull request
 
 on:
-- pull_request_target
+  pull_request_target:
+    types: 
+      - opened
+      - reopened
 
 jobs:
   triage:
@@ -9,6 +12,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     steps:
     - uses: actions/labeler@v4
       with:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #759 

## Description of the change:
Allows dependabot to add safe-to-test label to it's PRs and makes the labeler only call its workflow on `open` and `reopen` actions.

## Motivation for the change:
This change is helpful because dependabot shouldn't be blocked and the labeler shouldn't be spamming needs-triage whenever people do actions that don't require triage.

## How to manually test:
1. Not applicable.
