### PR TITLE
chore(about): use cryostat custom background in about modal

### DIFF
--- a/src/app/About/AboutCryostatModal.tsx
+++ b/src/app/About/AboutCryostatModal.tsx
@@ -40,6 +40,7 @@ import { AboutModal } from '@patternfly/react-core';
 import React from 'react';
 import build from '@app/build.json';
 import cryostatLogo from '@app/assets/cryostat_icon_rgb_reverse.svg';
+import bkgImg from '@app/assets/about_background.png';
 import { AboutDescription, CRYOSTAT_TRADEMARK } from './AboutDescription';
 
 export const AboutCryostatModal = ({ isOpen, onClose }) => {
@@ -52,6 +53,7 @@ export const AboutCryostatModal = ({ isOpen, onClose }) => {
         isOpen={isOpen}
         onClose={onClose}
         trademark={CRYOSTAT_TRADEMARK}
+        backgroundImageSrc={bkgImg}
       >
         <AboutDescription />
       </AboutModal>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #768 

## Description of the change:

Added a custom background image for our Cryostat about modal.

## Motivation for the change:

Cryostat needs its own background image instead of the Patternfly default.

## How to manually test:
1. `Run CRYOSTAT_IMAGE=<gh-action-image> sh smoketest.sh`
2. Go top top-right and click on the`?` icon .
3. See the new modal with latest background image.
