### PR TITLE
chore(featureflags): add dynamic flag wrapper component

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -77,7 +77,7 @@ import { SessionState } from '@app/Shared/Services/Login.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
-import { FeatureFlag } from '@app/Shared/FeatureFlag/FeatureFlag';
+import { DynamicFeatureFlag, FeatureFlag } from '@app/Shared/FeatureFlag/FeatureFlag';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -329,20 +329,20 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
         logo={
           <>
             <Brand alt="Cryostat" src={cryostatLogo} className="cryostat-logo" />
-            <FeatureFlag strict level={FeatureLevel.DEVELOPMENT}>
-              <PageHeaderToolsItem>
-                <Label style={{ marginLeft: '2ch' }} isCompact color="red">
-                  Development
-                </Label>
-              </PageHeaderToolsItem>
-            </FeatureFlag>
-            <FeatureFlag strict level={FeatureLevel.BETA}>
-              <PageHeaderToolsItem>
-                <Label style={{ marginLeft: '2ch' }} isCompact color="green">
-                  Beta
-                </Label>
-              </PageHeaderToolsItem>
-            </FeatureFlag>
+            <DynamicFeatureFlag
+              levels={[FeatureLevel.DEVELOPMENT, FeatureLevel.BETA]}
+              component={(level) => (
+                <PageHeaderToolsItem>
+                  <Label
+                    style={{ marginLeft: '2ch', textTransform: 'capitalize' }}
+                    isCompact
+                    color={level == FeatureLevel.BETA ? 'green' : 'red'}
+                  >
+                    {FeatureLevel[level].toLowerCase()}
+                  </Label>
+                </PageHeaderToolsItem>
+              )}
+            />
           </>
         }
         logoProps={logoProps}

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -323,26 +323,27 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
     </>
   );
 
+  const levelBadge = React.useCallback((level: FeatureLevel) => {
+    return (
+      <PageHeaderToolsItem>
+        <Label
+          isCompact
+          style={{ marginLeft: '2ch', textTransform: 'capitalize' }}
+          color={level === FeatureLevel.BETA ? 'green' : 'red'}
+        >
+          {FeatureLevel[level].toLowerCase()}
+        </Label>
+      </PageHeaderToolsItem>
+    );
+  }, []);
+
   const Header = (
     <>
       <PageHeader
         logo={
           <>
             <Brand alt="Cryostat" src={cryostatLogo} className="cryostat-logo" />
-            <DynamicFeatureFlag
-              levels={[FeatureLevel.DEVELOPMENT, FeatureLevel.BETA]}
-              component={(level) => (
-                <PageHeaderToolsItem>
-                  <Label
-                    style={{ marginLeft: '2ch', textTransform: 'capitalize' }}
-                    isCompact
-                    color={level == FeatureLevel.BETA ? 'green' : 'red'}
-                  >
-                    {FeatureLevel[level].toLowerCase()}
-                  </Label>
-                </PageHeaderToolsItem>
-              )}
-            />
+            <DynamicFeatureFlag levels={[FeatureLevel.DEVELOPMENT, FeatureLevel.BETA]} component={levelBadge} />
           </>
         }
         logoProps={logoProps}

--- a/src/app/Shared/FeatureFlag/FeatureFlag.tsx
+++ b/src/app/Shared/FeatureFlag/FeatureFlag.tsx
@@ -62,3 +62,20 @@ export const FeatureFlag: React.FunctionComponent<FeatureFlagProps> = ({ level, 
 
   return <></>;
 };
+
+export interface DynamicFeatureFlagProps {
+  levels: FeatureLevel[];
+  component: (level: FeatureLevel) => React.ReactNode;
+}
+
+export const DynamicFeatureFlag: React.FunctionComponent<DynamicFeatureFlagProps> = ({ levels, component }) => {
+  return (
+    <>
+      {levels.map((level) => (
+        <FeatureFlag strict level={level}>
+          {component(level)}
+        </FeatureFlag>
+      ))}
+    </>
+  );
+};

--- a/src/app/Shared/FeatureFlag/FeatureFlag.tsx
+++ b/src/app/Shared/FeatureFlag/FeatureFlag.tsx
@@ -71,11 +71,13 @@ export interface DynamicFeatureFlagProps {
 export const DynamicFeatureFlag: React.FunctionComponent<DynamicFeatureFlagProps> = ({ levels, component }) => {
   return (
     <>
-      {levels.map((level) => (
-        <FeatureFlag strict level={level}>
-          {component(level)}
-        </FeatureFlag>
-      ))}
+      {levels
+        .filter((level) => levels.includes(level))
+        .map((level) => (
+          <FeatureFlag strict level={level}>
+            {component(level)}
+          </FeatureFlag>
+        ))}
     </>
   );
 };

--- a/src/app/Shared/FeatureFlag/FeatureFlag.tsx
+++ b/src/app/Shared/FeatureFlag/FeatureFlag.tsx
@@ -40,29 +40,6 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 
-export interface FeatureFlagProps {
-  strict?: boolean;
-  level: FeatureLevel;
-  children?: React.ReactNode | undefined;
-}
-
-export const FeatureFlag: React.FunctionComponent<FeatureFlagProps> = ({ level, strict, children }) => {
-  const context = React.useContext(ServiceContext);
-  const addSubscription = useSubscriptions();
-  const [activeLevel, setActiveLevel] = React.useState(FeatureLevel.PRODUCTION);
-
-  React.useLayoutEffect(() => {
-    addSubscription(context.settings.featureLevel().subscribe((featureLevel) => setActiveLevel(featureLevel)));
-  }, [addSubscription, context.settings.featureLevel, setActiveLevel]);
-
-  const comparator = strict ? (a, b) => a === b : (a, b) => a >= b;
-  if (comparator(level, activeLevel)) {
-    return <>{children}</>;
-  }
-
-  return <></>;
-};
-
 export interface DynamicFeatureFlagProps {
   levels: FeatureLevel[];
   component: (level: FeatureLevel) => React.ReactNode;
@@ -90,4 +67,24 @@ export const DynamicFeatureFlag: React.FunctionComponent<DynamicFeatureFlagProps
   }, [levels, activeLevel, component, defaultComponent]);
 
   return <>{toRender}</>;
+};
+
+export interface FeatureFlagProps {
+  strict?: boolean;
+  level: FeatureLevel;
+  children?: React.ReactNode | undefined;
+}
+
+export const FeatureFlag: React.FunctionComponent<FeatureFlagProps> = ({ level, strict, children }) => {
+  const levels = React.useMemo(
+    () => (strict ? [level] : [...Array.from({ length: level + 1 }, (_, i) => i)]),
+    [strict, level]
+  );
+  const component = React.useCallback((_) => <>{children}</>, [children]);
+
+  return (
+    <>
+      <DynamicFeatureFlag levels={levels} component={component} />
+    </>
+  );
 };


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #761

Quick refactoring. Adds a new feature flag component type which is gated on a list of accepted levels and requires a prop function that generates the flagged component from the active level. This allows the flagged component to adapt to the active level rather than requiring separate definitions of a component for each level. In most cases the previous "static" `<FeatureFlag></FeatureFlag>` component should be preferred.
