### PR TITLE
feat(rules): allow cleanup resources when disabling automated rules

### DIFF
--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -69,7 +69,7 @@ import { LoadingView } from '@app/LoadingView/LoadingView';
 import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
 import { EventProbe } from '@app/Shared/Services/Api.service';
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { SearchIcon } from '@patternfly/react-icons';
 import { AboutAgentCard } from './AboutAgentCard';
 import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
@@ -164,7 +164,7 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
   }, [setWarningModalOpen]);
 
   const handleDeleteButton = React.useCallback(() => {
-    if (context.settings.deletionDialogsEnabledFor(DeleteWarningType.DeleteActiveProbes)) {
+    if (context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteActiveProbes)) {
       setWarningModalOpen(true);
     } else {
       handleDeleteAllProbes();
@@ -327,7 +327,7 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
                 </ToolbarGroup>
               </ToolbarContent>
               <DeleteWarningModal
-                warningType={DeleteWarningType.DeleteActiveProbes}
+                warningType={DeleteOrDisableWarningType.DeleteActiveProbes}
                 visible={warningModalOpen}
                 onAccept={handleWarningModalAccept}
                 onClose={handleWarningModalClose}

--- a/src/app/Agent/AgentProbeTemplates.tsx
+++ b/src/app/Agent/AgentProbeTemplates.tsx
@@ -38,7 +38,7 @@
 import { ErrorView } from '@app/ErrorView/ErrorView';
 import { LoadingView } from '@app/LoadingView/LoadingView';
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { FUpload, MultiFileUpload, UploadCallbacks } from '@app/Shared/FileUploads';
 import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 import { ProbeTemplate } from '@app/Shared/Services/Api.service';
@@ -233,7 +233,7 @@ export const AgentProbeTemplates: React.FunctionComponent<AgentProbeTemplatesPro
 
   const handleDeleteAction = React.useCallback(
     (template: ProbeTemplate) => {
-      if (context.settings.deletionDialogsEnabledFor(DeleteWarningType.DeleteEventTemplates)) {
+      if (context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteEventTemplates)) {
         setTemplateToDelete(template);
         setWarningModalOpen(true);
       } else {
@@ -319,7 +319,7 @@ export const AgentProbeTemplates: React.FunctionComponent<AgentProbeTemplatesPro
                   </ToolbarItem>
                 </ToolbarGroup>
                 <DeleteWarningModal
-                  warningType={DeleteWarningType.DeleteProbeTemplates}
+                  warningType={DeleteOrDisableWarningType.DeleteProbeTemplates}
                   visible={warningModalOpen}
                   onAccept={handleWarningModalAccept}
                   onClose={handleWarningModalClose}

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -39,7 +39,7 @@ import { CreateRecordingProps } from '@app/CreateRecording/CreateRecording';
 import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
 import { LoadingView } from '@app/LoadingView/LoadingView';
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { FUpload, MultiFileUpload, UploadCallbacks } from '@app/Shared/FileUploads';
 import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 import { EventTemplate } from '@app/Shared/Services/Api.service';
@@ -237,7 +237,7 @@ export const EventTemplates: React.FunctionComponent<EventTemplatesProps> = (pro
 
   const handleDeleteButton = React.useCallback(
     (t: EventTemplate) => {
-      if (context.settings.deletionDialogsEnabledFor(DeleteWarningType.DeleteEventTemplates)) {
+      if (context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteEventTemplates)) {
         setTemplateToDelete(t);
         setWarningModalOpen(true);
       } else {
@@ -371,7 +371,7 @@ export const EventTemplates: React.FunctionComponent<EventTemplatesProps> = (pro
               </ToolbarItem>
             </ToolbarGroup>
             <DeleteWarningModal
-              warningType={DeleteWarningType.DeleteEventTemplates}
+              warningType={DeleteOrDisableWarningType.DeleteEventTemplates}
               visible={warningModalOpen}
               onAccept={handleWarningModalAccept}
               onClose={handleWarningModalClose}

--- a/src/app/Modal/DeleteWarningModal.tsx
+++ b/src/app/Modal/DeleteWarningModal.tsx
@@ -37,12 +37,12 @@
  */
 import * as React from 'react';
 import { Modal, ModalVariant, Button, Checkbox, Stack, Split } from '@patternfly/react-core';
-import { DeleteWarningType, getFromWarningMap } from './DeleteWarningUtils';
+import { DeleteOrDisableWarningType, getFromWarningMap } from './DeleteWarningUtils';
 import { useState } from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
 
 export interface DeleteWarningProps {
-  warningType: DeleteWarningType;
+  warningType: DeleteOrDisableWarningType;
   visible: boolean;
   onAccept: () => void;
   onClose: () => void;

--- a/src/app/Modal/DeleteWarningUtils.tsx
+++ b/src/app/Modal/DeleteWarningUtils.tsx
@@ -80,7 +80,7 @@ export const DeleteAutomatedRules: DeleteOrDisableWarning = {
 };
 
 export const DisableAutomatedRules: DeleteOrDisableWarning = {
-  id: DeleteOrDisableWarningType.DeleteAutomatedRules,
+  id: DeleteOrDisableWarningType.DisableAutomatedRules,
   title: 'Disable Automated Rule?',
   label: 'Disable Automated Rule',
   description: `Rule will be disabled.`,

--- a/src/app/Modal/DeleteWarningUtils.tsx
+++ b/src/app/Modal/DeleteWarningUtils.tsx
@@ -35,10 +35,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-export enum DeleteWarningType {
+export enum DeleteOrDisableWarningType {
   DeleteActiveRecordings = 'DeleteActiveRecordings',
   DeleteArchivedRecordings = 'DeleteArchivedRecordings',
   DeleteAutomatedRules = 'DeleteAutomatedRules',
+  DisableAutomatedRules = 'DisableAutomatedRules',
   DeleteEventTemplates = 'DeleteEventTemplates',
   DeleteProbeTemplates = 'DeleteProbeTemplates',
   DeleteActiveProbes = 'DeleteActiveProbes',
@@ -46,82 +47,91 @@ export enum DeleteWarningType {
   DeleteCustomTargets = 'DeleteCustomTargets',
 }
 
-export interface DeleteWarning {
-  id: DeleteWarningType;
+export interface DeleteOrDisableWarning {
+  id: DeleteOrDisableWarningType;
   title: string;
   label: string;
   description: string;
   ariaLabel: string;
 }
 
-export const DeleteActiveRecordings: DeleteWarning = {
-  id: DeleteWarningType.DeleteActiveRecordings,
+export const DeleteActiveRecordings: DeleteOrDisableWarning = {
+  id: DeleteOrDisableWarningType.DeleteActiveRecordings,
   title: 'Permanently delete Active Recording?',
   label: 'Delete Active Recording',
   description: `Recording and report data will be lost.`,
   ariaLabel: 'Recording delete warning',
 };
 
-export const DeleteArchivedRecordings: DeleteWarning = {
-  id: DeleteWarningType.DeleteArchivedRecordings,
+export const DeleteArchivedRecordings: DeleteOrDisableWarning = {
+  id: DeleteOrDisableWarningType.DeleteArchivedRecordings,
   title: 'Permanently delete Archived Recording?',
   label: 'Delete Archived Recording',
   description: `Recording and report data will be lost.`,
   ariaLabel: 'Recording delete warning',
 };
 
-export const DeleteAutomatedRules: DeleteWarning = {
-  id: DeleteWarningType.DeleteAutomatedRules,
+export const DeleteAutomatedRules: DeleteOrDisableWarning = {
+  id: DeleteOrDisableWarningType.DeleteAutomatedRules,
   title: 'Permanently delete Automated Rule?',
   label: 'Delete Automated Rule',
   description: `Rule data will be lost.`,
   ariaLabel: 'Automated rule delete warning',
 };
 
-export const DeleteEventTemplates: DeleteWarning = {
-  id: DeleteWarningType.DeleteEventTemplates,
+export const DisableAutomatedRules: DeleteOrDisableWarning = {
+  id: DeleteOrDisableWarningType.DeleteAutomatedRules,
+  title: 'Disable Automated Rule?',
+  label: 'Disable Automated Rule',
+  description: `Rule will be disabled.`,
+  ariaLabel: 'Automated rule disable warning',
+};
+
+export const DeleteEventTemplates: DeleteOrDisableWarning = {
+  id: DeleteOrDisableWarningType.DeleteEventTemplates,
   title: 'Permanently delete Event Template?',
   label: 'Delete Event Template',
   description: `Custom event template data will be lost.`,
   ariaLabel: 'Event template delete warning',
 };
 
-export const DeleteProbeTemplates: DeleteWarning = {
-  id: DeleteWarningType.DeleteProbeTemplates,
+export const DeleteProbeTemplates: DeleteOrDisableWarning = {
+  id: DeleteOrDisableWarningType.DeleteProbeTemplates,
   title: 'Permanently delete Probe Template?',
   label: 'Delete Probe Template',
   description: `Custom probe template data will be lost.`,
   ariaLabel: 'Probe template delete warning',
 };
 
-export const DeleteActiveProbes: DeleteWarning = {
-  id: DeleteWarningType.DeleteActiveProbes,
+export const DeleteActiveProbes: DeleteOrDisableWarning = {
+  id: DeleteOrDisableWarningType.DeleteActiveProbes,
   title: 'Permanently remove Active Probes from the target?',
   label: 'Remove Active Probes',
   description: `Active probes will be removed from the target.`,
   ariaLabel: 'Active Probes remove warning',
 };
 
-export const DeleteJMXCredentials: DeleteWarning = {
-  id: DeleteWarningType.DeleteJMXCredentials,
+export const DeleteJMXCredentials: DeleteOrDisableWarning = {
+  id: DeleteOrDisableWarningType.DeleteJMXCredentials,
   title: 'Permanently delete JMX Credentials?',
   label: 'Delete JMX Credentials',
   description: `Credential data for this target will be lost.`,
   ariaLabel: 'JMX Credentials delete warning',
 };
 
-export const DeleteCustomTargets: DeleteWarning = {
-  id: DeleteWarningType.DeleteCustomTargets,
+export const DeleteCustomTargets: DeleteOrDisableWarning = {
+  id: DeleteOrDisableWarningType.DeleteCustomTargets,
   title: 'Permanently delete Custom Target?',
   label: 'Delete Custom Targets',
   description: `Custom target information will be lost.`,
   ariaLabel: 'Custom Targets delete warning',
 };
 
-export const DeleteWarningKinds: DeleteWarning[] = [
+export const DeleteWarningKinds: DeleteOrDisableWarning[] = [
   DeleteActiveRecordings,
   DeleteArchivedRecordings,
   DeleteAutomatedRules,
+  DisableAutomatedRules,
   DeleteEventTemplates,
   DeleteProbeTemplates,
   DeleteActiveProbes,
@@ -129,7 +139,7 @@ export const DeleteWarningKinds: DeleteWarning[] = [
   DeleteCustomTargets,
 ];
 
-export const getFromWarningMap = (warning: DeleteWarningType): DeleteWarning | undefined => {
+export const getFromWarningMap = (warning: DeleteOrDisableWarningType): DeleteOrDisableWarning | undefined => {
   const wt = DeleteWarningKinds.find((t) => t.id === warning);
   return wt;
 };

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -66,7 +66,7 @@ import { filterRecordings, RecordingFilters, RecordingFiltersCategories } from '
 import { RecordingsTable } from './RecordingsTable';
 import { ReportFrame } from './ReportFrame';
 import { DeleteWarningModal } from '../Modal/DeleteWarningModal';
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   recordingAddFilterIntent,
@@ -696,7 +696,7 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
   const [warningModalOpen, setWarningModalOpen] = React.useState(false);
 
   const deletionDialogsEnabled = React.useMemo(
-    () => context.settings.deletionDialogsEnabledFor(DeleteWarningType.DeleteActiveRecordings),
+    () => context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteActiveRecordings),
     [context, context.settings, context.settings.deletionDialogsEnabledFor]
   );
 
@@ -811,7 +811,7 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
   const deleteActiveWarningModal = React.useMemo(() => {
     return (
       <DeleteWarningModal
-        warningType={DeleteWarningType.DeleteActiveRecordings}
+        warningType={DeleteOrDisableWarningType.DeleteActiveRecordings}
         visible={warningModalOpen}
         onAccept={props.handleDeleteRecordings}
         onClose={handleWarningModalClose}

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -64,7 +64,7 @@ import { parseLabels } from '@app/RecordingMetadata/RecordingLabel';
 import { LabelCell } from '../RecordingMetadata/LabelCell';
 import { RecordingLabelsPanel } from './RecordingLabelsPanel';
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { RecordingFiltersCategories } from './RecordingFilters';
 import { filterRecordings, RecordingFilters } from './RecordingFilters';
 import { ArchiveUploadModal } from '@app/Archives/ArchiveUploadModal';
@@ -668,7 +668,7 @@ const ArchivedRecordingsToolbar: React.FunctionComponent<ArchivedRecordingsToolb
   const [warningModalOpen, setWarningModalOpen] = React.useState(false);
 
   const deletionDialogsEnabled = React.useMemo(
-    () => context.settings.deletionDialogsEnabledFor(DeleteWarningType.DeleteArchivedRecordings),
+    () => context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteArchivedRecordings),
     [context, context.settings, context.settings.deletionDialogsEnabledFor]
   );
 
@@ -687,7 +687,7 @@ const ArchivedRecordingsToolbar: React.FunctionComponent<ArchivedRecordingsToolb
   const deleteArchivedWarningModal = React.useMemo(() => {
     return (
       <DeleteWarningModal
-        warningType={DeleteWarningType.DeleteArchivedRecordings}
+        warningType={DeleteOrDisableWarningType.DeleteArchivedRecordings}
         visible={warningModalOpen}
         onAccept={props.handleDeleteRecordings}
         onClose={handleWarningModalClose}

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -56,7 +56,6 @@ import {
   SortByDirection,
   TableVariant,
   ISortBy,
-  IRowData,
   IAction,
   TableComposable,
   Thead,
@@ -119,9 +118,14 @@ export const isRule = (obj: Object): boolean => {
   return true;
 };
 
+export interface RuleToDeleteOrDisable {
+  rule: Rule;
+  type: 'DELETE' | 'DISABLE';
+}
+
 export interface RulesProps {}
 
-export const Rules: React.FunctionComponent<RulesProps> = (props) => {
+export const Rules: React.FunctionComponent<RulesProps> = ({}) => {
   const context = React.useContext(ServiceContext);
   const routerHistory = useHistory();
   const addSubscription = useSubscriptions();
@@ -132,7 +136,7 @@ export const Rules: React.FunctionComponent<RulesProps> = (props) => {
   const [rules, setRules] = React.useState([] as Rule[]);
   const [warningModalOpen, setWarningModalOpen] = React.useState(false);
   const [isUploadModalOpen, setIsUploadModalOpen] = React.useState(false);
-  const [ruleToDelete, setRuleToDelete] = React.useState<Rule | undefined>(undefined);
+  const [ruleToWarn, setRuleToWarn] = React.useState<RuleToDeleteOrDisable | undefined>(undefined);
   const [cleanRuleEnabled, setCleanRuleEnabled] = React.useState(true);
 
   const tableColumns = [
@@ -226,12 +230,11 @@ export const Rules: React.FunctionComponent<RulesProps> = (props) => {
     addSubscription(
       context.notificationChannel.messages(NotificationCategory.RuleUpdated).subscribe((msg) => {
         setRules((old) => {
-          for (const r of old) {
-            if (r.name === msg.message.name) {
-              r.enabled = msg.message.enabled;
-            }
+          const match = old.find((r) => r.name === msg.message.name);
+          if (match) {
+            return [...old.filter((r) => r.name !== msg.message.name), { ...match, enabled: msg.message.enabled }];
           }
-          return [...old];
+          return old;
         });
       })
     );
@@ -256,11 +259,27 @@ export const Rules: React.FunctionComponent<RulesProps> = (props) => {
     setIsUploadModalOpen(true);
   }, [setIsUploadModalOpen]);
 
-  const handleToggle = React.useCallback(
-    (rule: Rule, enabled: boolean): void => {
-      addSubscription(context.api.updateRule({ ...rule, enabled }).subscribe());
+  const handleDisableRule = React.useCallback(
+    (rule: Rule, cleanRuleEnabled: boolean) => {
+      addSubscription(context.api.updateRule({ ...rule, enabled: false }, cleanRuleEnabled).subscribe());
     },
     [context.api, addSubscription]
+  );
+
+  const handleToggle = React.useCallback(
+    (rule: Rule, enabled: boolean): void => {
+      if (enabled) {
+        addSubscription(context.api.updateRule({ ...rule, enabled }).subscribe());
+      } else {
+        if (context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DisableAutomatedRules)) {
+          setRuleToWarn({ rule: rule, type: 'DISABLE' });
+          setWarningModalOpen(true);
+        } else {
+          handleDisableRule(rule, cleanRuleEnabled);
+        }
+      }
+    },
+    [context.api, cleanRuleEnabled, addSubscription, handleDisableRule, setRuleToWarn, setWarningModalOpen]
   );
 
   const handleDelete = React.useCallback(
@@ -278,14 +297,27 @@ export const Rules: React.FunctionComponent<RulesProps> = (props) => {
   const handleDeleteButton = React.useCallback(
     (rule: Rule) => {
       if (context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteAutomatedRules)) {
-        setRuleToDelete(rule);
+        setRuleToWarn({ rule: rule, type: 'DELETE' });
         setWarningModalOpen(true);
       } else {
         handleDelete(rule, cleanRuleEnabled);
       }
     },
-    [context.settings, setWarningModalOpen, handleDelete, setRuleToDelete, cleanRuleEnabled]
+    [context.settings, setWarningModalOpen, handleDelete, setRuleToWarn, cleanRuleEnabled]
   );
+
+  const handleWarningModalAccept = React.useCallback(() => {
+    if (ruleToWarn?.type === 'DELETE') {
+      handleDelete(ruleToWarn!.rule, cleanRuleEnabled);
+    } else {
+      handleDisableRule(ruleToWarn!.rule, cleanRuleEnabled);
+    }
+  }, [handleDelete, handleDisableRule, ruleToWarn, cleanRuleEnabled]);
+
+  const handleWarningModalClose = React.useCallback(() => {
+    setWarningModalOpen(false);
+    setRuleToWarn(undefined);
+  }, [setWarningModalOpen, setRuleToWarn]);
 
   const actionResolver = React.useCallback(
     (rule: Rule): IAction[] => {
@@ -416,14 +448,6 @@ export const Rules: React.FunctionComponent<RulesProps> = (props) => {
     }
   }, [isLoading, rules, ruleRows]);
 
-  const handleWarningModalAccept = React.useCallback(() => {
-    handleDelete(ruleToDelete!, cleanRuleEnabled);
-  }, [handleDelete, ruleToDelete, cleanRuleEnabled]);
-
-  const handleWarningModalClose = React.useCallback(() => {
-    setWarningModalOpen(false);
-  }, [setWarningModalOpen]);
-
   return (
     <>
       <BreadcrumbPage pageTitle="Automated Rules">
@@ -441,15 +465,23 @@ export const Rules: React.FunctionComponent<RulesProps> = (props) => {
                     </Button>
                   </ToolbarItem>
                 </ToolbarGroup>
-                <RuleDeleteWarningModal
-                  warningType={DeleteOrDisableWarningType.DeleteAutomatedRules}
-                  rule={ruleToDelete?.name}
-                  visible={warningModalOpen}
-                  onAccept={handleWarningModalAccept}
-                  onClose={handleWarningModalClose}
-                  clean={cleanRuleEnabled}
-                  setClean={setCleanRuleEnabled}
-                />
+                {ruleToWarn ? (
+                  <RuleDeleteWarningModal
+                    warningType={
+                      ruleToWarn.type === 'DELETE'
+                        ? DeleteOrDisableWarningType.DeleteAutomatedRules
+                        : DeleteOrDisableWarningType.DisableAutomatedRules
+                    }
+                    ruleName={ruleToWarn.rule.name}
+                    visible={warningModalOpen}
+                    onAccept={handleWarningModalAccept}
+                    onClose={handleWarningModalClose}
+                    clean={cleanRuleEnabled}
+                    setClean={setCleanRuleEnabled}
+                  />
+                ) : (
+                  <></>
+                )}
               </ToolbarContent>
             </Toolbar>
             {viewContent}

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -75,7 +75,7 @@ import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { LoadingView } from '@app/LoadingView/LoadingView';
 import { RuleUploadModal } from './RulesUploadModal';
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { RuleDeleteWarningModal } from './RuleDeleteWarningModal';
 
 export interface Rule {
@@ -277,7 +277,7 @@ export const Rules: React.FunctionComponent<RulesProps> = (props) => {
 
   const handleDeleteButton = React.useCallback(
     (rule: Rule) => {
-      if (context.settings.deletionDialogsEnabledFor(DeleteWarningType.DeleteAutomatedRules)) {
+      if (context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteAutomatedRules)) {
         setRuleToDelete(rule);
         setWarningModalOpen(true);
       } else {
@@ -442,7 +442,7 @@ export const Rules: React.FunctionComponent<RulesProps> = (props) => {
                   </ToolbarItem>
                 </ToolbarGroup>
                 <RuleDeleteWarningModal
-                  warningType={DeleteWarningType.DeleteAutomatedRules}
+                  warningType={DeleteOrDisableWarningType.DeleteAutomatedRules}
                   rule={ruleToDelete?.name}
                   visible={warningModalOpen}
                   onAccept={handleWarningModalAccept}

--- a/src/app/SecurityPanel/Credentials/StoreJmxCredentials.tsx
+++ b/src/app/SecurityPanel/Credentials/StoreJmxCredentials.tsx
@@ -63,7 +63,7 @@ import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.s
 import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 import { LoadingView } from '@app/LoadingView/LoadingView';
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { MatchedTargetsTable } from './MatchedTargetsTable';
 
 const enum Actions {
@@ -274,7 +274,7 @@ export const StoreJmxCredentials = () => {
   }, [setShowAuthModal]);
 
   const handleDeleteButton = React.useCallback(() => {
-    if (context.settings.deletionDialogsEnabledFor(DeleteWarningType.DeleteJMXCredentials)) {
+    if (context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteJMXCredentials)) {
       setWarningModalOpen(true);
     } else {
       handleDeleteCredentials();
@@ -313,7 +313,7 @@ export const StoreJmxCredentials = () => {
     const deleteCredentialModal = React.useMemo(() => {
       return (
         <DeleteWarningModal
-          warningType={DeleteWarningType.DeleteJMXCredentials}
+          warningType={DeleteOrDisableWarningType.DeleteJMXCredentials}
           visible={warningModalOpen}
           onAccept={handleDeleteCredentials}
           onClose={handleWarningModalClose}

--- a/src/app/Settings/DeletionDialogControl.tsx
+++ b/src/app/Settings/DeletionDialogControl.tsx
@@ -40,7 +40,7 @@ import * as React from 'react';
 import { Divider, ExpandableSection, Switch, Stack, StackItem } from '@patternfly/react-core';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { UserSetting } from './Settings';
-import { DeleteWarningType, getFromWarningMap } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType, getFromWarningMap } from '@app/Modal/DeleteWarningUtils';
 
 const Component = () => {
   const context = React.useContext(ServiceContext);
@@ -49,7 +49,7 @@ const Component = () => {
 
   const handleCheckboxChange = React.useCallback(
     (checked, element) => {
-      state.set(DeleteWarningType[element.target.id], checked);
+      state.set(DeleteOrDisableWarningType[element.target.id], checked);
       context.settings.setDeletionDialogsEnabled(state);
       setState(new Map(state));
     },

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -257,10 +257,10 @@ export class ApiService {
     );
   }
 
-  updateRule(rule: Rule): Observable<boolean> {
+  updateRule(rule: Rule, clean = true): Observable<boolean> {
     const headers = new Headers();
     headers.set('Content-Type', 'application/json');
-    return this.sendRequest('v2', `rules/${rule.name}`, {
+    return this.sendRequest('v2', `rules/${rule.name}?clean=${clean}`, {
       method: 'PATCH',
       body: JSON.stringify(rule),
       headers,

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -260,20 +260,30 @@ export class ApiService {
   updateRule(rule: Rule, clean = true): Observable<boolean> {
     const headers = new Headers();
     headers.set('Content-Type', 'application/json');
-    return this.sendRequest('v2', `rules/${rule.name}?clean=${clean}`, {
-      method: 'PATCH',
-      body: JSON.stringify(rule),
-      headers,
-    }).pipe(
+    return this.sendRequest(
+      'v2',
+      `rules/${rule.name}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(rule),
+        headers,
+      },
+      new URLSearchParams({ clean: String(clean) })
+    ).pipe(
       map((resp) => resp.ok),
       first()
     );
   }
 
   deleteRule(name: string, clean: boolean = true): Observable<boolean> {
-    return this.sendRequest('v2', `rules/${name}?clean=${clean}`, {
-      method: 'DELETE',
-    }).pipe(
+    return this.sendRequest(
+      'v2',
+      `rules/${name}`,
+      {
+        method: 'DELETE',
+      },
+      new URLSearchParams({ clean: String(clean) })
+    ).pipe(
       map((resp) => resp.ok),
       first()
     );
@@ -678,6 +688,7 @@ export class ApiService {
           {
             method: 'GET',
           },
+          undefined,
           suppressNotifications
         ).pipe(
           concatMap((resp) => resp.json()),
@@ -1000,6 +1011,7 @@ export class ApiService {
     apiVersion: ApiVersion,
     path: string,
     config?: RequestInit,
+    params?: URLSearchParams,
     suppressNotifications = false,
     skipStatusCheck = false
   ): Observable<Response> {
@@ -1020,8 +1032,7 @@ export class ApiService {
           };
 
           _.mergeWith(config, defaultReq, customizer);
-
-          return fromFetch(`${this.login.authority}/api/${apiVersion}/${path}`, config);
+          return fromFetch(`${this.login.authority}/api/${apiVersion}/${path}${params ? '?' + params : ''}`, config);
         }),
         map((resp) => {
           if (resp.ok) return resp;
@@ -1067,6 +1078,7 @@ export class ApiService {
     apiVersion: ApiVersion,
     path: string,
     { method = 'GET', body, headers = {}, listeners, abortSignal }: XMLHttpRequestConfig,
+    params?: URLSearchParams,
     suppressNotifications = false,
     skipStatusCheck = false
   ): Observable<XMLHttpResponse> {
@@ -1076,7 +1088,7 @@ export class ApiService {
           return from(
             new Promise<XMLHttpResponse>((resolve, reject) => {
               const xhr = new XMLHttpRequest();
-              xhr.open(method, `${this.login.authority}/api/${apiVersion}/${path}`, true);
+              xhr.open(method, `${this.login.authority}/api/${apiVersion}/${path}${params ? '?' + params : ''}`, true);
 
               listeners?.onUploadProgress && xhr.upload.addEventListener('progress', listeners.onUploadProgress);
 

--- a/src/app/Shared/Services/Settings.service.tsx
+++ b/src/app/Shared/Services/Settings.service.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { getFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
 import { BehaviorSubject, Observable } from 'rxjs';
 import {
@@ -136,31 +136,31 @@ export class SettingsService {
     saveToLocalStorage('AUTOMATED_ANALYSIS_RECORDING_CONFIG', config);
   }
 
-  deletionDialogsEnabled(): Map<DeleteWarningType, boolean> {
+  deletionDialogsEnabled(): Map<DeleteOrDisableWarningType, boolean> {
     const value = getFromLocalStorage('DELETION_DIALOGS_ENABLED', undefined);
     if (typeof value === 'object') {
       const obj = new Map(Array.from(Object.entries(value)));
-      const res = new Map<DeleteWarningType, boolean>();
+      const res = new Map<DeleteOrDisableWarningType, boolean>();
       obj.forEach((v: any) => {
-        res.set(v[0] as DeleteWarningType, v[1] as boolean);
+        res.set(v[0] as DeleteOrDisableWarningType, v[1] as boolean);
       });
-      for (const t in DeleteWarningType) {
-        if (!res.has(DeleteWarningType[t])) {
-          res.set(DeleteWarningType[t], true);
+      for (const t in DeleteOrDisableWarningType) {
+        if (!res.has(DeleteOrDisableWarningType[t])) {
+          res.set(DeleteOrDisableWarningType[t], true);
         }
       }
       return res;
     }
 
-    const map = new Map<DeleteWarningType, boolean>();
-    for (const cat in DeleteWarningType) {
-      map.set(DeleteWarningType[cat], true);
+    const map = new Map<DeleteOrDisableWarningType, boolean>();
+    for (const cat in DeleteOrDisableWarningType) {
+      map.set(DeleteOrDisableWarningType[cat], true);
     }
     this.setDeletionDialogsEnabled(map);
     return map;
   }
 
-  deletionDialogsEnabledFor(type: DeleteWarningType): boolean {
+  deletionDialogsEnabledFor(type: DeleteOrDisableWarningType): boolean {
     const res = this.deletionDialogsEnabled().get(type);
     if (typeof res != 'boolean') {
       return true;
@@ -168,12 +168,12 @@ export class SettingsService {
     return res;
   }
 
-  setDeletionDialogsEnabled(map: Map<DeleteWarningType, boolean>): void {
+  setDeletionDialogsEnabled(map: Map<DeleteOrDisableWarningType, boolean>): void {
     const value = Array.from(map.entries());
     saveToLocalStorage('DELETION_DIALOGS_ENABLED', value);
   }
 
-  setDeletionDialogsEnabledFor(type: DeleteWarningType, enabled: boolean) {
+  setDeletionDialogsEnabledFor(type: DeleteOrDisableWarningType, enabled: boolean) {
     const map = this.deletionDialogsEnabled();
     map.set(type, enabled);
     this.setDeletionDialogsEnabled(map);

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -54,7 +54,7 @@ import {
 } from '@patternfly/react-core';
 import { ContainerNodeIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import { CreateTargetModal } from './CreateTargetModal';
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
 import { getFromLocalStorage, removeFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
 import { SerializedTarget } from '@app/Shared/SerializedTarget';
@@ -192,7 +192,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   }, [addSubscription, context.api, notifications, selected, setLoading]);
 
   const deletionDialogsEnabled = React.useMemo(
-    () => context.settings.deletionDialogsEnabledFor(DeleteWarningType.DeleteCustomTargets),
+    () => context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteCustomTargets),
     [context.settings]
   );
 
@@ -215,7 +215,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   const deleteArchivedWarningModal = React.useMemo(() => {
     return (
       <DeleteWarningModal
-        warningType={DeleteWarningType.DeleteCustomTargets}
+        warningType={DeleteOrDisableWarningType.DeleteCustomTargets}
         visible={warningModalOpen}
         onAccept={deleteTarget}
         onClose={handleWarningModalClose}

--- a/src/test/Events/EventTemplates.test.tsx
+++ b/src/test/Events/EventTemplates.test.tsx
@@ -44,7 +44,7 @@ import { EventTemplate } from '@app/Shared/Services/Api.service';
 import { MessageMeta, MessageType, NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/Services';
 import { EventTemplates } from '@app/Events/EventTemplates';
-import { DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { TargetService } from '@app/Shared/Services/Target.service';
 import { renderWithServiceContextAndRouter } from '../Common';
 import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
@@ -204,7 +204,7 @@ describe('<EventTemplates />', () => {
     expect(deleteRequestSpy).toHaveBeenCalledTimes(1);
     expect(deleteRequestSpy).toBeCalledWith('someEventTemplate');
     expect(dialogWarningSpy).toBeCalledTimes(1);
-    expect(dialogWarningSpy).toBeCalledWith(DeleteWarningType.DeleteEventTemplates, false);
+    expect(dialogWarningSpy).toBeCalledWith(DeleteOrDisableWarningType.DeleteEventTemplates, false);
   });
 
   it('deletes the template when Delete is clicked w/o popup warning', async () => {

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -96,7 +96,7 @@ jest.mock('@app/Recordings/RecordingFilters', () => {
 
 import { ActiveRecordingsTable } from '@app/Recordings/ActiveRecordingsTable';
 import { defaultServices, Services } from '@app/Shared/Services/Services';
-import { DeleteActiveRecordings, DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteActiveRecordings, DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import {
   emptyActiveRecordingFilters,
   emptyArchivedRecordingFilters,
@@ -398,7 +398,7 @@ describe('<ActiveRecordingsTable />', () => {
     expect(deleteRequestSpy).toBeCalledTimes(1);
     expect(deleteRequestSpy).toBeCalledWith('someRecording');
     expect(dialogWarningSpy).toBeCalledTimes(1);
-    expect(dialogWarningSpy).toBeCalledWith(DeleteWarningType.DeleteActiveRecordings, false);
+    expect(dialogWarningSpy).toBeCalledWith(DeleteOrDisableWarningType.DeleteActiveRecordings, false);
   });
 
   it('deletes the recording when Delete is clicked w/o popup warning', async () => {

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -46,7 +46,7 @@ import { ArchivedRecording, UPLOADS_SUBDIRECTORY } from '@app/Shared/Services/Ap
 import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
 import { ArchivedRecordingsTable } from '@app/Recordings/ArchivedRecordingsTable';
 import { defaultServices } from '@app/Shared/Services/Services';
-import { DeleteArchivedRecordings, DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteArchivedRecordings, DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import {
   emptyActiveRecordingFilters,
   emptyArchivedRecordingFilters,
@@ -346,7 +346,7 @@ describe('<ArchivedRecordingsTable />', () => {
     expect(deleteRequestSpy).toHaveBeenCalledTimes(1);
     expect(deleteRequestSpy).toBeCalledWith(mockTarget.connectUrl, 'someRecording');
     expect(dialogWarningSpy).toBeCalledTimes(1);
-    expect(dialogWarningSpy).toBeCalledWith(DeleteWarningType.DeleteArchivedRecordings, false);
+    expect(dialogWarningSpy).toBeCalledWith(DeleteOrDisableWarningType.DeleteArchivedRecordings, false);
   });
 
   it('deletes the recording when Delete is clicked w/o popup warning', async () => {

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -49,7 +49,7 @@ import {
   NotificationChannel,
   NotificationMessage,
 } from '@app/Shared/Services/NotificationChannel.service';
-import { DeleteAutomatedRules, DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteAutomatedRules, DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { renderWithServiceContextAndRouter } from '../Common';
 import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
@@ -191,7 +191,7 @@ describe('<Rules />', () => {
     expect(deleteRequestSpy).toHaveBeenCalledTimes(1);
     expect(deleteRequestSpy).toBeCalledWith(mockRule.name, true);
     expect(dialogWarningSpy).toBeCalledTimes(1);
-    expect(dialogWarningSpy).toBeCalledWith(DeleteWarningType.DeleteAutomatedRules, false);
+    expect(dialogWarningSpy).toBeCalledWith(DeleteOrDisableWarningType.DeleteAutomatedRules, false);
   });
 
   it('deletes a rule when Delete is clicked w/o popup warning', async () => {

--- a/src/test/SecurityPanel/Credentials/StoreJmxCredentials.test.tsx
+++ b/src/test/SecurityPanel/Credentials/StoreJmxCredentials.test.tsx
@@ -44,7 +44,7 @@ import { Modal, ModalVariant } from '@patternfly/react-core';
 import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
 import { StoreJmxCredentials } from '@app/SecurityPanel/Credentials/StoreJmxCredentials';
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
-import { DeleteJMXCredentials, DeleteWarningType } from '@app/Modal/DeleteWarningUtils';
+import { DeleteJMXCredentials, DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { Target } from '@app/Shared/Services/Target.service';
 import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 
@@ -347,7 +347,7 @@ describe('<StoreJmxCredentials />', () => {
     await user.click(within(screen.getByLabelText(DeleteJMXCredentials.ariaLabel)).getByText('Delete'));
 
     expect(dialogWarningSpy).toBeCalledTimes(1);
-    expect(dialogWarningSpy).toBeCalledWith(DeleteWarningType.DeleteJMXCredentials, false);
+    expect(dialogWarningSpy).toBeCalledWith(DeleteOrDisableWarningType.DeleteJMXCredentials, false);
     expect(queryRequestSpy).toHaveBeenCalledTimes(1);
     expect(deleteRequestSpy).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/pull/1289

## Description of the change:

- [x] Added warning modal for users to decide whether to clean up resources created by the automated rule.
- [x] Extend delete warning modals to supporting disabling.
- [x] Fix side-effects on mockRule in tests.

## Motivation for the change:

See https://github.com/cryostatio/cryostat/issues/1283

## How to manually test:
1. Go to Automated Rule tab
2. Create or enable a existing rule.
3. Now toggle the rule to disable it. The modal should show up.
