### PR TITLE
chore(eslint): eslint apply and add eslint to the CI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,10 +43,11 @@
   "rules": {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/interface-name-prefix": "off",
+    "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-unused-vars": "off",
     "import/no-unresolved": "off",
     "import/extensions": "off",
-    "import/first": "warn",
+    // "import/first": "warn",
     "import/order": ["warn", {
       "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
       "alphabetize": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -45,9 +45,9 @@
     "@typescript-eslint/interface-name-prefix": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/no-unused-vars": "off",
-    "import/no-unresolved": "off",
     "import/extensions": "off",
-    // "import/first": "warn",
+    "import/no-named-as-default": "off",
+    "import/no-unresolved": "off",
     "import/order": ["warn", {
       "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
       "alphabetize": {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -31,6 +30,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - uses: bahmutov/npm-install@v1
     - run: yarn format:check
-  # - run: yarn lint
+    - run: yarn eslint:check
     - run: yarn build:notests
     - run: yarn test:ci

--- a/src/app/About/About.tsx
+++ b/src/app/About/About.tsx
@@ -36,16 +36,16 @@
  * SOFTWARE.
  */
 
-import React from 'react';
-import build from '@app/build.json';
 import cryostatLogo from '@app/assets/cryostat_logo_hori_rgb_default.svg';
 import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
-import { AboutDescription, CRYOSTAT_TRADEMARK } from './AboutDescription';
+import build from '@app/build.json';
 import { Brand, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react-core';
+import React from 'react';
+import { AboutDescription, CRYOSTAT_TRADEMARK } from './AboutDescription';
 
 export interface AboutProps {}
 
-export const About: React.FunctionComponent<AboutProps> = (props) => {
+export const About: React.FC<AboutProps> = (_) => {
   return (
     <BreadcrumbPage pageTitle="About">
       <Card>

--- a/src/app/About/AboutCryostatModal.tsx
+++ b/src/app/About/AboutCryostatModal.tsx
@@ -35,12 +35,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+import bkgImg from '@app/assets/about_background.png';
+import cryostatLogo from '@app/assets/cryostat_icon_rgb_reverse.svg';
+import build from '@app/build.json';
 import { AboutModal } from '@patternfly/react-core';
 import React from 'react';
-import build from '@app/build.json';
-import cryostatLogo from '@app/assets/cryostat_icon_rgb_reverse.svg';
-import bkgImg from '@app/assets/about_background.png';
 import { AboutDescription, CRYOSTAT_TRADEMARK } from './AboutDescription';
 
 export const AboutCryostatModal = ({ isOpen, onClose }) => {

--- a/src/app/About/AboutDescription.tsx
+++ b/src/app/About/AboutDescription.tsx
@@ -36,11 +36,11 @@
  * SOFTWARE.
  */
 
+import build from '@app/build.json';
+import { NotificationsContext } from '@app/Notifications/Notifications';
+import { ServiceContext } from '@app/Shared/Services/Services';
 import { Text, TextContent, TextList, TextListItem, TextVariants } from '@patternfly/react-core';
 import React from 'react';
-import build from '@app/build.json';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { NotificationsContext } from '@app/Notifications/Notifications';
 
 export const CRYOSTAT_TRADEMARK = 'Copyright The Cryostat Authors, The Universal Permissive License (UPL), Version 1.0';
 
@@ -84,7 +84,7 @@ export const AboutDescription = () => {
     } else {
       return <Text component={TextVariants.p}>{cryostatVersion}</Text>;
     }
-  }, [build.commitHashUrl, cryostatCommitHash]);
+  }, [cryostatVersion, cryostatCommitHash]);
 
   return (
     <>

--- a/src/app/Agent/AboutAgentCard.tsx
+++ b/src/app/Agent/AboutAgentCard.tsx
@@ -40,7 +40,7 @@ import * as React from 'react';
 
 export interface AboutAgentCardProps {}
 
-export const AboutAgentCard: React.FunctionComponent<AboutAgentCardProps> = (props) => {
+export const AboutAgentCard: React.FC<AboutAgentCardProps> = (_) => {
   return (
     <Card>
       <CardTitle>About the JMC Agent</CardTitle>

--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -35,9 +35,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { ServiceContext } from '@app/Shared/Services/Services';
+import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
+import { LoadingView } from '@app/LoadingView/LoadingView';
+import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
+import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
+import { EventProbe } from '@app/Shared/Services/Api.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   Button,
@@ -52,6 +57,7 @@ import {
   EmptyStateIcon,
   Title,
 } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 import {
   TableVariant,
   ISortBy,
@@ -64,21 +70,14 @@ import {
   Tr,
   Td,
 } from '@patternfly/react-table';
-import { first } from 'rxjs/operators';
-import { LoadingView } from '@app/LoadingView/LoadingView';
-import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
-import { EventProbe } from '@app/Shared/Services/Api.service';
-import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
-import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
-import { SearchIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import { AboutAgentCard } from './AboutAgentCard';
-import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 
 export type LiveProbeActions = 'REMOVE';
 
 export interface AgentLiveProbesProps {}
 
-export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (props) => {
+export const AgentLiveProbes: React.FC<AgentLiveProbesProps> = (_) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
 
@@ -91,7 +90,7 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
   const [warningModalOpen, setWarningModalOpen] = React.useState(false);
   const [actionLoadings, setActionLoadings] = React.useState<Record<LiveProbeActions, boolean>>({ REMOVE: false });
 
-  const tableColumns = ['ID', 'Name', 'Class', 'Description', 'Method'];
+  const tableColumns = React.useMemo(() => ['ID', 'Name', 'Class', 'Description', 'Method'], []);
 
   const getSortParams = React.useCallback(
     (columnIndex: number): ThProps['sort'] => ({
@@ -136,7 +135,7 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
 
   const authRetry = React.useCallback(() => {
     context.target.setAuthRetry();
-  }, [context.target, context.target.setAuthRetry]);
+  }, [context.target]);
 
   const handleDeleteAllProbes = React.useCallback(() => {
     setActionLoadings((old) => {
@@ -266,7 +265,7 @@ export const AgentLiveProbes: React.FunctionComponent<AgentLiveProbesProps> = (p
           </Td>
         </Tr>
       )),
-    [filteredProbes]
+    [filteredProbes, tableColumns]
   );
 
   const actionLoadingProps = React.useMemo<Record<LiveProbeActions, LoadingPropsType>>(

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -79,7 +79,16 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { BarsIcon, BellIcon, CaretDownIcon, CogIcon, ExternalLinkAltIcon, PlusCircleIcon, QuestionCircleIcon, UserIcon } from '@patternfly/react-icons';
+import {
+  BarsIcon,
+  BellIcon,
+  CaretDownIcon,
+  CogIcon,
+  ExternalLinkAltIcon,
+  PlusCircleIcon,
+  QuestionCircleIcon,
+  UserIcon,
+} from '@patternfly/react-icons';
 import * as _ from 'lodash';
 import * as React from 'react';
 import { Link, matchPath, NavLink, useHistory, useLocation } from 'react-router-dom';
@@ -192,10 +201,7 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
     [notificationsContext]
   );
 
-  const handleTimeout = React.useCallback(
-    (key) => () => notificationsContext.setHidden(key),
-    [notificationsContext]
-  );
+  const handleTimeout = React.useCallback((key) => () => notificationsContext.setHidden(key), [notificationsContext]);
 
   React.useEffect(() => {
     addSubscription(
@@ -401,7 +407,6 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
     ),
     [
       notificationsContext,
-      isNotificationDrawerExpanded,
       unreadNotificationsCount,
       errorNotificationsCount,
       handleNotificationCenterToggle,
@@ -414,7 +419,7 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
       UserInfoToggle,
       userInfoItems,
       HelpToggle,
-      helpItems
+      helpItems,
     ]
   );
 

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -79,19 +79,10 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import {
-  BarsIcon,
-  BellIcon,
-  CaretDownIcon,
-  CogIcon,
-  ExternalLinkAltIcon,
-  PlusCircleIcon,
-  QuestionCircleIcon,
-  UserIcon,
-} from '@patternfly/react-icons';
-import _ from 'lodash';
+import { BarsIcon, BellIcon, CaretDownIcon, CogIcon, ExternalLinkAltIcon, PlusCircleIcon, QuestionCircleIcon, UserIcon } from '@patternfly/react-icons';
+import * as _ from 'lodash';
 import * as React from 'react';
-import { matchPath, Link, NavLink, useHistory, useLocation } from 'react-router-dom';
+import { Link, matchPath, NavLink, useHistory, useLocation } from 'react-router-dom';
 import { map } from 'rxjs/operators';
 import { AuthModal } from './AuthModal';
 import { SslErrorModal } from './SslErrorModal';

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -100,7 +100,7 @@ interface AppLayoutProps {
   children: React.ReactNode;
 }
 
-const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
+const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const serviceContext = React.useContext(ServiceContext);
   const notificationsContext = React.useContext(NotificationsContext);
   const addSubscription = useSubscriptions();
@@ -229,7 +229,7 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
   );
 
   const mobileOnSelect = React.useCallback(
-    (_selected) => {
+    (_) => {
       if (isMobileView) {
         setIsNavOpenMobile(false);
       }

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -35,11 +35,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import * as _ from 'lodash';
-import { ServiceContext } from '@app/Shared/Services/Services';
+import { AboutCryostatModal } from '@app/About/AboutCryostatModal';
+import cryostatLogo from '@app/assets/cryostat_logo_hori_rgb_reverse.svg';
+import build from '@app/build.json';
 import { NotificationCenter } from '@app/Notifications/NotificationCenter';
+import { Notification, NotificationsContext } from '@app/Notifications/Notifications';
 import { IAppRoute, navGroups, routes } from '@app/routes';
+import { DynamicFeatureFlag, FeatureFlag } from '@app/Shared/FeatureFlag/FeatureFlag';
+import { SessionState } from '@app/Shared/Services/Login.service';
+import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { FeatureLevel } from '@app/Shared/Services/Settings.service';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { openTabForUrl } from '@app/utils/utils';
 import {
   Alert,
   AlertGroup,
@@ -70,7 +78,6 @@ import {
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  Text,
 } from '@patternfly/react-core';
 import {
   BarsIcon,
@@ -82,21 +89,12 @@ import {
   QuestionCircleIcon,
   UserIcon,
 } from '@patternfly/react-icons';
+import _ from 'lodash';
+import * as React from 'react';
+import { matchPath, Link, NavLink, useHistory, useLocation } from 'react-router-dom';
 import { map } from 'rxjs/operators';
-import { matchPath, NavLink, useHistory, useLocation } from 'react-router-dom';
-import { Notification, NotificationsContext } from '@app/Notifications/Notifications';
 import { AuthModal } from './AuthModal';
 import { SslErrorModal } from './SslErrorModal';
-import { AboutCryostatModal } from '@app/About/AboutCryostatModal';
-import cryostatLogo from '@app/assets/cryostat_logo_hori_rgb_reverse.svg';
-import { SessionState } from '@app/Shared/Services/Login.service';
-import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { FeatureLevel } from '@app/Shared/Services/Settings.service';
-import { DynamicFeatureFlag, FeatureFlag } from '@app/Shared/FeatureFlag/FeatureFlag';
-import build from '@app/build.json';
-import { openTabForUrl } from '@app/utils/utils';
-import { Link } from 'react-router-dom';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -107,9 +105,6 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
   const notificationsContext = React.useContext(NotificationsContext);
   const addSubscription = useSubscriptions();
   const routerHistory = useHistory();
-  const logoProps = {
-    href: '/',
-  };
   const [isNavOpen, setIsNavOpen] = React.useState(true);
   const [isMobileView, setIsMobileView] = React.useState(true);
   const [isNavOpenMobile, setIsNavOpenMobile] = React.useState(false);
@@ -137,15 +132,15 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
 
   React.useEffect(() => {
     addSubscription(notificationsContext.notifications().subscribe((n) => setNotifications([...n])));
-  }, [notificationsContext.notifications, addSubscription]);
+  }, [notificationsContext, addSubscription]);
 
   React.useEffect(() => {
     addSubscription(notificationsContext.drawerState().subscribe(setNotificationDrawerExpanded));
-  }, [addSubscription, notificationsContext.drawerState, setNotificationDrawerExpanded]);
+  }, [addSubscription, notificationsContext, setNotificationDrawerExpanded]);
 
   React.useEffect(() => {
     addSubscription(serviceContext.settings.visibleNotificationsCount().subscribe(setVisibleNotificationsCount));
-  }, [addSubscription, serviceContext.settings.visibleNotificationsCount, setVisibleNotificationsCount]);
+  }, [addSubscription, serviceContext.settings, setVisibleNotificationsCount]);
 
   const notificationsToDisplay = React.useMemo(() => {
     return notifications
@@ -156,7 +151,7 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
         if (!curr.timestamp) return 1;
         return prev.timestamp - curr.timestamp;
       });
-  }, [notifications, serviceContext.settings, serviceContext.settings.notificationsEnabledFor]);
+  }, [notifications, serviceContext.settings]);
 
   const overflowMessage = React.useMemo(() => {
     if (isNotificationDrawerExpanded) {
@@ -171,12 +166,7 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
 
   React.useEffect(() => {
     addSubscription(notificationsContext.unreadNotifications().subscribe((s) => setUnreadNotificationsCount(s.length)));
-  }, [
-    notificationsContext.unreadNotifications,
-    unreadNotificationsCount,
-    setUnreadNotificationsCount,
-    addSubscription,
-  ]);
+  }, [notificationsContext, unreadNotificationsCount, setUnreadNotificationsCount, addSubscription]);
 
   React.useEffect(() => {
     addSubscription(
@@ -208,12 +198,12 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
 
   const handleMarkNotificationRead = React.useCallback(
     (key) => () => notificationsContext.setRead(key, true),
-    [notificationsContext.setRead]
+    [notificationsContext]
   );
 
   const handleTimeout = React.useCallback(
     (key) => () => notificationsContext.setHidden(key),
-    [notificationsContext.setHidden]
+    [notificationsContext]
   );
 
   React.useEffect(() => {
@@ -242,7 +232,7 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
   );
 
   const mobileOnSelect = React.useCallback(
-    (selected) => {
+    (_selected) => {
       if (isMobileView) {
         setIsNavOpenMobile(false);
       }
@@ -252,19 +242,19 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
 
   const handleSettingsButtonClick = React.useCallback(() => {
     routerHistory.push('/settings');
-  }, [routerHistory.push]);
+  }, [routerHistory]);
 
   const handleNotificationCenterToggle = React.useCallback(() => {
     notificationsContext.setDrawerState(!isNotificationDrawerExpanded);
-  }, [isNotificationDrawerExpanded, notificationsContext.setDrawerState]);
+  }, [isNotificationDrawerExpanded, notificationsContext]);
 
   const handleCloseNotificationCenter = React.useCallback(() => {
     notificationsContext.setDrawerState(false);
-  }, [notificationsContext.setDrawerState]);
+  }, [notificationsContext]);
 
   const handleOpenNotificationCenter = React.useCallback(() => {
     notificationsContext.setDrawerState(true);
-  }, [notificationsContext.setDrawerState]);
+  }, [notificationsContext]);
 
   React.useEffect(() => {
     addSubscription(
@@ -276,7 +266,7 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
 
   const handleLogout = React.useCallback(() => {
     addSubscription(serviceContext.login.setLoggedOut().subscribe());
-  }, [serviceContext.login, serviceContext.login.setLoggedOut, addSubscription]);
+  }, [serviceContext.login, addSubscription]);
 
   const handleUserInfoToggle = React.useCallback(() => setShowUserInfoDropdown((v) => !v), [setShowUserInfoDropdown]);
 
@@ -314,11 +304,11 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
 
   const handleOpenDocumentation = React.useCallback(() => {
     openTabForUrl(build.homePageUrl);
-  }, [openTabForUrl, build]);
+  }, []);
 
   const handleOpenDiscussion = React.useCallback(() => {
     openTabForUrl(build.discussionUrl);
-  }, [openTabForUrl, build]);
+  }, []);
 
   const helpItems = React.useMemo(
     () => [
@@ -419,7 +409,7 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
       </>
     ),
     [
-      notificationsContext.info,
+      notificationsContext,
       isNotificationDrawerExpanded,
       unreadNotificationsCount,
       errorNotificationsCount,
@@ -432,6 +422,8 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
       showHelpDropdown,
       UserInfoToggle,
       userInfoItems,
+      HelpToggle,
+      helpItems
     ]
   );
 
@@ -521,7 +513,7 @@ const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
         </NavList>
       </Nav>
     ),
-    [navGroups, routes, mobileOnSelect, isActiveRoute]
+    [mobileOnSelect, isActiveRoute]
   );
 
   const Sidebar = React.useMemo(

--- a/src/app/AppLayout/AuthModal.tsx
+++ b/src/app/AppLayout/AuthModal.tsx
@@ -35,14 +35,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { Modal, ModalVariant, Text } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
-import { JmxAuthForm } from './JmxAuthForm';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { filter, first, map, mergeMap } from 'rxjs';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { Modal, ModalVariant, Text } from '@patternfly/react-core';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { filter, first, map, mergeMap } from 'rxjs';
+import { JmxAuthForm } from './JmxAuthForm';
 
 export interface AuthModalProps {
   visible: boolean;
@@ -50,7 +50,7 @@ export interface AuthModalProps {
   onSave: () => void;
 }
 
-export const AuthModal: React.FunctionComponent<AuthModalProps> = (props) => {
+export const AuthModal: React.FC<AuthModalProps> = ({ onDismiss, onSave: onPropsSave, ...props }) => {
   const context = React.useContext(ServiceContext);
   const [loading, setLoading] = React.useState(false);
   const addSubscription = useSubscriptions();
@@ -70,12 +70,12 @@ export const AuthModal: React.FunctionComponent<AuthModalProps> = (props) => {
           .subscribe((ok) => {
             setLoading(false);
             if (ok) {
-              props.onSave();
+              onPropsSave();
             }
           })
       );
     },
-    [context.target, context.api, props.onSave, setLoading]
+    [addSubscription, context.jmxCredentials, context.target, setLoading, onPropsSave]
   );
 
   return (
@@ -83,17 +83,17 @@ export const AuthModal: React.FunctionComponent<AuthModalProps> = (props) => {
       isOpen={props.visible}
       variant={ModalVariant.large}
       showClose={!loading}
-      onClose={props.onDismiss}
+      onClose={onDismiss}
       title="Authentication Required"
       description={
         <Text>
           This target JVM requires authentication. The credentials you provide here will be passed from Cryostat to the
           target when establishing JMX connections. Enter credentials specific to this target, or go to{' '}
-          <Link onClick={props.onDismiss} to="/security">
+          <Link onClick={onDismiss} to="/security">
             Security
           </Link>{' '}
           to add a credential matching multiple targets. Visit{' '}
-          <Link onClick={props.onDismiss} to="/settings">
+          <Link onClick={onDismiss} to="/settings">
             Settings
           </Link>{' '}
           to confirm and configure whether these credentials will be held only for this browser session or stored
@@ -101,7 +101,7 @@ export const AuthModal: React.FunctionComponent<AuthModalProps> = (props) => {
         </Text>
       }
     >
-      <JmxAuthForm onSave={onSave} onDismiss={props.onDismiss} focus={true} loading={loading} />
+      <JmxAuthForm onSave={onSave} onDismiss={onDismiss} focus={true} loading={loading} />
     </Modal>
   );
 };

--- a/src/app/AppLayout/JmxAuthForm.tsx
+++ b/src/app/AppLayout/JmxAuthForm.tsx
@@ -35,9 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { ActionGroup, Button, Form, FormGroup, TextInput } from '@patternfly/react-core';
 import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
+import { ActionGroup, Button, Form, FormGroup, TextInput } from '@patternfly/react-core';
+import * as React from 'react';
 
 export interface JmxAuthFormProps {
   onDismiss: () => void;
@@ -47,18 +47,18 @@ export interface JmxAuthFormProps {
   children?: React.ReactNode;
 }
 
-export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = (props) => {
+export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = ({ onDismiss, onSave, ...props }) => {
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');
 
   const handleSave = React.useCallback(() => {
-    props.onSave(username, password);
-  }, [props.onSave, username, password]);
+    onSave(username, password);
+  }, [onSave, username, password]);
 
   const handleDismiss = React.useCallback(() => {
     // Do not set state as form is unmounted after cancel
-    props.onDismiss();
-  }, [props.onDismiss]);
+    onDismiss();
+  }, [onDismiss]);
 
   const handleKeyUp = React.useCallback(
     (event: React.KeyboardEvent): void => {

--- a/src/app/AppLayout/JmxAuthForm.tsx
+++ b/src/app/AppLayout/JmxAuthForm.tsx
@@ -47,7 +47,7 @@ export interface JmxAuthFormProps {
   children?: React.ReactNode;
 }
 
-export const JmxAuthForm: React.FunctionComponent<JmxAuthFormProps> = ({ onDismiss, onSave, ...props }) => {
+export const JmxAuthForm: React.FC<JmxAuthFormProps> = ({ onDismiss, onSave, ...props }) => {
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');
 

--- a/src/app/AppLayout/SslErrorModal.tsx
+++ b/src/app/AppLayout/SslErrorModal.tsx
@@ -35,9 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { Button, Modal, ModalVariant, Text } from '@patternfly/react-core';
-import { useHistory, useRouteMatch } from 'react-router-dom';
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
 
 export interface SslErrorModalProps {
   visible: boolean;
@@ -46,7 +46,6 @@ export interface SslErrorModalProps {
 
 export const SslErrorModal: React.FunctionComponent<SslErrorModalProps> = (props) => {
   const routerHistory = useHistory();
-  const { url } = useRouteMatch();
 
   const handleClick = () => {
     routerHistory.push('/security');

--- a/src/app/AppLayout/SslErrorModal.tsx
+++ b/src/app/AppLayout/SslErrorModal.tsx
@@ -44,7 +44,7 @@ export interface SslErrorModalProps {
   onDismiss: () => void;
 }
 
-export const SslErrorModal: React.FunctionComponent<SslErrorModalProps> = (props) => {
+export const SslErrorModal: React.FC<SslErrorModalProps> = (props) => {
   const routerHistory = useHistory();
 
   const handleClick = () => {

--- a/src/app/Archives/AllArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllArchivedRecordingsTable.tsx
@@ -35,9 +35,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { ServiceContext } from '@app/Shared/Services/Services';
+import { LoadingView } from '@app/LoadingView/LoadingView';
+import { ArchivedRecordingsTable } from '@app/Recordings/ArchivedRecordingsTable';
+import { RecordingDirectory } from '@app/Shared/Services/Api.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   Toolbar,
@@ -54,14 +56,11 @@ import {
   Split,
   SplitItem,
 } from '@patternfly/react-core';
+import { HelpIcon, SearchIcon } from '@patternfly/react-icons';
 import { TableComposable, Th, Thead, Tbody, Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
-import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
-import { ArchivedRecordingsTable } from '@app/Recordings/ArchivedRecordingsTable';
+import * as React from 'react';
 import { of } from 'rxjs';
-import { LoadingView } from '@app/LoadingView/LoadingView';
-import { RecordingDirectory } from '@app/Shared/Services/Api.service';
 import { getTargetFromDirectory, includesDirectory, indexOfDirectory } from './ArchiveDirectoryUtil';
-import { HelpIcon } from '@patternfly/react-icons';
 
 export interface AllArchivedRecordingsTableProps {}
 
@@ -143,7 +142,7 @@ export const AllArchivedRecordingsTable: React.FunctionComponent<AllArchivedReco
 
   React.useEffect(() => {
     addSubscription(
-      context.notificationChannel.messages(NotificationCategory.RecordingMetadataUpdated).subscribe((v) => {
+      context.notificationChannel.messages(NotificationCategory.RecordingMetadataUpdated).subscribe(() => {
         refreshDirectoriesAndCounts();
       })
     );
@@ -151,7 +150,7 @@ export const AllArchivedRecordingsTable: React.FunctionComponent<AllArchivedReco
 
   React.useEffect(() => {
     addSubscription(
-      context.notificationChannel.messages(NotificationCategory.ActiveRecordingSaved).subscribe((v) => {
+      context.notificationChannel.messages(NotificationCategory.ActiveRecordingSaved).subscribe(() => {
         refreshDirectoriesAndCounts();
       })
     );
@@ -159,7 +158,7 @@ export const AllArchivedRecordingsTable: React.FunctionComponent<AllArchivedReco
 
   React.useEffect(() => {
     addSubscription(
-      context.notificationChannel.messages(NotificationCategory.ArchivedRecordingCreated).subscribe((v) => {
+      context.notificationChannel.messages(NotificationCategory.ArchivedRecordingCreated).subscribe(() => {
         refreshDirectoriesAndCounts();
       })
     );
@@ -167,7 +166,7 @@ export const AllArchivedRecordingsTable: React.FunctionComponent<AllArchivedReco
 
   React.useEffect(() => {
     addSubscription(
-      context.notificationChannel.messages(NotificationCategory.ArchivedRecordingDeleted).subscribe((v) => {
+      context.notificationChannel.messages(NotificationCategory.ArchivedRecordingDeleted).subscribe(() => {
         refreshDirectoriesAndCounts();
       })
     );
@@ -196,7 +195,7 @@ export const AllArchivedRecordingsTable: React.FunctionComponent<AllArchivedReco
 
   const directoryRows = React.useMemo(() => {
     return directories.map((dir, idx) => {
-      let isExpanded: boolean = includesDirectory(expandedDirectories, dir);
+      const isExpanded: boolean = includesDirectory(expandedDirectories, dir);
 
       const handleToggle = () => {
         if ((counts.get(dir.connectUrl) || 0) !== 0 || isExpanded) {
@@ -234,11 +233,11 @@ export const AllArchivedRecordingsTable: React.FunctionComponent<AllArchivedReco
         </Tr>
       );
     });
-  }, [directories, expandedDirectories, counts, isHidden]);
+  }, [toggleExpanded, directories, expandedDirectories, counts, isHidden, tableColumns]);
 
   const recordingRows = React.useMemo(() => {
     return directories.map((dir, idx) => {
-      let isExpanded: boolean = includesDirectory(expandedDirectories, dir);
+      const isExpanded: boolean = includesDirectory(expandedDirectories, dir);
 
       return (
         <Tr key={`${idx}_child`} isExpanded={isExpanded} isHidden={isHidden[idx]}>
@@ -258,10 +257,10 @@ export const AllArchivedRecordingsTable: React.FunctionComponent<AllArchivedReco
         </Tr>
       );
     });
-  }, [directories, expandedDirectories, isHidden]);
+  }, [directories, expandedDirectories, isHidden, tableColumns.length]);
 
   const rowPairs = React.useMemo(() => {
-    let rowPairs: JSX.Element[] = [];
+    const rowPairs: JSX.Element[] = [];
     for (let i = 0; i < directoryRows.length; i++) {
       rowPairs.push(directoryRows[i]);
       rowPairs.push(recordingRows[i]);

--- a/src/app/Archives/AllArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllArchivedRecordingsTable.tsx
@@ -64,7 +64,7 @@ import { getTargetFromDirectory, includesDirectory, indexOfDirectory } from './A
 
 export interface AllArchivedRecordingsTableProps {}
 
-export const AllArchivedRecordingsTable: React.FunctionComponent<AllArchivedRecordingsTableProps> = () => {
+export const AllArchivedRecordingsTable: React.FC<AllArchivedRecordingsTableProps> = () => {
   const context = React.useContext(ServiceContext);
 
   const [directories, setDirectories] = React.useState([] as RecordingDirectory[]);

--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -110,11 +110,12 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
     [setTargets, setCounts, setIsLoading]
   );
 
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   const refreshTargetsAndCounts = React.useCallback(() => {
     setIsLoading(true);
     addSubscription(
       context.api
-        .graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
+        .graphql<any>(
           `query AllTargetsArchives {
                targetNodes {
                  target {
@@ -135,12 +136,13 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
         .subscribe(handleTargetsAndCounts)
     );
   }, [addSubscription, context.api, setIsLoading, handleTargetsAndCounts]);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
 
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   const getCountForNewTarget = React.useCallback(
     (target: Target) => {
       addSubscription(
         context.api
-          /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
           .graphql<any>(
             `
         query ArchiveCountForTarget($connectUrl: String) {
@@ -168,6 +170,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
     [addSubscription, context.api, setCounts]
   );
 
+  /* eslint-enable @typescript-eslint/no-explicit-any */
   const handleLostTarget = React.useCallback(
     (target: Target) => {
       setTargets((old) => {

--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -35,10 +35,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
+import { LoadingView } from '@app/LoadingView/LoadingView';
+import { ArchivedRecordingsTable } from '@app/Recordings/ArchivedRecordingsTable';
+import { GraphQLResponse } from '@app/Shared/Services/Api.service';
+import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { includesTarget, indexOfTarget, isEqualTarget, Target } from '@app/Shared/Services/Target.service';
-import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
+import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   Toolbar,
@@ -52,13 +55,11 @@ import {
   EmptyStateIcon,
   Title,
 } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
 import { TableComposable, Th, Thead, Tbody, Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
-import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
-import { ArchivedRecordingsTable } from '@app/Recordings/ArchivedRecordingsTable';
+import * as React from 'react';
 import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
-import { LoadingView } from '@app/LoadingView/LoadingView';
 
 export interface AllTargetsArchivedRecordingsTableProps {}
 
@@ -113,7 +114,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
     setIsLoading(true);
     addSubscription(
       context.api
-        .graphql<any>(
+        .graphql<GraphQLResponse>(
           `query AllTargetsArchives {
                targetNodes {
                  target {
@@ -133,13 +134,13 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
         .pipe(map((v) => v.data.targetNodes))
         .subscribe(handleTargetsAndCounts)
     );
-  }, [addSubscription, context, context.api, setIsLoading, handleTargetsAndCounts]);
+  }, [addSubscription, context.api, setIsLoading, handleTargetsAndCounts]);
 
   const getCountForNewTarget = React.useCallback(
     (target: Target) => {
       addSubscription(
         context.api
-          .graphql<any>(
+          .graphql<GraphQLResponse>(
             `
         query ArchiveCountForTarget($connectUrl: String) {
           targetNodes(filter: { name: $connectUrl }) {
@@ -163,7 +164,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
           )
       );
     },
-    [addSubscription, context, context.api, setCounts]
+    [addSubscription, context.api, setCounts]
   );
 
   const handleLostTarget = React.useCallback(
@@ -284,7 +285,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
 
   const targetRows = React.useMemo(() => {
     return targets.map((target, idx) => {
-      let isExpanded: boolean = includesTarget(expandedTargets, target);
+      const isExpanded: boolean = includesTarget(expandedTargets, target);
 
       const handleToggle = () => {
         if ((counts.get(target.connectUrl) || 0) !== 0 || isExpanded) {
@@ -315,11 +316,11 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
         </Tr>
       );
     });
-  }, [targets, expandedTargets, counts, isHidden]);
+  }, [toggleExpanded, targets, expandedTargets, counts, isHidden, tableColumns]);
 
   const recordingRows = React.useMemo(() => {
     return targets.map((target, idx) => {
-      let isExpanded: boolean = includesTarget(expandedTargets, target);
+      const isExpanded: boolean = includesTarget(expandedTargets, target);
 
       return (
         <Tr key={`${idx}_child`} isExpanded={isExpanded} isHidden={isHidden[idx]}>
@@ -333,10 +334,10 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
         </Tr>
       );
     });
-  }, [targets, expandedTargets, isHidden]);
+  }, [targets, expandedTargets, isHidden, tableColumns.length]);
 
   const rowPairs = React.useMemo(() => {
-    let rowPairs: JSX.Element[] = [];
+    const rowPairs: JSX.Element[] = [];
     for (let i = 0; i < targetRows.length; i++) {
       rowPairs.push(targetRows[i]);
       rowPairs.push(recordingRows[i]);

--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -62,9 +62,7 @@ import { map } from 'rxjs/operators';
 
 export interface AllTargetsArchivedRecordingsTableProps {}
 
-export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
-  AllTargetsArchivedRecordingsTableProps
-> = () => {
+export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecordingsTableProps> = () => {
   const context = React.useContext(ServiceContext);
 
   const [targets, setTargets] = React.useState([] as Target[]);

--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -37,7 +37,6 @@
  */
 import { LoadingView } from '@app/LoadingView/LoadingView';
 import { ArchivedRecordingsTable } from '@app/Recordings/ArchivedRecordingsTable';
-import { GraphQLResponse } from '@app/Shared/Services/Api.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { includesTarget, indexOfTarget, isEqualTarget, Target } from '@app/Shared/Services/Target.service';
@@ -92,6 +91,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
   );
 
   const handleTargetsAndCounts = React.useCallback(
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     (targetNodes: any) => {
       const updatedTargets: Target[] = [];
       const updatedCounts = new Map<string, number>();
@@ -114,7 +114,7 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
     setIsLoading(true);
     addSubscription(
       context.api
-        .graphql<GraphQLResponse>(
+        .graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
           `query AllTargetsArchives {
                targetNodes {
                  target {
@@ -140,7 +140,8 @@ export const AllTargetsArchivedRecordingsTable: React.FunctionComponent<
     (target: Target) => {
       addSubscription(
         context.api
-          .graphql<GraphQLResponse>(
+          /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+          .graphql<any>(
             `
         query ArchiveCountForTarget($connectUrl: String) {
           targetNodes(filter: { name: $connectUrl }) {

--- a/src/app/Archives/ArchiveUploadModal.tsx
+++ b/src/app/Archives/ArchiveUploadModal.tsx
@@ -63,7 +63,7 @@ export interface ArchiveUploadModalProps {
   onClose: () => void;
 }
 
-export const ArchiveUploadModal: React.FunctionComponent<ArchiveUploadModalProps> = (props) => {
+export const ArchiveUploadModal: React.FC<ArchiveUploadModalProps> = ({ onClose, ...props }) => {
   const addSubscriptions = useSubscriptions();
   const context = React.useContext(ServiceContext);
   const submitRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to submit trigger div
@@ -97,9 +97,9 @@ export const ArchiveUploadModal: React.FunctionComponent<ArchiveUploadModalProps
       abortRef.current && abortRef.current.click();
     } else {
       reset();
-      props.onClose();
+      onClose();
     }
-  }, [uploading, abortRef.current, reset, props.onClose]);
+  }, [uploading, abortRef, reset, onClose]);
 
   const onFileSubmit = React.useCallback(
     (fileUploads: FUpload[], { getProgressUpdateCallback, onSingleSuccess, onSingleFailure }: UploadCallbacks) => {
@@ -139,12 +139,12 @@ export const ArchiveUploadModal: React.FunctionComponent<ArchiveUploadModalProps
           })
       );
     },
-    [addSubscriptions, context.api, setUploading, handleClose, getFormattedLabels, setAllOks]
+    [addSubscriptions, context.api, setUploading, getFormattedLabels, setAllOks]
   );
 
   const handleSubmit = React.useCallback(() => {
     submitRef.current && submitRef.current.click();
-  }, [submitRef.current]);
+  }, [submitRef]);
 
   const onFilesChange = React.useCallback(
     (fileUploads: FUpload[]) => {

--- a/src/app/Archives/Archives.tsx
+++ b/src/app/Archives/Archives.tsx
@@ -35,18 +35,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { Card, CardBody, EmptyState, EmptyStateIcon, Tab, Tabs, TabTitleText, Title } from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
-import { AllArchivedRecordingsTable } from './AllArchivedRecordingsTable';
-import { AllTargetsArchivedRecordingsTable } from './AllTargetsArchivedRecordingsTable';
 import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { ArchivedRecordingsTable } from '@app/Recordings/ArchivedRecordingsTable';
-import { Target } from '@app/Shared/Services/Target.service';
-import { of } from 'rxjs';
 import { UPLOADS_SUBDIRECTORY } from '@app/Shared/Services/Api.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { Target } from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { Card, CardBody, EmptyState, EmptyStateIcon, Tab, Tabs, TabTitleText, Title } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+import { of } from 'rxjs';
+import { AllArchivedRecordingsTable } from './AllArchivedRecordingsTable';
+import { AllTargetsArchivedRecordingsTable } from './AllTargetsArchivedRecordingsTable';
 
 /*
   This specific target is used as the "source" for the Uploads version of the ArchivedRecordingsTable.
@@ -62,7 +62,7 @@ export const uploadAsTarget: Target = {
 
 export interface ArchivesProps {}
 
-export const Archives: React.FunctionComponent<ArchivesProps> = (props) => {
+export const Archives: React.FC<ArchivesProps> = (_) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [activeTab, setActiveTab] = React.useState(0);

--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -35,9 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { Breadcrumb, BreadcrumbHeading, BreadcrumbItem, PageSection, Stack, StackItem } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Breadcrumb, BreadcrumbHeading, BreadcrumbItem, PageSection, Stack, StackItem } from '@patternfly/react-core';
 
 interface BreadcrumbPageProps {
   pageTitle: string;

--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -50,7 +50,7 @@ export interface BreadcrumbTrail {
   path: string;
 }
 
-export const BreadcrumbPage: React.FunctionComponent<BreadcrumbPageProps> = (props) => {
+export const BreadcrumbPage: React.FC<BreadcrumbPageProps> = (props) => {
   return (
     <>
       <PageSection>

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -35,14 +35,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
+import { TemplateType } from '@app/Shared/Services/Api.service';
 import { TargetView } from '@app/TargetView/TargetView';
 import { Card, CardBody, Tab, Tabs } from '@patternfly/react-core';
+import * as React from 'react';
 import { StaticContext } from 'react-router';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { CustomRecordingForm } from './CustomRecordingForm';
 import { SnapshotRecordingForm } from './SnapshotRecordingForm';
-import { TemplateType } from '@app/Shared/Services/Api.service';
 
 export interface CreateRecordingProps {
   templateName?: string;
@@ -56,7 +56,7 @@ export interface EventTemplate {
   type: TemplateType;
 }
 
-const Comp: React.FunctionComponent<RouteComponentProps<{}, StaticContext, CreateRecordingProps>> = (props) => {
+const Comp: React.FC<RouteComponentProps<Record<string, never>, StaticContext, CreateRecordingProps>> = (props) => {
   const [activeTab, setActiveTab] = React.useState(0);
 
   const onTabSelect = React.useCallback((evt, idx) => setActiveTab(Number(idx)), [setActiveTab]);

--- a/src/app/CreateRecording/SnapshotRecordingForm.tsx
+++ b/src/app/CreateRecording/SnapshotRecordingForm.tsx
@@ -46,7 +46,7 @@ import { first } from 'rxjs';
 
 export interface SnapshotRecordingFormProps {}
 
-export const SnapshotRecordingForm: React.FunctionComponent<SnapshotRecordingFormProps> = (_) => {
+export const SnapshotRecordingForm: React.FC<SnapshotRecordingFormProps> = (_) => {
   const history = useHistory();
   const addSubscription = useSubscriptions();
   const context = React.useContext(ServiceContext);

--- a/src/app/CreateRecording/SnapshotRecordingForm.tsx
+++ b/src/app/CreateRecording/SnapshotRecordingForm.tsx
@@ -35,18 +35,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { ActionGroup, Button, Form, Text, TextVariants } from '@patternfly/react-core';
-import { useHistory } from 'react-router-dom';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { first } from 'rxjs';
-import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 import { authFailMessage, ErrorView, isAuthFail, missingSSLMessage } from '@app/ErrorView/ErrorView';
+import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { ActionGroup, Button, Form, Text, TextVariants } from '@patternfly/react-core';
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import { first } from 'rxjs';
 
 export interface SnapshotRecordingFormProps {}
 
-export const SnapshotRecordingForm: React.FunctionComponent<SnapshotRecordingFormProps> = (props) => {
+export const SnapshotRecordingForm: React.FunctionComponent<SnapshotRecordingFormProps> = (_) => {
   const history = useHistory();
   const addSubscription = useSubscriptions();
   const context = React.useContext(ServiceContext);

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -76,7 +76,7 @@ import { getDashboardCards, getConfigByTitle, PropControl } from './Dashboard';
 
 interface AddCardProps {}
 
-export const AddCard: React.FunctionComponent<AddCardProps> = (_: AddCardProps) => {
+export const AddCard: React.FC<AddCardProps> = (_) => {
   const addSubscription = useSubscriptions();
   const settingsContext = useContext(ServiceContext);
 

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -169,7 +169,7 @@ export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (prop
   // Query NEEDS 'state' so that isActiveRecording(result) is valid
   const queryActiveRecordings = React.useCallback(
     (connectUrl: string) => {
-      return context.api.graphql<any>(
+      return context.api.graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
         `
       query ActiveRecordingsForAutomatedAnalysis($connectUrl: String) {
         targetNodes(filter: { name: $connectUrl }) {
@@ -199,7 +199,7 @@ export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (prop
 
   const queryArchivedRecordings = React.useCallback(
     (connectUrl: string) => {
-      return context.api.graphql<any>(
+      return context.api.graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
         `
       query ArchivedRecordingsForAutomatedAnalysis($connectUrl: String) {
         archivedRecordings(filter: { sourceTarget: $connectUrl }) {

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
-import LoadingView from '@app/LoadingView/LoadingView';
+import { LoadingView } from '@app/LoadingView/LoadingView';
 import {
   emptyAutomatedAnalysisFilters,
   TargetAutomatedAnalysisFilters,
@@ -100,7 +100,9 @@ import { InfoCircleIcon, OutlinedQuestionCircleIcon, Spinner2Icon, TrashIcon } f
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { filter, first, map, tap } from 'rxjs';
+import { DashboardCardDescriptor, DashboardCardProps } from '../Dashboard';
 import { AutomatedAnalysisConfigDrawer } from './AutomatedAnalysisConfigDrawer';
+import { AutomatedAnalysisConfigForm } from './AutomatedAnalysisConfigForm';
 import {
   AutomatedAnalysisFilters,
   AutomatedAnalysisFiltersCategories,
@@ -109,12 +111,10 @@ import {
 } from './AutomatedAnalysisFilters';
 import { clickableAutomatedAnalysisKey, ClickableAutomatedAnalysisLabel } from './ClickableAutomatedAnalysisLabel';
 import { AutomatedAnalysisScoreFilter } from './Filters/AutomatedAnalysisScoreFilter';
-import { DashboardCardDescriptor, DashboardCardProps } from '../Dashboard';
-import { AutomatedAnalysisConfigForm } from './AutomatedAnalysisConfigForm';
 
-interface AutomatedAnalysisCardProps extends DashboardCardProps {}
+type AutomatedAnalysisCardProps = DashboardCardProps;
 
-export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCardProps> = (props) => {
+export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const dispatch = useDispatch<StateDispatch>();
@@ -194,7 +194,7 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
         { connectUrl }
       );
     },
-    [context.api, context.api.graphql]
+    [context.api]
   );
 
   const queryArchivedRecordings = React.useCallback(
@@ -218,7 +218,7 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
         { connectUrl }
       );
     },
-    [context.api, context.api.graphql]
+    [context.api]
   );
 
   const handleStateErrors = React.useCallback(
@@ -388,10 +388,8 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
     );
   }, [
     addSubscription,
-    context.api,
     context.target,
     context.reports,
-    automatedAnalysisAddTargetIntent,
     setIsLoading,
     setReport,
     categorizeEvaluation,
@@ -411,7 +409,7 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
           if (resp.ok || resp.status === 400) {
             // in-case the recording already exists
             generateReport();
-          } else if (resp?.status === 500) {
+          } else if (resp.status === 500) {
             handleStateErrors(TEMPLATE_UNSUPPORTED_MESSAGE);
           }
         } else {
@@ -419,14 +417,7 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
         }
       })
     );
-  }, [
-    addSubscription,
-    context.api,
-    context.settings,
-    context.settings.automatedAnalysisRecordingConfig,
-    generateReport,
-    handleStateErrors,
-  ]);
+  }, [addSubscription, context.api, context.settings, generateReport, handleStateErrors]);
 
   const getMessageAndRetry = React.useCallback(
     (errorMessage: string | undefined): [string | undefined, undefined | (() => void)] => {
@@ -452,7 +443,7 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
 
   React.useEffect(() => {
     addSubscription(context.target.authRetry().subscribe(generateReport));
-  }, [addSubscription, context.target]);
+  }, [addSubscription, context.target, generateReport]);
 
   React.useEffect(() => {
     context.target.target().subscribe((target) => {
@@ -496,7 +487,6 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
     targetAutomatedAnalysisFilters,
     targetAutomatedAnalysisGlobalFilters,
     showNAScores,
-    filterAutomatedAnalysis,
     setFilteredCategorizedEvaluation,
   ]);
 
@@ -582,17 +572,12 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
         dispatch(automatedAnalysisAddFilterIntent(target, filterKey, filterValue));
       }
     },
-    [
-      dispatch,
-      automatedAnalysisDeleteCategoryFiltersIntent,
-      automatedAnalysisDeleteFilterIntent,
-      automatedAnalysisAddFilterIntent,
-    ]
+    [dispatch]
   );
 
   const handleClearFilters = React.useCallback(() => {
     dispatch(automatedAnalysisDeleteAllFiltersIntent(targetConnectURL));
-  }, [dispatch, automatedAnalysisDeleteAllFiltersIntent, targetConnectURL]);
+  }, [dispatch, targetConnectURL]);
 
   const reportStalenessText = React.useMemo(() => {
     if (isLoading || !(usingArchivedReport || usingCachedReport)) {
@@ -675,6 +660,9 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
     targetConnectURL,
     categorizedEvaluation,
     targetAutomatedAnalysisFilters,
+    usingArchivedReport,
+    usingCachedReport,
+    clearAnalysis,
     generateReport,
     handleClearFilters,
     handleNAScoreChange,
@@ -777,7 +765,7 @@ export const AutomatedAnalysisCard: React.FunctionComponent<AutomatedAnalysisCar
         <Stack hasGutter>
           <StackItem>{errorMessage ? null : toolbar}</StackItem>
           <StackItem className="automated-analysis-score-filter-stack-item">
-            {errorMessage ? null : <AutomatedAnalysisScoreFilter targetConnectUrl={targetConnectURL} />}
+            {errorMessage ? null : <AutomatedAnalysisScoreFilter />}
           </StackItem>
           <StackItem>
             <CardBody isFilled={true}>

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -169,7 +169,8 @@ export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (prop
   // Query NEEDS 'state' so that isActiveRecording(result) is valid
   const queryActiveRecordings = React.useCallback(
     (connectUrl: string) => {
-      return context.api.graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      return context.api.graphql<any>(
         `
       query ActiveRecordingsForAutomatedAnalysis($connectUrl: String) {
         targetNodes(filter: { name: $connectUrl }) {
@@ -199,9 +200,9 @@ export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (prop
 
   const queryArchivedRecordings = React.useCallback(
     (connectUrl: string) => {
-      return context.api.graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
-        `
-      query ArchivedRecordingsForAutomatedAnalysis($connectUrl: String) {
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      return context.api.graphql<any>(
+        `query ArchivedRecordingsForAutomatedAnalysis($connectUrl: String) {
         archivedRecordings(filter: { sourceTarget: $connectUrl }) {
           data {
             name

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigDrawer.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigDrawer.tsx
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import LoadingView from '@app/LoadingView/LoadingView';
+import { LoadingView } from '@app/LoadingView/LoadingView';
 import { RecordingAttributes } from '@app/Shared/Services/Api.service';
 import { RECORDING_FAILURE_MESSAGE, TEMPLATE_UNSUPPORTED_MESSAGE } from '@app/Shared/Services/Report.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
@@ -70,7 +70,11 @@ interface AutomatedAnalysisConfigDrawerProps {
   onError: (error: Error) => void;
 }
 
-export const AutomatedAnalysisConfigDrawer: React.FunctionComponent<AutomatedAnalysisConfigDrawerProps> = (props) => {
+export const AutomatedAnalysisConfigDrawer: React.FC<AutomatedAnalysisConfigDrawerProps> = ({
+  onCreate,
+  onError,
+  ...props
+}) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
 
@@ -94,21 +98,21 @@ export const AutomatedAnalysisConfigDrawer: React.FunctionComponent<AutomatedAna
           next: (resp) => {
             setIsLoading(false);
             if (resp && resp.ok) {
-              props.onCreate();
+              onCreate();
             } else if (resp?.status === 500) {
-              props.onError(new Error(TEMPLATE_UNSUPPORTED_MESSAGE));
+              onError(new Error(TEMPLATE_UNSUPPORTED_MESSAGE));
             } else {
-              props.onError(new Error(RECORDING_FAILURE_MESSAGE));
+              onError(new Error(RECORDING_FAILURE_MESSAGE));
             }
           },
           error: (err) => {
             setIsLoading(false);
-            props.onError(err);
+            onError(err);
           },
         })
       );
     },
-    [addSubscription, context.api, props.onCreate, props.onError, setIsLoading]
+    [addSubscription, context.api, setIsLoading, onCreate, onError]
   );
 
   const onDefaultRecordingStart = React.useCallback(() => {
@@ -140,11 +144,11 @@ export const AutomatedAnalysisConfigDrawer: React.FunctionComponent<AutomatedAna
           </DrawerActions>
         </DrawerHead>
         <DrawerPanelBody>
-          <AutomatedAnalysisConfigForm onCreate={props.onCreate} isSettingsForm={false} />
+          <AutomatedAnalysisConfigForm onCreate={onCreate} isSettingsForm={false} />
         </DrawerPanelBody>
       </DrawerPanelContent>
     );
-  }, [props.onCreate, onDrawerClose]);
+  }, [isExpanded, onDrawerClose, onCreate]);
 
   const dropdownItems = React.useMemo(
     () => [

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.tsx
@@ -75,7 +75,11 @@ interface AutomatedAnalysisConfigFormProps {
   isSettingsForm: boolean;
 }
 
-export const AutomatedAnalysisConfigForm: React.FunctionComponent<AutomatedAnalysisConfigFormProps> = (props) => {
+export const AutomatedAnalysisConfigForm: React.FunctionComponent<AutomatedAnalysisConfigFormProps> = ({
+  onCreate,
+  onSave,
+  ...props
+}) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
 
@@ -191,11 +195,11 @@ export const AutomatedAnalysisConfigForm: React.FunctionComponent<AutomatedAnaly
   );
 
   const getEventString = React.useCallback(() => {
-    var str = '';
-    if (!!templateName) {
+    let str = '';
+    if (templateName) {
       str += `template=${templateName}`;
     }
-    if (!!templateType) {
+    if (templateType) {
       str += `,type=${templateType}`;
     }
     return str;
@@ -212,12 +216,12 @@ export const AutomatedAnalysisConfigForm: React.FunctionComponent<AutomatedAnaly
     addSubscription(
       context.api.createRecording(recordingAttributes).subscribe({
         next: (resp) => {
-          if (resp && resp.ok && props.onCreate) {
-            props.onCreate();
+          if (resp && resp.ok && onCreate) {
+            onCreate();
           }
           setIsLoading(false);
         },
-        error: (err) => {
+        error: () => {
           setIsLoading(false);
         },
       })
@@ -227,7 +231,7 @@ export const AutomatedAnalysisConfigForm: React.FunctionComponent<AutomatedAnaly
     context.api,
     setIsLoading,
     getEventString,
-    props.onCreate,
+    onCreate,
     maxAge,
     maxAgeUnits,
     maxSize,
@@ -244,8 +248,8 @@ export const AutomatedAnalysisConfigForm: React.FunctionComponent<AutomatedAnaly
     setIsSaveLoading(true);
     const timer = setTimeout(() => {
       setShowHelperMessage(true);
-      if (props.onSave) {
-        props.onSave();
+      if (onSave) {
+        onSave();
       }
       setIsSaveLoading(false);
     }, 500);
@@ -254,13 +258,12 @@ export const AutomatedAnalysisConfigForm: React.FunctionComponent<AutomatedAnaly
     getEventString,
     setIsSaveLoading,
     setShowHelperMessage,
-    props.onSave,
+    onSave,
     maxAge,
     maxAgeUnits,
     maxSize,
     maxSizeUnits,
     context.settings,
-    context.settings.setAutomatedAnalysisRecordingConfig,
   ]);
 
   const authRetry = React.useCallback(() => {

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.tsx
@@ -75,7 +75,7 @@ interface AutomatedAnalysisConfigFormProps {
   isSettingsForm: boolean;
 }
 
-export const AutomatedAnalysisConfigForm: React.FunctionComponent<AutomatedAnalysisConfigFormProps> = ({
+export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormProps> = ({
   onCreate,
   onSave,
   ...props
@@ -216,8 +216,8 @@ export const AutomatedAnalysisConfigForm: React.FunctionComponent<AutomatedAnaly
     addSubscription(
       context.api.createRecording(recordingAttributes).subscribe({
         next: (resp) => {
-          if (resp && resp.ok && onCreate) {
-            onCreate();
+          if (resp && resp.ok) {
+            onCreate && onCreate();
           }
           setIsLoading(false);
         },

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters.tsx
@@ -35,13 +35,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { allowedAutomatedAnalysisFilters } from '@app/Shared/Redux/Filters/AutomatedAnalysisFilterSlice';
 import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 import { automatedAnalysisUpdateCategoryIntent, RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
+import { RuleEvaluation } from '@app/Shared/Services/Report.service';
 import {
   Dropdown,
   DropdownItem,
   DropdownPosition,
   DropdownToggle,
+  ToolbarChipGroup,
   ToolbarFilter,
   ToolbarGroup,
   ToolbarItem,
@@ -50,10 +53,8 @@ import {
 import { FilterIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { RuleEvaluation } from '@app/Shared/Services/Report.service';
 import { AutomatedAnalysisNameFilter } from './Filters/AutomatedAnalysisNameFilter';
 import { AutomatedAnalysisTopicFilter } from './Filters/AutomatedAnalysisTopicFilter';
-import { allowedAutomatedAnalysisFilters } from '@app/Shared/Redux/Filters/AutomatedAnalysisFilterSlice';
 
 export interface AutomatedAnalysisFiltersCategories {
   Name: string[];
@@ -71,7 +72,10 @@ export interface AutomatedAnalysisFiltersProps {
   updateFilters: (target: string, updateFilterOptions: UpdateFilterOptions) => void;
 }
 
-export const AutomatedAnalysisFilters: React.FunctionComponent<AutomatedAnalysisFiltersProps> = (props) => {
+export const AutomatedAnalysisFilters: React.FunctionComponent<AutomatedAnalysisFiltersProps> = ({
+  updateFilters,
+  ...props
+}) => {
   const dispatch = useDispatch<StateDispatch>();
 
   const currentCategory = useSelector((state: RootState) => {
@@ -93,30 +97,31 @@ export const AutomatedAnalysisFilters: React.FunctionComponent<AutomatedAnalysis
       setIsCategoryDropdownOpen(false);
       dispatch(automatedAnalysisUpdateCategoryIntent(props.target, category));
     },
-    [dispatch, automatedAnalysisUpdateCategoryIntent, setIsCategoryDropdownOpen, props.target]
+    [dispatch, setIsCategoryDropdownOpen, props.target]
   );
 
   const onDelete = React.useCallback(
-    (category, value) => props.updateFilters(props.target, { filterKey: category, filterValue: value, deleted: true }),
-    [props.updateFilters, props.target]
+    (category: string | ToolbarChipGroup, value) =>
+      updateFilters(props.target, { filterKey: category as string, filterValue: value, deleted: true }),
+    [updateFilters, props.target]
   );
 
   const onDeleteGroup = React.useCallback(
-    (category) =>
-      props.updateFilters(props.target, { filterKey: category, deleted: true, deleteOptions: { all: true } }),
-    [props.updateFilters, props.target]
+    (category: string | ToolbarChipGroup) =>
+      updateFilters(props.target, { filterKey: category as string, deleted: true, deleteOptions: { all: true } }),
+    [updateFilters, props.target]
   );
 
   const onNameInput = React.useCallback(
-    (inputName) => props.updateFilters(props.target, { filterKey: currentCategory!, filterValue: inputName }),
-    [props.updateFilters, currentCategory, props.target]
+    (inputName: string) => updateFilters(props.target, { filterKey: currentCategory, filterValue: inputName }),
+    [updateFilters, currentCategory, props.target]
   );
 
   const onTopicInput = React.useCallback(
-    (inputTopic) => {
-      props.updateFilters(props.target, { filterKey: currentCategory!, filterValue: inputTopic });
+    (inputTopic: string) => {
+      updateFilters(props.target, { filterKey: currentCategory, filterValue: inputTopic });
     },
-    [props.updateFilters, currentCategory, props.target]
+    [updateFilters, currentCategory, props.target]
   );
 
   const categoryDropdown = React.useMemo(() => {
@@ -137,16 +142,18 @@ export const AutomatedAnalysisFilters: React.FunctionComponent<AutomatedAnalysis
         ))}
       />
     );
-  }, [allowedAutomatedAnalysisFilters, isCategoryDropdownOpen, currentCategory, onCategoryToggle, onCategorySelect]);
+  }, [isCategoryDropdownOpen, currentCategory, onCategoryToggle, onCategorySelect]);
 
   const filterDropdownItems = React.useMemo(
     () => [
       <AutomatedAnalysisNameFilter
+        key={'name'}
         evaluations={props.evaluations}
         filteredNames={props.filters.Name}
         onSubmit={onNameInput}
       />,
       <AutomatedAnalysisTopicFilter
+        key={'topic'}
         evaluations={props.evaluations}
         filteredTopics={props.filters.Topic}
         onSubmit={onTopicInput}
@@ -192,7 +199,7 @@ export const filterAutomatedAnalysis = (
 
   let filtered = topicEvalTuple;
 
-  if (!!filters.Name.length) {
+  if (filters.Name.length) {
     filtered = filtered.map(([topic, evaluations]) => {
       return [topic, evaluations.filter((evaluation) => filters.Name.includes(evaluation.name))] as [
         string,

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters.tsx
@@ -72,10 +72,7 @@ export interface AutomatedAnalysisFiltersProps {
   updateFilters: (target: string, updateFilterOptions: UpdateFilterOptions) => void;
 }
 
-export const AutomatedAnalysisFilters: React.FunctionComponent<AutomatedAnalysisFiltersProps> = ({
-  updateFilters,
-  ...props
-}) => {
+export const AutomatedAnalysisFilters: React.FC<AutomatedAnalysisFiltersProps> = ({ updateFilters, ...props }) => {
   const dispatch = useDispatch<StateDispatch>();
 
   const currentCategory = useSelector((state: RootState) => {
@@ -199,7 +196,7 @@ export const filterAutomatedAnalysis = (
 
   let filtered = topicEvalTuple;
 
-  if (filters.Name.length) {
+  if (filters.Name != null && !!filters.Name.length) {
     filtered = filtered.map(([topic, evaluations]) => {
       return [topic, evaluations.filter((evaluation) => filters.Name.includes(evaluation.name))] as [
         string,

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.tsx
@@ -46,10 +46,7 @@ export interface AutomatedAnalysisNameFilterProps {
   onSubmit: (inputName: string) => void;
 }
 
-export const AutomatedAnalysisNameFilter: React.FunctionComponent<AutomatedAnalysisNameFilterProps> = ({
-  onSubmit,
-  ...props
-}) => {
+export const AutomatedAnalysisNameFilter: React.FC<AutomatedAnalysisNameFilterProps> = ({ onSubmit, ...props }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
 
   const onSelect = React.useCallback(

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.tsx
@@ -36,9 +36,9 @@
  * SOFTWARE.
  */
 
-import React from 'react';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import { CategorizedRuleEvaluations } from '@app/Shared/Services/Report.service';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import React from 'react';
 
 export interface AutomatedAnalysisNameFilterProps {
   evaluations: CategorizedRuleEvaluations[];
@@ -46,23 +46,26 @@ export interface AutomatedAnalysisNameFilterProps {
   onSubmit: (inputName: string) => void;
 }
 
-export const AutomatedAnalysisNameFilter: React.FunctionComponent<AutomatedAnalysisNameFilterProps> = (props) => {
+export const AutomatedAnalysisNameFilter: React.FunctionComponent<AutomatedAnalysisNameFilterProps> = ({
+  onSubmit,
+  ...props
+}) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
 
   const onSelect = React.useCallback(
     (_, selection, isPlaceholder) => {
       if (!isPlaceholder) {
         setIsExpanded(false);
-        props.onSubmit(selection);
+        onSubmit(selection);
       }
     },
-    [props.onSubmit, setIsExpanded]
+    [onSubmit, setIsExpanded]
   );
 
   const nameOptions = React.useMemo(() => {
     const flatEvalMap: string[] = [] as string[];
-    for (let topic of props.evaluations.map((r) => r[1])) {
-      for (let rule of topic) {
+    for (const topic of props.evaluations.map((r) => r[1])) {
+      for (const rule of topic) {
         flatEvalMap.push(rule.name);
       }
     }

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.tsx
@@ -51,11 +51,9 @@ import {
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-export interface AutomatedAnalysisScoreFilterProps {
-  targetConnectUrl: string;
-}
+export interface AutomatedAnalysisScoreFilterProps {}
 
-export const AutomatedAnalysisScoreFilter: React.FunctionComponent<AutomatedAnalysisScoreFilterProps> = (props) => {
+export const AutomatedAnalysisScoreFilter: React.FC<AutomatedAnalysisScoreFilterProps> = (_) => {
   const dispatch = useDispatch<StateDispatch>();
   const currentScore = useSelector((state: RootState) => {
     const filters = state.automatedAnalysisFilters.state.globalFilters.filters;

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.tsx
@@ -36,9 +36,9 @@
  * SOFTWARE.
  */
 
-import React from 'react';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import { CategorizedRuleEvaluations } from '@app/Shared/Services/Report.service';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import React from 'react';
 
 export interface AutomatedAnalysisTopicFilterProps {
   evaluations: CategorizedRuleEvaluations[];
@@ -46,17 +46,20 @@ export interface AutomatedAnalysisTopicFilterProps {
   onSubmit: (inputName: string) => void;
 }
 
-export const AutomatedAnalysisTopicFilter: React.FunctionComponent<AutomatedAnalysisTopicFilterProps> = (props) => {
+export const AutomatedAnalysisTopicFilter: React.FunctionComponent<AutomatedAnalysisTopicFilterProps> = ({
+  onSubmit,
+  ...props
+}) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
 
   const onSelect = React.useCallback(
     (_, selection, isPlaceholder) => {
       if (!isPlaceholder) {
         setIsExpanded(false);
-        props.onSubmit(selection);
+        onSubmit(selection);
       }
     },
-    [props.onSubmit, setIsExpanded]
+    [onSubmit, setIsExpanded]
   );
 
   const topicOptions = React.useMemo(() => {

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.tsx
@@ -46,10 +46,7 @@ export interface AutomatedAnalysisTopicFilterProps {
   onSubmit: (inputName: string) => void;
 }
 
-export const AutomatedAnalysisTopicFilter: React.FunctionComponent<AutomatedAnalysisTopicFilterProps> = ({
-  onSubmit,
-  ...props
-}) => {
+export const AutomatedAnalysisTopicFilter: React.FC<AutomatedAnalysisTopicFilterProps> = ({ onSubmit, ...props }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
 
   const onSelect = React.useCallback(

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -51,7 +51,7 @@ export interface DashboardCardDescriptor {
   title: string;
   description: string;
   descriptionFull: JSX.Element | string;
-  component: React.FunctionComponent<any>;
+  component: React.FC<any>;
   propControls: PropControl[];
   advancedConfig?: JSX.Element;
 }

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -35,6 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { dashboardCardConfigDeleteCardIntent, RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
 import { TargetView } from '@app/TargetView/TargetView';

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -35,16 +35,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { Card, CardActions, CardBody, CardHeader, Stack, StackItem, Text } from '@patternfly/react-core';
-import { useDispatch, useSelector } from 'react-redux';
-import { TargetView } from '@app/TargetView/TargetView';
-import { AddCard } from './AddCard';
-import { DashboardCardActionMenu } from './DashboardCardActionMenu';
-import { AutomatedAnalysisCardDescriptor } from './AutomatedAnalysis/AutomatedAnalysisCard';
 import { dashboardCardConfigDeleteCardIntent, RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
-import { Observable, of } from 'rxjs';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
+import { TargetView } from '@app/TargetView/TargetView';
+import { Card, CardActions, CardBody, CardHeader, Stack, StackItem, Text } from '@patternfly/react-core';
+import * as React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Observable, of } from 'rxjs';
+import { AddCard } from './AddCard';
+import { AutomatedAnalysisCardDescriptor } from './AutomatedAnalysis/AutomatedAnalysisCard';
+import { DashboardCardActionMenu } from './DashboardCardActionMenu';
 
 export interface DashboardCardDescriptor {
   title: string;
@@ -206,7 +206,7 @@ export function getConfigByTitle(title: string): DashboardCardDescriptor {
   throw new Error(`Unknown card type selection: ${title}`);
 }
 
-export const Dashboard: React.FunctionComponent<DashboardProps> = (props) => {
+export const Dashboard: React.FC<DashboardProps> = (_) => {
   const dispatch = useDispatch<StateDispatch>();
   const cardConfigs = useSelector((state: RootState) => state.dashboardConfigs.list);
 
@@ -214,7 +214,7 @@ export const Dashboard: React.FunctionComponent<DashboardProps> = (props) => {
     (idx: number) => {
       dispatch(dashboardCardConfigDeleteCardIntent(idx));
     },
-    [dispatch, dashboardCardConfigDeleteCardIntent]
+    [dispatch]
   );
 
   return (
@@ -224,7 +224,7 @@ export const Dashboard: React.FunctionComponent<DashboardProps> = (props) => {
           <StackItem key={idx}>
             {React.createElement(getConfigByName(cfg.name).component, {
               ...cfg.props,
-              actions: [<DashboardCardActionMenu onRemove={() => handleRemove(idx)} />],
+              actions: [<DashboardCardActionMenu key={`${cfg.name}-remove`} onRemove={() => handleRemove(idx)} />],
             })}
           </StackItem>
         ))}

--- a/src/app/DurationPicker/DurationPicker.tsx
+++ b/src/app/DurationPicker/DurationPicker.tsx
@@ -35,8 +35,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { FormSelect, FormSelectOption, Split, SplitItem, TextInput } from '@patternfly/react-core';
+import * as React from 'react';
 
 export interface DurationPickerProps {
   onPeriodChange: (period: number) => void;

--- a/src/app/DurationPicker/DurationPicker.tsx
+++ b/src/app/DurationPicker/DurationPicker.tsx
@@ -46,7 +46,7 @@ export interface DurationPickerProps {
   enabled: boolean;
 }
 
-export const DurationPicker: React.FunctionComponent<DurationPickerProps> = (props) => {
+export const DurationPicker: React.FC<DurationPickerProps> = (props) => {
   return (
     <>
       <Split hasGutter={true}>

--- a/src/app/DynamicImport.tsx
+++ b/src/app/DynamicImport.tsx
@@ -35,8 +35,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
+import * as React from 'react';
 
 interface IDynamicImport {
   /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/src/app/ErrorView/ErrorView.tsx
+++ b/src/app/ErrorView/ErrorView.tsx
@@ -51,7 +51,7 @@ export interface ErrorViewProps {
   retry?: () => void;
 }
 
-export const ErrorView: React.FunctionComponent<ErrorViewProps> = (props) => {
+export const ErrorView: React.FC<ErrorViewProps> = (props) => {
   return (
     <>
       <EmptyState>

--- a/src/app/ErrorView/ErrorView.tsx
+++ b/src/app/ErrorView/ErrorView.tsx
@@ -35,18 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import {
-  Button,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  Title,
-  Text,
-  StackItem,
-  Stack,
-} from '@patternfly/react-core';
+import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, Title, StackItem, Stack } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 
 export const authFailMessage = 'Auth failure';
 

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -35,10 +35,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
+import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
+import { LoadingView } from '@app/LoadingView/LoadingView';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { hashCode } from '@app/utils/utils';
 import {
   Toolbar,
   ToolbarContent,
@@ -51,12 +53,10 @@ import {
   Title,
   Text,
 } from '@patternfly/react-core';
-import { ExpandableRowContent, TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { concatMap, filter, first } from 'rxjs/operators';
-import { LoadingView } from '@app/LoadingView/LoadingView';
-import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
 import { SearchIcon } from '@patternfly/react-icons';
-import { hashCode } from '@app/utils/utils';
+import { ExpandableRowContent, TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import * as React from 'react';
+import { concatMap, filter, first } from 'rxjs/operators';
 
 export interface EventType {
   name: string;
@@ -87,7 +87,7 @@ const includesSubstr = (a: string, b: string) => !!a && !!b && a.toLowerCase().i
 
 export interface EventTypesProps {}
 
-export const EventTypes: React.FunctionComponent<EventTypesProps> = (props) => {
+export const EventTypes: React.FunctionComponent<EventTypesProps> = (_) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const prevPerPage = React.useRef(10);
@@ -100,7 +100,7 @@ export const EventTypes: React.FunctionComponent<EventTypesProps> = (props) => {
   const [isLoading, setIsLoading] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState('');
 
-  const tableColumns = ['', 'Name', 'Type ID', 'Description', 'Categories'];
+  const tableColumns = React.useMemo(() => ['', 'Name', 'Type ID', 'Description', 'Categories'], []);
 
   const handleTypes = React.useCallback(
     (types) => {
@@ -136,7 +136,7 @@ export const EventTypes: React.FunctionComponent<EventTypesProps> = (props) => {
           error: handleError,
         })
     );
-  }, [addSubscription, context.target, context.api]);
+  }, [addSubscription, context.target, context.api, handleTypes, handleError]);
 
   React.useEffect(() => {
     addSubscription(
@@ -149,7 +149,7 @@ export const EventTypes: React.FunctionComponent<EventTypesProps> = (props) => {
 
   React.useEffect(() => {
     addSubscription(context.target.authFailure().subscribe(() => setErrorMessage(authFailMessage)));
-  }, [context.target]);
+  }, [addSubscription, context.target]);
 
   const filterTypesByText = React.useMemo(() => {
     if (!filterText) {
@@ -169,7 +169,7 @@ export const EventTypes: React.FunctionComponent<EventTypesProps> = (props) => {
     const visibleTypes = filterTypesByText.slice(offset, offset + perPage);
 
     const rows: RowData[] = [];
-    visibleTypes.forEach((t: EventType, idx: number) => {
+    visibleTypes.forEach((t: EventType) => {
       let child = '';
       for (const opt in t.options) {
         child += `${opt}=[${t.options[opt].defaultValue}]\t`;
@@ -203,7 +203,7 @@ export const EventTypes: React.FunctionComponent<EventTypesProps> = (props) => {
   );
 
   const onToggle = React.useCallback(
-    (t: EventType, index: number) => {
+    (t: EventType, _index: number) => {
       setOpenRows((old) => {
         const typeId = hashCode(t.typeId);
         if (old.some((id) => id === typeId)) {
@@ -225,7 +225,7 @@ export const EventTypes: React.FunctionComponent<EventTypesProps> = (props) => {
 
   const authRetry = React.useCallback(() => {
     context.target.setAuthRetry();
-  }, [context.target, context.target.setAuthRetry]);
+  }, [context.target]);
 
   const typeRowPairs = React.useMemo(() => {
     return displayedTypeRowData.map((rowData: RowData, index) => (

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -237,7 +237,7 @@ export const EventTypes: React.FC<EventTypesProps> = (_) => {
               rowIndex: index,
               isExpanded: rowData.isExpanded,
               expandId: `expandable-event-type-row-${index}`,
-              onToggle: () => onToggle(rowData.eventType, index),
+              onToggle: () => onToggle(rowData.eventType),
             }}
           />
           {rowData.cellContents.map((content, idx) => (

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -87,7 +87,7 @@ const includesSubstr = (a: string, b: string) => !!a && !!b && a.toLowerCase().i
 
 export interface EventTypesProps {}
 
-export const EventTypes: React.FunctionComponent<EventTypesProps> = (_) => {
+export const EventTypes: React.FC<EventTypesProps> = (_) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const prevPerPage = React.useRef(10);
@@ -203,7 +203,7 @@ export const EventTypes: React.FunctionComponent<EventTypesProps> = (_) => {
   );
 
   const onToggle = React.useCallback(
-    (t: EventType, _index: number) => {
+    (t: EventType) => {
       setOpenRows((old) => {
         const typeId = hashCode(t.typeId);
         if (old.some((id) => id === typeId)) {

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -35,21 +35,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { TargetView } from '@app/TargetView/TargetView';
-import { Card, CardBody, Stack, StackItem, Tab, Tabs, Tooltip } from '@patternfly/react-core';
-import { EventTemplates } from './EventTemplates';
-import { AgentProbeTemplates } from '@app/Agent/AgentProbeTemplates';
 import { AgentLiveProbes } from '@app/Agent/AgentLiveProbes';
-import { EventTypes } from './EventTypes';
-import { concatMap, filter } from 'rxjs';
+import { AgentProbeTemplates } from '@app/Agent/AgentProbeTemplates';
+import { ServiceContext } from '@app/Shared/Services/Services';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
+import { TargetView } from '@app/TargetView/TargetView';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { Card, CardBody, Stack, StackItem, Tab, Tabs, Tooltip } from '@patternfly/react-core';
+import * as React from 'react';
+import { concatMap, filter } from 'rxjs';
+import { EventTemplates } from './EventTemplates';
+import { EventTypes } from './EventTypes';
 
 export interface EventsProps {}
 
-export const Events: React.FunctionComponent<EventsProps> = (props) => {
+export const Events: React.FunctionComponent<EventsProps> = (_) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [eventActiveTab, setEventActiveTab] = React.useState(0);

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -49,7 +49,7 @@ import { EventTypes } from './EventTypes';
 
 export interface EventsProps {}
 
-export const Events: React.FunctionComponent<EventsProps> = (_) => {
+export const Events: React.FC<EventsProps> = (_) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [eventActiveTab, setEventActiveTab] = React.useState(0);

--- a/src/app/LoadingView/LoadingView.tsx
+++ b/src/app/LoadingView/LoadingView.tsx
@@ -35,8 +35,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { Bullseye, EmptyState, EmptyStateIcon, Spinner, Title } from '@patternfly/react-core';
+import * as React from 'react';
 
 export interface LoadingViewProps {
   title?: string;
@@ -56,5 +56,3 @@ export const LoadingView: React.FunctionComponent<LoadingViewProps> = (props) =>
     </>
   );
 };
-
-export default LoadingView;

--- a/src/app/LoadingView/LoadingView.tsx
+++ b/src/app/LoadingView/LoadingView.tsx
@@ -42,7 +42,7 @@ export interface LoadingViewProps {
   title?: string;
 }
 
-export const LoadingView: React.FunctionComponent<LoadingViewProps> = (props) => {
+export const LoadingView: React.FC<LoadingViewProps> = (props) => {
   return (
     <>
       <Bullseye>

--- a/src/app/Login/BasicAuthForm.tsx
+++ b/src/app/Login/BasicAuthForm.tsx
@@ -43,7 +43,7 @@ import * as React from 'react';
 import { map } from 'rxjs/operators';
 import { FormProps } from './FormProps';
 
-export const BasicAuthForm: React.FunctionComponent<FormProps> = ({ onSubmit }) => {
+export const BasicAuthForm: React.FC<FormProps> = ({ onSubmit }) => {
   const context = React.useContext(ServiceContext);
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');

--- a/src/app/Login/BasicAuthForm.tsx
+++ b/src/app/Login/BasicAuthForm.tsx
@@ -35,15 +35,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
+import { AuthMethod } from '@app/Shared/Services/Login.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { ActionGroup, Button, Checkbox, Form, FormGroup, Text, TextInput, TextVariants } from '@patternfly/react-core';
+import { Base64 } from 'js-base64';
+import * as React from 'react';
 import { map } from 'rxjs/operators';
 import { FormProps } from './FormProps';
-import { Base64 } from 'js-base64';
-import { AuthMethod } from '@app/Shared/Services/Login.service';
 
-export const BasicAuthForm: React.FunctionComponent<FormProps> = (props) => {
+export const BasicAuthForm: React.FunctionComponent<FormProps> = ({ onSubmit }) => {
   const context = React.useContext(ServiceContext);
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');
@@ -58,7 +58,7 @@ export const BasicAuthForm: React.FunctionComponent<FormProps> = (props) => {
           setUsername(creds);
           return;
         }
-        let parts: string[] = creds.split(':');
+        const parts: string[] = creds.split(':');
         setUsername(parts[0]);
         setPassword(parts[1]);
       });
@@ -88,9 +88,9 @@ export const BasicAuthForm: React.FunctionComponent<FormProps> = (props) => {
 
   const handleSubmit = React.useCallback(
     (evt) => {
-      props.onSubmit(evt, `${username}:${password}`, AuthMethod.BASIC, rememberMe);
+      onSubmit(evt, `${username}:${password}`, AuthMethod.BASIC, rememberMe);
     },
-    [props, props.onSubmit, username, password, context.login, rememberMe]
+    [onSubmit, username, password, rememberMe]
   );
 
   // FIXME Patternfly Form component onSubmit is not triggered by Enter keydown when the Form contains

--- a/src/app/Login/ConnectionError.tsx
+++ b/src/app/Login/ConnectionError.tsx
@@ -35,9 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 
 export const ConnectionError = () => (
   <EmptyState>

--- a/src/app/Login/Login.tsx
+++ b/src/app/Login/Login.tsx
@@ -48,7 +48,7 @@ import { OpenShiftAuthDescriptionText, OpenShiftPlaceholderAuthForm } from './Op
 
 export interface LoginProps {}
 
-export const Login: React.FunctionComponent<LoginProps> = (_) => {
+export const Login: React.FC<LoginProps> = (_) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const notifications = React.useContext(NotificationsContext);

--- a/src/app/Login/NoopAuthForm.tsx
+++ b/src/app/Login/NoopAuthForm.tsx
@@ -39,7 +39,7 @@ import { AuthMethod } from '@app/Shared/Services/Login.service';
 import * as React from 'react';
 import { FormProps } from './FormProps';
 
-export const NoopAuthForm: React.FunctionComponent<FormProps> = ({ onSubmit }) => {
+export const NoopAuthForm: React.FC<FormProps> = ({ onSubmit }) => {
   React.useEffect(() => {
     const noopEvt = {
       preventDefault: () => undefined,

--- a/src/app/Login/NoopAuthForm.tsx
+++ b/src/app/Login/NoopAuthForm.tsx
@@ -39,14 +39,14 @@ import { AuthMethod } from '@app/Shared/Services/Login.service';
 import * as React from 'react';
 import { FormProps } from './FormProps';
 
-export const NoopAuthForm: React.FunctionComponent<FormProps> = (props) => {
+export const NoopAuthForm: React.FunctionComponent<FormProps> = ({ onSubmit }) => {
   React.useEffect(() => {
     const noopEvt = {
-      preventDefault: () => {},
+      preventDefault: () => undefined,
     } as Event;
 
-    props.onSubmit(noopEvt, '', AuthMethod.NONE, false);
-  }, [props.onSubmit]);
+    onSubmit(noopEvt, '', AuthMethod.NONE, false);
+  }, [onSubmit]);
 
   return <></>;
 };

--- a/src/app/Login/OpenShiftPlaceholderAuthForm.tsx
+++ b/src/app/Login/OpenShiftPlaceholderAuthForm.tsx
@@ -38,6 +38,7 @@
 import { NotificationsContext } from '@app/Notifications/Notifications';
 import { AuthMethod, SessionState } from '@app/Shared/Services/Login.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, Text, TextVariants, Title } from '@patternfly/react-core';
 import { LockIcon } from '@patternfly/react-icons';
 import * as React from 'react';
@@ -48,19 +49,18 @@ export const OpenShiftPlaceholderAuthForm: React.FunctionComponent<FormProps> = 
   const context = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const [showPermissionDenied, setShowPermissionDenied] = React.useState(false);
+  const addSubscription = useSubscriptions();
 
   React.useEffect(() => {
-    const sub = combineLatest([context.login.getSessionState(), notifications.problemsNotifications()]).subscribe(
-      (parts) => {
+    addSubscription(
+      combineLatest([context.login.getSessionState(), notifications.problemsNotifications()]).subscribe((parts) => {
         const sessionState = parts[0];
         const errors = parts[1];
         const missingCryostatPermissions = errors.find((error) => error.title.includes('401')) !== undefined;
-
         setShowPermissionDenied(sessionState === SessionState.NO_USER_SESSION && missingCryostatPermissions);
-      }
+      })
     );
-    return () => sub.unsubscribe();
-  }, [notifications, context.login, setShowPermissionDenied]);
+  }, [addSubscription, notifications, context.login, setShowPermissionDenied]);
 
   const handleSubmit = React.useCallback(
     (evt) => {

--- a/src/app/Login/OpenShiftPlaceholderAuthForm.tsx
+++ b/src/app/Login/OpenShiftPlaceholderAuthForm.tsx
@@ -35,40 +35,39 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, Text, TextVariants, Title } from '@patternfly/react-core';
-import { FormProps } from './FormProps';
-import { LockIcon } from '@patternfly/react-icons';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { AuthMethod, SessionState } from '@app/Shared/Services/Login.service';
 import { NotificationsContext } from '@app/Notifications/Notifications';
+import { AuthMethod, SessionState } from '@app/Shared/Services/Login.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, Text, TextVariants, Title } from '@patternfly/react-core';
+import { LockIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import { combineLatest } from 'rxjs';
+import { FormProps } from './FormProps';
 
-export const OpenShiftPlaceholderAuthForm: React.FunctionComponent<FormProps> = (props) => {
-  const serviceContext = React.useContext(ServiceContext);
+export const OpenShiftPlaceholderAuthForm: React.FunctionComponent<FormProps> = ({ onSubmit }) => {
+  const context = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const [showPermissionDenied, setShowPermissionDenied] = React.useState(false);
 
   React.useEffect(() => {
-    const sub = combineLatest([
-      serviceContext.login.getSessionState(),
-      notifications.problemsNotifications(),
-    ]).subscribe((parts) => {
-      const sessionState = parts[0];
-      const errors = parts[1];
-      const missingCryostatPermissions = errors.find((error) => error.title.includes('401')) !== undefined;
+    const sub = combineLatest([context.login.getSessionState(), notifications.problemsNotifications()]).subscribe(
+      (parts) => {
+        const sessionState = parts[0];
+        const errors = parts[1];
+        const missingCryostatPermissions = errors.find((error) => error.title.includes('401')) !== undefined;
 
-      setShowPermissionDenied(sessionState === SessionState.NO_USER_SESSION && missingCryostatPermissions);
-    });
+        setShowPermissionDenied(sessionState === SessionState.NO_USER_SESSION && missingCryostatPermissions);
+      }
+    );
     return () => sub.unsubscribe();
-  }, [setShowPermissionDenied]);
+  }, [notifications, context.login, setShowPermissionDenied]);
 
   const handleSubmit = React.useCallback(
     (evt) => {
       // Triggers a redirect to OpenShift Container Platform login page
-      props.onSubmit(evt, 'anInvalidToken', AuthMethod.BEARER, true);
+      onSubmit(evt, 'anInvalidToken', AuthMethod.BEARER, true);
     },
-    [props, props.onSubmit, serviceContext.login]
+    [onSubmit]
   );
 
   const permissionDenied = (

--- a/src/app/Modal/CancelUploadModal.tsx
+++ b/src/app/Modal/CancelUploadModal.tsx
@@ -36,8 +36,8 @@
  * SOFTWARE.
  */
 
-import * as React from 'react';
 import { Button, Modal } from '@patternfly/react-core';
+import * as React from 'react';
 
 export interface CancelUploadModalProps {
   visible: boolean;

--- a/src/app/Modal/DeleteWarningModal.tsx
+++ b/src/app/Modal/DeleteWarningModal.tsx
@@ -35,11 +35,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { Modal, ModalVariant, Button, Checkbox, Stack, Split } from '@patternfly/react-core';
-import { DeleteOrDisableWarningType, getFromWarningMap } from './DeleteWarningUtils';
-import { useState } from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { Modal, ModalVariant, Button, Checkbox, Stack, Split } from '@patternfly/react-core';
+import * as React from 'react';
+import { useState } from 'react';
+import { DeleteOrDisableWarningType, getFromWarningMap } from './DeleteWarningUtils';
 
 export interface DeleteWarningProps {
   warningType: DeleteOrDisableWarningType;
@@ -48,11 +48,11 @@ export interface DeleteWarningProps {
   onClose: () => void;
 }
 
-export const DeleteWarningModal = ({ warningType, visible, onAccept, onClose }: DeleteWarningProps): JSX.Element => {
+export const DeleteWarningModal = ({ onAccept, onClose, ...props }: DeleteWarningProps): JSX.Element => {
   const context = React.useContext(ServiceContext);
   const [doNotAsk, setDoNotAsk] = useState(false);
 
-  const realWarningType = getFromWarningMap(warningType);
+  const realWarningType = getFromWarningMap(props.warningType);
 
   const onAcceptClose = React.useCallback(() => {
     onAccept();
@@ -60,7 +60,7 @@ export const DeleteWarningModal = ({ warningType, visible, onAccept, onClose }: 
     if (doNotAsk && !!realWarningType) {
       context.settings.setDeletionDialogsEnabledFor(realWarningType.id, false);
     }
-  }, [onAccept, onClose, doNotAsk, context, context.settings]);
+  }, [context.settings, onAccept, onClose, doNotAsk, realWarningType]);
 
   return (
     <Modal
@@ -69,7 +69,7 @@ export const DeleteWarningModal = ({ warningType, visible, onAccept, onClose }: 
       aria-label={realWarningType?.ariaLabel}
       titleIconVariant="warning"
       variant={ModalVariant.medium}
-      isOpen={visible}
+      isOpen={props.visible}
       showClose
       onClose={onClose}
       actions={[

--- a/src/app/NotFound/NotFound.tsx
+++ b/src/app/NotFound/NotFound.tsx
@@ -35,9 +35,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { Link } from 'react-router-dom';
-import { NotFoundCard } from './NotFoundCard';
+import '@app/app.css';
+import { IAppRoute, routes, flatten } from '@app/routes';
 import {
   Button,
   EmptyState,
@@ -46,18 +45,20 @@ import {
   EmptyStateSecondaryActions,
   Title,
 } from '@patternfly/react-core';
-import '@app/app.css';
 import { MapMarkedAltIcon } from '@patternfly/react-icons';
-import { IAppRoute, routes, flatten } from '@app/routes';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { NotFoundCard } from './NotFoundCard';
 
 export interface NotFoundProps {}
 
-export const NotFound: React.FunctionComponent<NotFoundProps> = (props) => {
+export const NotFound: React.FunctionComponent<NotFoundProps> = (_) => {
   const cards = flatten(routes)
     .filter((route: IAppRoute): boolean => !!route.description)
     .sort((a: IAppRoute, b: IAppRoute): number => a.title.localeCompare(b.title))
     .map((route: IAppRoute) => (
       <NotFoundCard
+        key={route.title}
         title={route.title}
         bodyText={route.description}
         linkText={`View ${route.title.toLocaleLowerCase()}`}
@@ -70,9 +71,9 @@ export const NotFound: React.FunctionComponent<NotFoundProps> = (props) => {
       <EmptyState className="pf-c-empty-state-not-found">
         <EmptyStateIcon icon={MapMarkedAltIcon} />
         <Title headingLevel="h4" size="lg">
-          404: We couldn't find that page
+          404: We couldn&apos;t find that page
         </Title>
-        <EmptyStateBody>One of the following pages might have what you're looking for.</EmptyStateBody>
+        <EmptyStateBody>One of the following pages might have what you&apos;re looking for.</EmptyStateBody>
         <EmptyStateSecondaryActions>{cards}</EmptyStateSecondaryActions>
         <Button variant="primary" component={(props) => <Link {...props} to="/" />}>
           Take me home

--- a/src/app/NotFound/NotFoundCard.tsx
+++ b/src/app/NotFound/NotFoundCard.tsx
@@ -36,9 +36,9 @@
  * SOFTWARE.
  */
 
+import { Card, CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Card, CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
 
 export const NotFoundCard = ({ title, bodyText, linkText, linkPath }) => {
   return (

--- a/src/app/Notifications/NotificationCenter.tsx
+++ b/src/app/Notifications/NotificationCenter.tsx
@@ -35,7 +35,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import {
   Dropdown,
   DropdownItem,
@@ -53,8 +52,9 @@ import {
   Text,
   TextVariants,
 } from '@patternfly/react-core';
-import { Notification, NotificationsContext } from './Notifications';
+import * as React from 'react';
 import { combineLatest } from 'rxjs';
+import { Notification, NotificationsContext } from './Notifications';
 
 export interface NotificationCenterProps {
   onClose: () => void;
@@ -134,21 +134,21 @@ export const NotificationCenter: React.FunctionComponent<NotificationCenterProps
         return category;
       });
     });
-  }, [setDrawerCategories, drawerCategories[PROBLEMS_CATEGORY_IDX].unreadCount]);
+  }, [setDrawerCategories, drawerCategories]);
 
   const handleMarkAllRead = React.useCallback(() => {
     context.markAllRead();
-  }, [context, context.markAllRead]);
+  }, [context]);
 
   const handleClearAll = React.useCallback(() => {
     context.clearAll();
-  }, [context, context.clearAll]);
+  }, [context]);
 
   const markRead = React.useCallback(
     (key?: string) => {
       context.setRead(key);
     },
-    [context, context.setRead]
+    [context]
   );
 
   const timestampToDateTimeString = (timestamp?: number): string => {

--- a/src/app/Notifications/Notifications.tsx
+++ b/src/app/Notifications/Notifications.tsx
@@ -35,12 +35,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
+import { AlertVariant } from '@patternfly/react-core';
+import { nanoid } from 'nanoid';
 import * as React from 'react';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { concatMap, filter, first, map } from 'rxjs/operators';
-import { AlertVariant } from '@patternfly/react-core';
-import { nanoid } from 'nanoid';
-import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 
 export interface Notification {
   hidden?: boolean;
@@ -143,12 +143,12 @@ export class Notifications {
     return this.notifications().pipe(map((a) => a.filter(Notifications.isProblemNotification)));
   }
 
-  setHidden(key?: string, hidden: boolean = true): void {
+  setHidden(key?: string, hidden = true): void {
     if (!key) {
       return;
     }
     this._notifications$.pipe(first()).subscribe((prev) => {
-      for (let n of prev) {
+      for (const n of prev) {
         if (n.key === key) {
           n.hidden = hidden;
         }
@@ -157,12 +157,12 @@ export class Notifications {
     });
   }
 
-  setRead(key?: string, read: boolean = true): void {
+  setRead(key?: string, read = true): void {
     if (!key) {
       return;
     }
     this._notifications$.pipe(first()).subscribe((prev) => {
-      for (let n of prev) {
+      for (const n of prev) {
         if (n.key === key) {
           n.read = read;
         }
@@ -173,7 +173,7 @@ export class Notifications {
 
   markAllRead(): void {
     this._notifications$.pipe(first()).subscribe((prev) => {
-      for (let n of prev) {
+      for (const n of prev) {
         n.read = true;
       }
       this._notifications$.next(prev);

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -164,6 +164,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
     [recordings, getIdxFromRecording, props.checkedIndices]
   );
 
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   const refreshRecordingList = React.useCallback(() => {
     let observable: Observable<Recording[]>;
     if (props.directoryRecordings) {
@@ -179,7 +180,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
     } else {
       observable = props.isUploadsTable
         ? context.api
-            .graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
+            .graphql<any>(
               `query GetUploadedRecordings($filter: ArchivedRecordingFilterInput) {
                 archivedRecordings(filter: $filter) {
                   data {
@@ -201,7 +202,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
         : context.target.target().pipe(
             filter((target) => target !== NO_TARGET),
             concatMap((target) =>
-              context.api.graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
+              context.api.graphql<any>(
                 `query ActiveRecordingsForTarget($connectUrl: String) {
                 targetNodes(filter: { name: $connectUrl }) {
                   recordings {
@@ -236,6 +237,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
     context.api,
     setRecordings,
   ]);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
 
   const saveButtonLoadingProps = React.useMemo(
     () =>

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -35,10 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { Button, Split, SplitItem, Stack, StackItem, Text, Tooltip, ValidatedOptions } from '@patternfly/react-core';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { uploadAsTarget } from '@app/Archives/Archives';
+import { LabelCell } from '@app/RecordingMetadata/LabelCell';
+import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 import {
   ActiveRecording,
   ArchivedRecording,
@@ -46,16 +45,17 @@ import {
   RecordingDirectory,
   UPLOADS_SUBDIRECTORY,
 } from '@app/Shared/Services/Api.service';
-import { includesLabel, parseLabels, RecordingLabel } from './RecordingLabel';
-import { combineLatest, concatMap, filter, first, forkJoin, map, merge, Observable, of } from 'rxjs';
-import { LabelCell } from '@app/RecordingMetadata/LabelCell';
-import { RecordingLabelFields } from './RecordingLabelFields';
-import { HelpIcon } from '@patternfly/react-icons';
-import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { NO_TARGET } from '@app/Shared/Services/Target.service';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { hashCode } from '@app/utils/utils';
-import { uploadAsTarget } from '@app/Archives/Archives';
-import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
+import { Button, Split, SplitItem, Stack, StackItem, Text, Tooltip, ValidatedOptions } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+import { combineLatest, concatMap, filter, first, forkJoin, map, Observable, of } from 'rxjs';
+import { includesLabel, parseLabels, RecordingLabel } from './RecordingLabel';
+import { RecordingLabelFields } from './RecordingLabelFields';
 
 export interface BulkEditLabelsProps {
   isTargetRecording: boolean;
@@ -77,7 +77,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
 
   const getIdxFromRecording = React.useCallback(
     (r: Recording): number => (props.isTargetRecording ? (r as ActiveRecording).id : hashCode(r.name)),
-    [hashCode, props.isTargetRecording]
+    [props.isTargetRecording]
   );
 
   const handlePostUpdate = React.useCallback(() => {
@@ -87,7 +87,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
 
   const handleUpdateLabels = React.useCallback(() => {
     setLoading(true);
-    const tasks: Observable<any>[] = [];
+    const tasks: Observable<unknown>[] = [];
     const toDelete = savedCommonLabels.filter((label) => !includesLabel(commonLabels, label));
 
     recordings.forEach((r: Recording) => {
@@ -119,18 +119,16 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
     );
   }, [
     addSubscription,
+    context.api,
+    getIdxFromRecording,
+    handlePostUpdate,
+    commonLabels,
+    savedCommonLabels,
     recordings,
     props.checkedIndices,
     props.isTargetRecording,
     props.isUploadsTable,
     props.directory,
-    props.directoryRecordings,
-    editing,
-    commonLabels,
-    savedCommonLabels,
-    parseLabels,
-    context.api,
-    handlePostUpdate,
   ]);
 
   const handleEditLabels = React.useCallback(() => {
@@ -144,7 +142,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
 
   const updateCommonLabels = React.useCallback(
     (setLabels: (l: RecordingLabel[]) => void) => {
-      let allRecordingLabels = [] as RecordingLabel[][];
+      const allRecordingLabels = [] as RecordingLabel[][];
 
       recordings.forEach((r: Recording) => {
         const idx = getIdxFromRecording(r);
@@ -163,7 +161,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
 
       setLabels(updatedCommonLabels);
     },
-    [recordings, props.checkedIndices]
+    [recordings, getIdxFromRecording, props.checkedIndices]
   );
 
   const refreshRecordingList = React.useCallback(() => {
@@ -234,7 +232,6 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
     props.isTargetRecording,
     props.isUploadsTable,
     props.directoryRecordings,
-    context,
     context.target,
     context.api,
     setRecordings,
@@ -274,7 +271,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
         );
       })
     );
-  }, [addSubscription, context.notificationChannel, setRecordings]);
+  }, [addSubscription, context.target, context.notificationChannel, setRecordings, props.isUploadsTable]);
 
   React.useEffect(() => {
     updateCommonLabels(setCommonLabels);
@@ -283,7 +280,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
     if (!recordings.length && editing) {
       setEditing(false);
     }
-  }, [recordings, setCommonLabels, setSavedCommonLabels, updateCommonLabels, setEditing]);
+  }, [editing, recordings, setCommonLabels, setSavedCommonLabels, updateCommonLabels, setEditing]);
 
   React.useEffect(() => {
     if (!props.checkedIndices.length) {

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -179,7 +179,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
     } else {
       observable = props.isUploadsTable
         ? context.api
-            .graphql<any>(
+            .graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
               `query GetUploadedRecordings($filter: ArchivedRecordingFilterInput) {
                 archivedRecordings(filter: $filter) {
                   data {
@@ -201,7 +201,7 @@ export const BulkEditLabels: React.FunctionComponent<BulkEditLabelsProps> = (pro
         : context.target.target().pipe(
             filter((target) => target !== NO_TARGET),
             concatMap((target) =>
-              context.api.graphql<any>(
+              context.api.graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
                 `query ActiveRecordingsForTarget($connectUrl: String) {
                 targetNodes(filter: { name: $connectUrl }) {
                   recordings {

--- a/src/app/RecordingMetadata/ClickableLabel.tsx
+++ b/src/app/RecordingMetadata/ClickableLabel.tsx
@@ -36,7 +36,6 @@
  * SOFTWARE.
  */
 
-import { getLabelDisplay } from '@app/Recordings/Filters/LabelFilter';
 import { Label } from '@patternfly/react-core';
 import React from 'react';
 import { RecordingLabel } from './RecordingLabel';
@@ -47,7 +46,7 @@ export interface ClickableLabelCellProps {
   onLabelClick: (label: RecordingLabel) => void;
 }
 
-export const ClickableLabel: React.FunctionComponent<ClickableLabelCellProps> = (props) => {
+export const ClickableLabel: React.FunctionComponent<ClickableLabelCellProps> = ({ onLabelClick, ...props }) => {
   const [isHoveredOrFocused, setIsHoveredOrFocused] = React.useState(false);
   const labelColor = React.useMemo(() => (props.isSelected ? 'blue' : 'grey'), [props.isSelected]);
 
@@ -65,10 +64,7 @@ export const ClickableLabel: React.FunctionComponent<ClickableLabelCellProps> = 
     return {};
   }, [props.isSelected, isHoveredOrFocused]);
 
-  const handleLabelClicked = React.useCallback(
-    () => props.onLabelClick(props.label),
-    [props.label, props.onLabelClick, getLabelDisplay]
-  );
+  const handleLabelClicked = React.useCallback(() => onLabelClick(props.label), [props.label, onLabelClick]);
 
   return (
     <>

--- a/src/app/RecordingMetadata/LabelCell.tsx
+++ b/src/app/RecordingMetadata/LabelCell.tsx
@@ -62,7 +62,7 @@ export const LabelCell: React.FunctionComponent<LabelCellProps> = (props) => {
       }
       return false;
     },
-    [getLabelDisplay, props.clickableOptions]
+    [props.clickableOptions]
   );
 
   const getLabelColor = React.useCallback(
@@ -79,7 +79,7 @@ export const LabelCell: React.FunctionComponent<LabelCellProps> = (props) => {
         });
       }
     },
-    [props.clickableOptions, props.target, getLabelDisplay]
+    [isLabelSelected, props.clickableOptions, props.target]
   );
 
   return (

--- a/src/app/RecordingMetadata/RecordingLabel.tsx
+++ b/src/app/RecordingMetadata/RecordingLabel.tsx
@@ -43,7 +43,7 @@ export interface RecordingLabel {
   value: string;
 }
 
-export const parseLabels = (jsonLabels: Object) => {
+export const parseLabels = (jsonLabels: object) => {
   if (!jsonLabels) return [];
 
   return Object.entries(jsonLabels).map(([k, v]) => {

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -36,7 +36,21 @@
  * SOFTWARE.
  */
 
+import { authFailMessage } from '@app/ErrorView/ErrorView';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { parseLabels } from '@app/RecordingMetadata/RecordingLabel';
+import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
+import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
+import { emptyActiveRecordingFilters, TargetRecordingFilters } from '@app/Shared/Redux/Filters/RecordingFilterSlice';
+import {
+  recordingAddFilterIntent,
+  recordingDeleteFilterIntent,
+  recordingAddTargetIntent,
+  recordingDeleteCategoryFiltersIntent,
+  recordingDeleteAllFiltersIntent,
+  RootState,
+  StateDispatch,
+} from '@app/Shared/Redux/ReduxStore';
 import { ActiveRecording, RecordingState } from '@app/Shared/Services/Api.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
@@ -56,31 +70,17 @@ import {
 } from '@patternfly/react-core';
 import { Tbody, Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
 import * as React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import { combineLatest, forkJoin, merge, Observable } from 'rxjs';
 import { concatMap, filter, first } from 'rxjs/operators';
+import { DeleteWarningModal } from '../Modal/DeleteWarningModal';
 import { LabelCell } from '../RecordingMetadata/LabelCell';
 import { RecordingActions } from './RecordingActions';
-import { RecordingLabelsPanel } from './RecordingLabelsPanel';
 import { filterRecordings, RecordingFilters, RecordingFiltersCategories } from './RecordingFilters';
+import { RecordingLabelsPanel } from './RecordingLabelsPanel';
 import { RecordingsTable } from './RecordingsTable';
 import { ReportFrame } from './ReportFrame';
-import { DeleteWarningModal } from '../Modal/DeleteWarningModal';
-import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
-import { useDispatch, useSelector } from 'react-redux';
-import {
-  recordingAddFilterIntent,
-  recordingDeleteFilterIntent,
-  recordingAddTargetIntent,
-  recordingDeleteCategoryFiltersIntent,
-  recordingDeleteAllFiltersIntent,
-  RootState,
-  StateDispatch,
-} from '@app/Shared/Redux/ReduxStore';
-import { emptyActiveRecordingFilters, TargetRecordingFilters } from '@app/Shared/Redux/Filters/RecordingFilterSlice';
-import { authFailMessage } from '@app/ErrorView/ErrorView';
-import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
-import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 
 export enum PanelContent {
   LABELS,
@@ -143,7 +143,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
 
   const handleCreateRecording = React.useCallback(() => {
     routerHistory.push(`${url}/create`);
-  }, [routerHistory]);
+  }, [routerHistory, url]);
 
   const handleEditLabels = React.useCallback(() => {
     setShowDetailsPanel(true);
@@ -185,7 +185,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
           error: handleError,
         })
     );
-  }, [addSubscription, context, context.target, context.api, setIsLoading, handleRecordings, handleError]);
+  }, [addSubscription, context.target, context.api, setIsLoading, handleRecordings, handleError]);
 
   React.useEffect(() => {
     addSubscription(
@@ -195,15 +195,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
         refreshRecordingList();
       })
     );
-  }, [
-    addSubscription,
-    context,
-    context.target,
-    refreshRecordingList,
-    setTargetConnectURL,
-    dispatch,
-    recordingAddTargetIntent,
-  ]);
+  }, [addSubscription, context, context.target, refreshRecordingList, setTargetConnectURL, dispatch]);
 
   React.useEffect(() => {
     addSubscription(
@@ -300,7 +292,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
 
   React.useEffect(() => {
     setFilteredRecordings(filterRecordings(recordings, targetRecordingFilters));
-  }, [recordings, targetRecordingFilters, setFilteredRecordings, filterRecordings]);
+  }, [recordings, targetRecordingFilters, setFilteredRecordings]);
 
   React.useEffect(() => {
     setCheckedIndices((ci) => {
@@ -311,7 +303,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
 
   React.useEffect(() => {
     setHeaderChecked(checkedIndices.length === filteredRecordings.length);
-  }, [setHeaderChecked, checkedIndices]);
+  }, [setHeaderChecked, checkedIndices, filteredRecordings.length]);
 
   React.useEffect(() => {
     if (!context.settings.autoRefreshEnabled()) {
@@ -389,7 +381,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
 
   const handleDeleteRecordings = React.useCallback(() => {
     setActionLoadings((old) => ({ ...old, DELETE: true }));
-    const tasks: Observable<{}>[] = [];
+    const tasks: Observable<boolean>[] = [];
     filteredRecordings.forEach((r: ActiveRecording) => {
       if (checkedIndices.includes(r.id)) {
         context.reports.delete(r);
@@ -414,7 +406,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
 
   const handleClearFilters = React.useCallback(() => {
     dispatch(recordingDeleteAllFiltersIntent(targetConnectURL, false));
-  }, [dispatch, recordingDeleteAllFiltersIntent, targetConnectURL]);
+  }, [dispatch, targetConnectURL]);
 
   const updateFilters = React.useCallback(
     (target, { filterValue, filterKey, deleted = false, deleteOptions }: UpdateFilterOptions) => {
@@ -428,7 +420,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
         dispatch(recordingAddFilterIntent(target, filterKey, filterValue, false));
       }
     },
-    [dispatch, recordingDeleteCategoryFiltersIntent, recordingDeleteFilterIntent, recordingAddFilterIntent]
+    [dispatch]
   );
 
   const RecordingRow = (props) => {
@@ -441,17 +433,17 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
       [props.recording.name, props.recording.startTime]
     );
 
-    const handleToggle = React.useCallback(() => toggleExpanded(expandedRowId), [toggleExpanded]);
+    const handleToggle = React.useCallback(() => toggleExpanded(expandedRowId), [expandedRowId]);
 
     const isExpanded = React.useMemo(() => {
       return expandedRows.includes(expandedRowId);
-    }, [expandedRows, expandedRowId]);
+    }, [expandedRowId]);
 
     const handleCheck = React.useCallback(
       (checked) => {
         handleRowCheck(checked, props.index);
       },
-      [handleRowCheck, props.index]
+      [props.index]
     );
 
     const parentRow = React.useMemo(() => {
@@ -517,28 +509,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
           />
         </Tr>
       );
-    }, [
-      props.duration,
-      props.index,
-      props.recording,
-      props.recording.duration,
-      props.recording.name,
-      props.recording.startTime,
-      props.recording.state,
-      props.timeStr,
-      props.recording.metadata.labels,
-      props.labelFilters,
-      context.api,
-      context.api.uploadActiveRecordingToGrafana,
-      checkedIndices,
-      handleCheck,
-      handleToggle,
-      updateFilters,
-      isExpanded,
-      tableColumns,
-      parsedLabels,
-      targetConnectURL,
-    ]);
+    }, [props.index, props.recording, props.labelFilters, handleCheck, handleToggle, isExpanded, parsedLabels]);
 
     const childRow = React.useMemo(() => {
       return (
@@ -559,17 +530,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
           </Td>
         </Tr>
       );
-    }, [
-      props.recording,
-      props.recording.name,
-      props.duration,
-      props.index,
-      isExpanded,
-      tableColumns,
-      props.recording.toDisk,
-      props.recording.maxAge,
-      props.recording.maxSize,
-    ]);
+    }, [props.recording, props.index, isExpanded]);
     return (
       <Tbody key={props.index} isExpanded={isExpanded}>
         {parentRow}
@@ -587,7 +548,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
           : [...expandedRows, id];
       });
     },
-    [expandedRows, setExpandedRows]
+    [setExpandedRows]
   );
 
   const RecordingsToolbar = React.useMemo(
@@ -697,7 +658,7 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
 
   const deletionDialogsEnabled = React.useMemo(
     () => context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteActiveRecordings),
-    [context, context.settings, context.settings.deletionDialogsEnabledFor]
+    [context.settings]
   );
 
   const handleWarningModalClose = React.useCallback(() => {
@@ -710,7 +671,7 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
     } else {
       props.handleDeleteRecordings();
     }
-  }, [deletionDialogsEnabled, setWarningModalOpen, props.handleDeleteRecordings]);
+  }, [deletionDialogsEnabled, setWarningModalOpen, props]);
 
   const isStopDisabled = React.useMemo(() => {
     if (!props.checkedIndices.length || props.actionLoadings['STOP']) {
@@ -719,7 +680,7 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
     const filtered = props.filteredRecordings.filter((r) => props.checkedIndices.includes(r.id));
     const anyRunning = filtered.some((r) => r.state === RecordingState.RUNNING || r.state == RecordingState.STARTING);
     return !anyRunning;
-  }, [props.checkedIndices, props.filteredRecordings]);
+  }, [props.actionLoadings, props.checkedIndices, props.filteredRecordings]);
 
   const actionLoadingProps = React.useMemo<Record<ActiveActions, LoadingPropsType>>(
     () => ({
@@ -798,14 +759,16 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
       </>
     );
   }, [
-    props.checkedIndices,
+    handleDeleteButton,
+    isStopDisabled,
+    actionLoadingProps,
     props.handleCreateRecording,
     props.handleArchiveRecordings,
     props.handleEditLabels,
     props.handleStopRecordings,
     props.actionLoadings,
-    handleDeleteButton,
-    actionLoadingProps,
+    props.archiveEnabled,
+    props.checkedIndices,
   ]);
 
   const deleteActiveWarningModal = React.useMemo(() => {

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -423,6 +423,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
     [dispatch]
   );
 
+  /* eslint-enable react-hooks/exhaustive-deps */
   const RecordingRow = (props) => {
     const parsedLabels = React.useMemo(() => {
       return parseLabels(props.recording.metadata.labels);
@@ -592,6 +593,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
     return filteredRecordings.map((r) => (
       <RecordingRow key={r.id} recording={r} labelFilters={targetRecordingFilters.Label} index={r.id} />
     ));
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [filteredRecordings, expandedRows, targetRecordingFilters, checkedIndices]);
 
   const LabelsPanel = React.useMemo(

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -165,7 +165,7 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
 
   const queryTargetRecordings = React.useCallback(
     (connectUrl: string) => {
-      return context.api.graphql<any>(
+      return context.api.graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
         `
       query ArchivedRecordingsForTarget($connectUrl: String) {
         archivedRecordings(filter: { sourceTarget: $connectUrl }) {
@@ -187,7 +187,7 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
   );
 
   const queryUploadedRecordings = React.useCallback(() => {
-    return context.api.graphql<any>(
+    return context.api.graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
       `query UploadedRecordings($filter: ArchivedRecordingFilterInput){
         archivedRecordings(filter: $filter) {
           data {

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -165,7 +165,8 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
 
   const queryTargetRecordings = React.useCallback(
     (connectUrl: string) => {
-      return context.api.graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      return context.api.graphql<any>(
         `
       query ArchivedRecordingsForTarget($connectUrl: String) {
         archivedRecordings(filter: { sourceTarget: $connectUrl }) {
@@ -187,7 +188,8 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
   );
 
   const queryUploadedRecordings = React.useCallback(() => {
-    return context.api.graphql<any> /* eslint-disable-line @typescript-eslint/no-explicit-any */(
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    return context.api.graphql<any>(
       `query UploadedRecordings($filter: ArchivedRecordingFilterInput){
         archivedRecordings(filter: $filter) {
           data {
@@ -572,6 +574,7 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
         directory={propsDirectory}
       />
     ));
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [filteredRecordings, propsTarget, propsDirectory, targetRecordingFilters.Label]);
 
   const handleUploadModalClose = React.useCallback(() => {

--- a/src/app/Recordings/Filters/DateTimePicker.tsx
+++ b/src/app/Recordings/Filters/DateTimePicker.tsx
@@ -50,17 +50,17 @@ import { SearchIcon } from '@patternfly/react-icons';
 import React from 'react';
 
 export interface DateTimePickerProps {
-  onSubmit: (date: any) => void;
+  onSubmit: (date: string) => void;
 }
 
-export const DateTimePicker: React.FunctionComponent<DateTimePickerProps> = (props) => {
+export const DateTimePicker: React.FunctionComponent<DateTimePickerProps> = ({ onSubmit }) => {
   const [selectedDate, setSelectedDate] = React.useState<Date | undefined>();
   const [selectedHour, setSelectedHour] = React.useState(0);
   const [selectedMinute, setSelectedMinute] = React.useState(0);
   const [isTimeOpen, setIsTimeOpen] = React.useState(false);
 
   const onDateChange = React.useCallback(
-    (inputDateValue: string, newDate: Date | undefined) => {
+    (_inputDateValue: string, newDate: Date | undefined) => {
       setSelectedDate(newDate);
     },
     [setSelectedDate]
@@ -82,9 +82,13 @@ export const DateTimePicker: React.FunctionComponent<DateTimePickerProps> = (pro
   );
 
   const handleSubmit = React.useCallback(() => {
-    selectedDate!.setUTCHours(selectedHour, selectedMinute);
-    props.onSubmit(selectedDate!.toISOString());
-  }, [selectedDate, selectedHour, selectedMinute, props.onSubmit]);
+    if (selectedDate) {
+      selectedDate.setUTCHours(selectedHour, selectedMinute);
+      onSubmit(selectedDate.toISOString());
+    } else {
+      console.error('Date is undefined');
+    }
+  }, [selectedDate, selectedHour, selectedMinute, onSubmit]);
 
   return (
     <Flex>

--- a/src/app/Recordings/Filters/DurationFilter.tsx
+++ b/src/app/Recordings/Filters/DurationFilter.tsx
@@ -36,27 +36,28 @@
  * SOFTWARE.
  */
 
-import React from 'react';
 import { Checkbox, Flex, FlexItem, TextInput } from '@patternfly/react-core';
+import React from 'react';
 
 export interface DurationFilterProps {
   durations: string[] | undefined;
-  onDurationInput: (e: any) => void;
+  onDurationInput: (e: number) => void;
   onContinuousDurationSelect: (checked: boolean) => void;
 }
 
-export const DurationFilter: React.FunctionComponent<DurationFilterProps> = (props) => {
+export const DurationFilter: React.FC<DurationFilterProps> = ({
+  durations,
+  onDurationInput,
+  onContinuousDurationSelect,
+}) => {
   const [duration, setDuration] = React.useState(30);
-  const isContinuous = React.useMemo(
-    () => props.durations && props.durations.includes('continuous'),
-    [props.durations]
-  );
+  const isContinuous = React.useMemo(() => durations && durations.includes('continuous'), [durations]);
 
-  const handleContinousCheckBoxChange = React.useCallback(
-    (checked, evt) => {
-      props.onContinuousDurationSelect(checked);
+  const handleContinuousCheckBoxChange = React.useCallback(
+    (checked) => {
+      onContinuousDurationSelect(checked);
     },
-    [props.onContinuousDurationSelect]
+    [onContinuousDurationSelect]
   );
 
   const handleEnterKey = React.useCallback(
@@ -64,9 +65,9 @@ export const DurationFilter: React.FunctionComponent<DurationFilterProps> = (pro
       if (e.key && e.key !== 'Enter') {
         return;
       }
-      props.onDurationInput(duration);
+      onDurationInput(duration);
     },
-    [props.onDurationInput, duration]
+    [onDurationInput, duration]
   );
 
   return (
@@ -87,7 +88,7 @@ export const DurationFilter: React.FunctionComponent<DurationFilterProps> = (pro
           label="Continuous"
           id="continuous-checkbox"
           isChecked={isContinuous}
-          onChange={handleContinousCheckBoxChange}
+          onChange={handleContinuousCheckBoxChange}
         />
       </FlexItem>
     </Flex>

--- a/src/app/Recordings/Filters/LabelFilter.tsx
+++ b/src/app/Recordings/Filters/LabelFilter.tsx
@@ -36,10 +36,10 @@
  * SOFTWARE.
  */
 
-import React from 'react';
-import { Label, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
-import { Recording } from '@app/Shared/Services/Api.service';
 import { parseLabels, RecordingLabel } from '@app/RecordingMetadata/RecordingLabel';
+import { Recording } from '@app/Shared/Services/Api.service';
+import { Label, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import React from 'react';
 
 export interface LabelFilterProps {
   recordings: Recording[];
@@ -49,29 +49,29 @@ export interface LabelFilterProps {
 
 export const getLabelDisplay = (label: RecordingLabel) => `${label.key}:${label.value}`;
 
-export const LabelFilter: React.FunctionComponent<LabelFilterProps> = (props) => {
+export const LabelFilter: React.FunctionComponent<LabelFilterProps> = ({ recordings, filteredLabels, onSubmit }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
 
   const onSelect = React.useCallback(
     (_, selection, isPlaceholder) => {
       if (!isPlaceholder) {
         setIsExpanded(false);
-        props.onSubmit(selection);
+        onSubmit(selection);
       }
     },
-    [props.onSubmit, setIsExpanded]
+    [onSubmit, setIsExpanded]
   );
 
   const labels = React.useMemo(() => {
     const labels = new Set<string>();
-    props.recordings.forEach((r) => {
+    recordings.forEach((r) => {
       if (!r || !r.metadata || !r.metadata.labels) return;
       parseLabels(r.metadata.labels).map((label) => labels.add(getLabelDisplay(label)));
     });
     return Array.from(labels)
-      .filter((l) => !props.filteredLabels.includes(l))
+      .filter((l) => !filteredLabels.includes(l))
       .sort();
-  }, [props.recordings, parseLabels, getLabelDisplay]);
+  }, [recordings, filteredLabels]);
 
   return (
     <Select

--- a/src/app/Recordings/Filters/NameFilter.tsx
+++ b/src/app/Recordings/Filters/NameFilter.tsx
@@ -36,9 +36,9 @@
  * SOFTWARE.
  */
 
-import React from 'react';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import { Recording } from '@app/Shared/Services/Api.service';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import React from 'react';
 
 export interface NameFilterProps {
   recordings: Recording[];
@@ -46,25 +46,25 @@ export interface NameFilterProps {
   onSubmit: (inputName: string) => void;
 }
 
-export const NameFilter: React.FunctionComponent<NameFilterProps> = (props) => {
+export const NameFilter: React.FunctionComponent<NameFilterProps> = ({ recordings, filteredNames, onSubmit }) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
 
   const onSelect = React.useCallback(
     (_, selection, isPlaceholder) => {
       if (!isPlaceholder) {
         setIsExpanded(false);
-        props.onSubmit(selection);
+        onSubmit(selection);
       }
     },
-    [props.onSubmit, setIsExpanded]
+    [onSubmit, setIsExpanded]
   );
 
   const nameOptions = React.useMemo(() => {
-    return props.recordings
+    return recordings
       .map((r) => r.name)
-      .filter((n) => !props.filteredNames.includes(n))
+      .filter((n) => !filteredNames.includes(n))
       .map((option, index) => <SelectOption key={index} value={option} />);
-  }, [props.recordings, props.filteredNames]);
+  }, [recordings, filteredNames]);
 
   return (
     <Select

--- a/src/app/Recordings/Filters/RecordingStateFilter.tsx
+++ b/src/app/Recordings/Filters/RecordingStateFilter.tsx
@@ -36,24 +36,27 @@
  * SOFTWARE.
  */
 
-import React from 'react';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import { RecordingState } from '@app/Shared/Services/Api.service';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import React from 'react';
 
 export interface RecordingStateFilterProps {
   filteredStates: RecordingState[] | undefined;
-  onSelectToggle: (state: any) => void;
+  onSelectToggle: (state: RecordingState) => void;
 }
 
-export const RecordingStateFilter: React.FunctionComponent<RecordingStateFilterProps> = (props) => {
+export const RecordingStateFilter: React.FunctionComponent<RecordingStateFilterProps> = ({
+  filteredStates,
+  onSelectToggle,
+}) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   const onSelect = React.useCallback(
     (_, selection) => {
       setIsOpen(false);
-      props.onSelectToggle(selection);
+      onSelectToggle(selection);
     },
-    [setIsOpen, props.onSelectToggle]
+    [setIsOpen, onSelectToggle]
   );
 
   return (
@@ -61,7 +64,7 @@ export const RecordingStateFilter: React.FunctionComponent<RecordingStateFilterP
       variant={SelectVariant.checkbox}
       onToggle={setIsOpen}
       onSelect={onSelect}
-      selections={props.filteredStates}
+      selections={filteredStates}
       isOpen={isOpen}
       aria-label="Filter by state"
       placeholderText="Filter by state"

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 import { NotificationsContext } from '@app/Notifications/Notifications';
-import { ActiveRecording, Recording } from '@app/Shared/Services/Api.service';
+import { Recording } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { Target } from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
@@ -92,7 +92,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
           }
         })
     );
-  }, [addSubscription, notifications, props.uploadFn, context.api]);
+  }, [addSubscription, notifications, props, context.api]);
 
   const handleDownloadRecording = React.useCallback(() => {
     context.api.downloadRecording(props.recording);

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -35,6 +35,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
+import {
+  allowedActiveRecordingFilters,
+  allowedArchivedRecordingFilters,
+} from '@app/Shared/Redux/Filters/RecordingFilterSlice';
+import { recordingUpdateCategoryIntent, StateDispatch, RootState } from '@app/Shared/Redux/ReduxStore';
+import { Recording, RecordingState } from '@app/Shared/Services/Api.service';
 import {
   Dropdown,
   DropdownItem,
@@ -48,19 +55,12 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { DateTimePicker } from './Filters/DateTimePicker';
 import { DurationFilter } from './Filters/DurationFilter';
 import { LabelFilter } from './Filters/LabelFilter';
 import { NameFilter } from './Filters/NameFilter';
 import { RecordingStateFilter } from './Filters/RecordingStateFilter';
-import { Recording, RecordingState } from '@app/Shared/Services/Api.service';
-import { useDispatch, useSelector } from 'react-redux';
-import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
-import { recordingUpdateCategoryIntent, StateDispatch, RootState } from '@app/Shared/Redux/ReduxStore';
-import {
-  allowedActiveRecordingFilters,
-  allowedArchivedRecordingFilters,
-} from '@app/Shared/Redux/Filters/RecordingFilterSlice';
 
 export interface RecordingFiltersCategories {
   Name: string[];
@@ -79,15 +79,19 @@ export interface RecordingFiltersProps {
   updateFilters: (target: string, updateFilterOptions: UpdateFilterOptions) => void;
 }
 
-export const RecordingFilters: React.FunctionComponent<RecordingFiltersProps> = (props) => {
+export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
+  target,
+  isArchived,
+  recordings,
+  filters,
+  updateFilters,
+}) => {
   const dispatch = useDispatch<StateDispatch>();
 
   const currentCategory = useSelector((state: RootState) => {
-    const targetRecordingFilters = state.recordingFilters.list.filter(
-      (targetFilter) => targetFilter.target === props.target
-    );
+    const targetRecordingFilters = state.recordingFilters.list.filter((targetFilter) => targetFilter.target === target);
     if (!targetRecordingFilters.length) return 'Name'; // Target is not yet loaded
-    return (props.isArchived ? targetRecordingFilters[0].archived : targetRecordingFilters[0].active).selectedCategory;
+    return (isArchived ? targetRecordingFilters[0].archived : targetRecordingFilters[0].active).selectedCategory;
   });
 
   const [isCategoryDropdownOpen, setIsCategoryDropdownOpen] = React.useState(false);
@@ -99,60 +103,57 @@ export const RecordingFilters: React.FunctionComponent<RecordingFiltersProps> = 
   const onCategorySelect = React.useCallback(
     (category) => {
       setIsCategoryDropdownOpen(false);
-      dispatch(recordingUpdateCategoryIntent(props.target, category, props.isArchived));
+      dispatch(recordingUpdateCategoryIntent(target, category, isArchived));
     },
-    [dispatch, recordingUpdateCategoryIntent, setIsCategoryDropdownOpen, props.target, props.isArchived]
+    [dispatch, setIsCategoryDropdownOpen, target, isArchived]
   );
 
   const onDelete = React.useCallback(
-    (category, value) => props.updateFilters(props.target, { filterKey: category, filterValue: value, deleted: true }),
-    [props.updateFilters, props.target]
+    (category, value) => updateFilters(target, { filterKey: category, filterValue: value, deleted: true }),
+    [updateFilters, target]
   );
 
   const onDeleteGroup = React.useCallback(
-    (category) =>
-      props.updateFilters(props.target, { filterKey: category, deleted: true, deleteOptions: { all: true } }),
-    [props.updateFilters, props.target]
+    (category) => updateFilters(target, { filterKey: category, deleted: true, deleteOptions: { all: true } }),
+    [updateFilters, target]
   );
 
   const onNameInput = React.useCallback(
-    (inputName) => props.updateFilters(props.target, { filterKey: currentCategory!, filterValue: inputName }),
-    [props.updateFilters, currentCategory, props.target]
+    (inputName) => updateFilters(target, { filterKey: currentCategory, filterValue: inputName }),
+    [updateFilters, currentCategory, target]
   );
 
   const onLabelInput = React.useCallback(
-    (inputLabel) => props.updateFilters(props.target, { filterKey: currentCategory!, filterValue: inputLabel }),
-    [props.updateFilters, currentCategory, props.target]
+    (inputLabel) => updateFilters(target, { filterKey: currentCategory, filterValue: inputLabel }),
+    [updateFilters, currentCategory, target]
   );
 
   const onStartedBeforeInput = React.useCallback(
-    (searchDate) => props.updateFilters(props.target, { filterKey: currentCategory!, filterValue: searchDate }),
-    [props.updateFilters, currentCategory, props.target]
+    (searchDate) => updateFilters(target, { filterKey: currentCategory, filterValue: searchDate }),
+    [updateFilters, currentCategory, target]
   );
 
   const onStartedAfterInput = React.useCallback(
-    (searchDate) => props.updateFilters(props.target, { filterKey: currentCategory!, filterValue: searchDate }),
-    [props.updateFilters, currentCategory, props.target]
+    (searchDate) => updateFilters(target, { filterKey: currentCategory, filterValue: searchDate }),
+    [updateFilters, currentCategory, target]
   );
 
   const onDurationInput = React.useCallback(
-    (duration) =>
-      props.updateFilters(props.target, { filterKey: currentCategory!, filterValue: `${duration.toString()} s` }),
-    [props.updateFilters, currentCategory, props.target]
+    (duration) => updateFilters(target, { filterKey: currentCategory, filterValue: `${duration.toString()} s` }),
+    [updateFilters, currentCategory, target]
   );
 
   const onRecordingStateSelectToggle = React.useCallback(
     (searchState) => {
-      const deleted = props.filters.State && props.filters.State.includes(searchState);
-      props.updateFilters(props.target, { filterKey: currentCategory!, filterValue: searchState, deleted: deleted });
+      const deleted = filters.State && filters.State.includes(searchState);
+      updateFilters(target, { filterKey: currentCategory, filterValue: searchState, deleted: deleted });
     },
-    [props.updateFilters, currentCategory, props.target]
+    [updateFilters, currentCategory, target, filters.State]
   );
 
   const onContinuousDurationSelect = React.useCallback(
-    (cont) =>
-      props.updateFilters(props.target, { filterKey: currentCategory!, filterValue: 'continuous', deleted: !cont }),
-    [props.updateFilters, currentCategory, props.target]
+    (cont) => updateFilters(target, { filterKey: currentCategory, filterValue: 'continuous', deleted: !cont }),
+    [updateFilters, currentCategory, target]
   );
 
   const categoryDropdown = React.useMemo(() => {
@@ -166,49 +167,44 @@ export const RecordingFilters: React.FunctionComponent<RecordingFiltersProps> = 
           </DropdownToggle>
         }
         isOpen={isCategoryDropdownOpen}
-        dropdownItems={(!props.isArchived ? allowedActiveRecordingFilters : allowedArchivedRecordingFilters).map(
-          (cat) => (
-            <DropdownItem aria-label={cat} key={cat} onClick={() => onCategorySelect(cat)}>
-              {cat}
-            </DropdownItem>
-          )
-        )}
+        dropdownItems={(!isArchived ? allowedActiveRecordingFilters : allowedArchivedRecordingFilters).map((cat) => (
+          <DropdownItem aria-label={cat} key={cat} onClick={() => onCategorySelect(cat)}>
+            {cat}
+          </DropdownItem>
+        ))}
       />
     );
-  }, [
-    props.isArchived,
-    allowedActiveRecordingFilters,
-    allowedArchivedRecordingFilters,
-    isCategoryDropdownOpen,
-    currentCategory,
-    onCategoryToggle,
-    onCategorySelect,
-  ]);
+  }, [isArchived, isCategoryDropdownOpen, currentCategory, onCategoryToggle, onCategorySelect]);
 
   const filterDropdownItems = React.useMemo(
     () => [
-      <NameFilter recordings={props.recordings} onSubmit={onNameInput} filteredNames={props.filters.Name} />,
-      <LabelFilter recordings={props.recordings} onSubmit={onLabelInput} filteredLabels={props.filters.Label} />,
-      ...(!props.isArchived
+      <NameFilter key={'name'} recordings={recordings} onSubmit={onNameInput} filteredNames={filters.Name} />,
+      <LabelFilter key={'label'} recordings={recordings} onSubmit={onLabelInput} filteredLabels={filters.Label} />,
+      ...(!isArchived
         ? [
-            <RecordingStateFilter filteredStates={props.filters.State} onSelectToggle={onRecordingStateSelectToggle} />,
-            <DateTimePicker onSubmit={onStartedBeforeInput} />,
-            <DateTimePicker onSubmit={onStartedAfterInput} />,
+            <RecordingStateFilter
+              key={'recording-state'}
+              filteredStates={filters.State}
+              onSelectToggle={onRecordingStateSelectToggle}
+            />,
+            <DateTimePicker key={'datetime-before'} onSubmit={onStartedBeforeInput} />,
+            <DateTimePicker key={'datetime-after'} onSubmit={onStartedAfterInput} />,
             <DurationFilter
-              durations={props.filters.DurationSeconds}
+              key={'duration'}
+              durations={filters.DurationSeconds}
               onContinuousDurationSelect={onContinuousDurationSelect}
               onDurationInput={onDurationInput}
-            ></DurationFilter>,
+            />,
           ]
         : []),
     ],
     [
-      props.isArchived,
-      props.recordings,
-      props.filters.Name,
-      props.filters.Label,
-      props.filters.State,
-      props.filters.DurationSeconds,
+      isArchived,
+      recordings,
+      filters.Name,
+      filters.Label,
+      filters.State,
+      filters.DurationSeconds,
       onNameInput,
       onLabelInput,
       onRecordingStateSelectToggle,
@@ -225,10 +221,10 @@ export const RecordingFilters: React.FunctionComponent<RecordingFiltersProps> = 
         <ToolbarItem>
           <InputGroup>
             {categoryDropdown}
-            {Object.keys(props.filters).map((filterKey, i) => (
+            {Object.keys(filters).map((filterKey, i) => (
               <ToolbarFilter
                 key={filterKey}
-                chips={props.filters[filterKey]}
+                chips={filters[filterKey]}
                 deleteChip={onDelete}
                 deleteChipGroup={onDeleteGroup}
                 categoryName={filterKey}
@@ -251,7 +247,7 @@ export const filterRecordings = (recordings: any[], filters: RecordingFiltersCat
 
   let filtered = recordings;
 
-  if (!!filters.Name.length) {
+  if (filters.Name.length) {
     filtered = filtered.filter((r) => filters.Name.includes(r.name));
   }
   if (!!filters.State && !!filters.State.length) {
@@ -286,7 +282,7 @@ export const filterRecordings = (recordings: any[], filters: RecordingFiltersCat
       }).length;
     });
   }
-  if (!!filters.Label.length) {
+  if (filters.Label.length) {
     filtered = filtered.filter(
       (r) => Object.entries(r.metadata.labels).filter(([k, v]) => filters.Label.includes(`${k}:${v}`)).length
     );

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -240,6 +240,7 @@ export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
   );
 };
 
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export const filterRecordings = (recordings: any[], filters: RecordingFiltersCategories) => {
   if (!recordings || !recordings.length) {
     return recordings;

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -35,17 +35,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Card, CardBody, CardTitle, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import * as React from 'react';
 import { ActiveRecordingsTable } from './ActiveRecordingsTable';
 import { ArchivedRecordingsTable } from './ArchivedRecordingsTable';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
 
 export interface RecordingsProps {}
 
-export const Recordings: React.FunctionComponent<RecordingsProps> = (props) => {
+export const Recordings: React.FunctionComponent<RecordingsProps> = (_) => {
   const context = React.useContext(ServiceContext);
   const [activeTab, setActiveTab] = React.useState(0);
   const [archiveEnabled, setArchiveEnabled] = React.useState(false);

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -35,7 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
+import { ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
+import { LoadingView } from '@app/LoadingView/LoadingView';
+import { ServiceContext } from '@app/Shared/Services/Services';
 import {
   Title,
   EmptyState,
@@ -43,13 +45,10 @@ import {
   EmptyStateBody,
   Button,
   EmptyStateSecondaryActions,
-  Text,
 } from '@patternfly/react-core';
-import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
+import { SearchIcon } from '@patternfly/react-icons';
 import { TableComposable, Thead, Tr, Th, OuterScrollContainer, InnerScrollContainer } from '@patternfly/react-table';
-import { LoadingView } from '@app/LoadingView/LoadingView';
-import { ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
-import { ServiceContext } from '@app/Shared/Services/Services';
+import * as React from 'react';
 
 export interface RecordingsTableProps {
   toolbar: React.ReactElement;
@@ -73,7 +72,7 @@ export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (p
 
   const authRetry = React.useCallback(() => {
     context.target.setAuthRetry();
-  }, [context.target, context.target.setAuthRetry]);
+  }, [context.target]);
 
   const isError = React.useMemo(() => props.errorMessage != '', [props.errorMessage]);
 
@@ -139,7 +138,7 @@ export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (p
                 }}
               />
               <Th key="table-header-expand" />
-              {props.tableColumns.map((key, idx) => (
+              {props.tableColumns.map((key, _) => (
                 <Th key={`table-header-${key}`}>{key}</Th>
               ))}
               <Th key="table-header-actions" />

--- a/src/app/Recordings/ReportFrame.tsx
+++ b/src/app/Recordings/ReportFrame.tsx
@@ -35,20 +35,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { Recording, isHttpError } from '@app/Shared/Services/Api.service';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { Spinner } from '@patternfly/react-core';
-import { first } from 'rxjs/operators';
 import { isGenerationError } from '@app/Shared/Services/Report.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { Spinner } from '@patternfly/react-core';
+import * as React from 'react';
+import { first } from 'rxjs/operators';
 
 export interface ReportFrameProps extends React.HTMLProps<HTMLIFrameElement> {
   isExpanded: boolean;
   recording: Recording;
 }
 
-export const ReportFrame: React.FunctionComponent<ReportFrameProps> = React.memo((props) => {
+export const ReportFrame: React.FunctionComponent<ReportFrameProps> = (props) => {
   const addSubscription = useSubscriptions();
   const context = React.useContext(ServiceContext);
   const [report, setReport] = React.useState(undefined as string | undefined);
@@ -63,9 +63,9 @@ export const ReportFrame: React.FunctionComponent<ReportFrameProps> = React.memo
       context.reports
         .report(recording)
         .pipe(first())
-        .subscribe(
-          (report) => setReport(report),
-          (err) => {
+        .subscribe({
+          next: setReport,
+          error: (err) => {
             if (isGenerationError(err)) {
               err.messageDetail.pipe(first()).subscribe((detail) => setReport(detail));
             } else if (isHttpError(err)) {
@@ -73,8 +73,8 @@ export const ReportFrame: React.FunctionComponent<ReportFrameProps> = React.memo
             } else {
               setReport(JSON.stringify(err));
             }
-          }
-        )
+          },
+        })
     );
   }, [addSubscription, context.reports, recording, isExpanded, setReport, props]);
 
@@ -86,4 +86,4 @@ export const ReportFrame: React.FunctionComponent<ReportFrameProps> = React.memo
       <iframe title="Automated Analysis" srcDoc={report} {...rest} onLoad={onLoad} hidden={!(loaded && isExpanded)} />
     </>
   );
-});
+};

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -35,7 +35,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
+import { BreadcrumbPage, BreadcrumbTrail } from '@app/BreadcrumbPage/BreadcrumbPage';
+import { EventTemplate } from '@app/CreateRecording/CreateRecording';
+import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
+import { NotificationsContext } from '@app/Notifications/Notifications';
+import { MatchExpressionEvaluator } from '@app/Shared/MatchExpressionEvaluator';
+import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
+import { TemplateType } from '@app/Shared/Services/Api.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { NO_TARGET } from '@app/Shared/Services/Target.service';
+import { SelectTemplateSelectorForm } from '@app/TemplateSelector/SelectTemplateSelectorForm';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   ActionGroup,
   Button,
@@ -55,26 +65,16 @@ import {
   TextVariants,
   ValidatedOptions,
 } from '@patternfly/react-core';
+import * as React from 'react';
 import { useHistory, withRouter } from 'react-router-dom';
 import { iif } from 'rxjs';
 import { filter, first, mergeMap, toArray } from 'rxjs/operators';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { NotificationsContext } from '@app/Notifications/Notifications';
-import { BreadcrumbPage, BreadcrumbTrail } from '@app/BreadcrumbPage/BreadcrumbPage';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { EventTemplate } from '@app/CreateRecording/CreateRecording';
-import { MatchExpressionEvaluator } from '@app/Shared/MatchExpressionEvaluator';
-import { SelectTemplateSelectorForm } from '@app/TemplateSelector/SelectTemplateSelectorForm';
-import { NO_TARGET } from '@app/Shared/Services/Target.service';
-import { authFailMessage, ErrorView, isAuthFail } from '@app/ErrorView/ErrorView';
-import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 import { Rule } from './Rules';
-import { TemplateType } from '@app/Shared/Services/Api.service';
 
 // FIXME check if this is correct/matches backend name validation
 export const RuleNamePattern = /^[\w_]+$/;
 
-const Comp: React.FunctionComponent<{}> = () => {
+const Comp: React.FC = () => {
   const context = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const history = useHistory();
@@ -110,7 +110,7 @@ const Comp: React.FunctionComponent<{}> = () => {
   );
 
   const eventSpecifierString = React.useMemo(() => {
-    var str = '';
+    let str = '';
     if (templateName) {
       str += `template=${templateName}`;
     }
@@ -118,7 +118,7 @@ const Comp: React.FunctionComponent<{}> = () => {
       str += `,type=${templateType}`;
     }
     return str;
-  }, [templateName]);
+  }, [templateName, templateType]);
 
   const handleTemplateChange = React.useCallback(
     (templateName?: string, templateType?: TemplateType) => {
@@ -203,9 +203,9 @@ const Comp: React.FunctionComponent<{}> = () => {
   }, [
     setLoading,
     addSubscription,
-    context,
     context.api,
     history,
+    notifications,
     name,
     nameValid,
     description,
@@ -228,7 +228,7 @@ const Comp: React.FunctionComponent<{}> = () => {
       setTemplates(templates);
       setErrorMessage('');
     },
-    [setTemplateName, setErrorMessage]
+    [setTemplates, setErrorMessage]
   );
 
   const refreshTemplateList = React.useCallback(() => {
@@ -254,7 +254,7 @@ const Comp: React.FunctionComponent<{}> = () => {
           error: handleError,
         })
     );
-  }, [addSubscription, context.api, context.target, setTemplates]);
+  }, [addSubscription, context.api, context.target, handleError, handleTemplateList]);
 
   React.useEffect(() => {
     addSubscription(context.target.target().subscribe(refreshTemplateList));
@@ -266,7 +266,7 @@ const Comp: React.FunctionComponent<{}> = () => {
         setErrorMessage(authFailMessage);
       })
     );
-  }, [context.target, authFailMessage, setErrorMessage, addSubscription]);
+  }, [addSubscription, context.target, setErrorMessage]);
 
   const breadcrumbs: BreadcrumbTrail[] = [
     {
@@ -294,7 +294,7 @@ const Comp: React.FunctionComponent<{}> = () => {
 
   const authRetry = React.useCallback(() => {
     context.target.setAuthRetry();
-  }, [context.target, context.target.setAuthRetry]);
+  }, [context.target]);
 
   return (
     <BreadcrumbPage pageTitle="Create" breadcrumbs={breadcrumbs}>
@@ -314,7 +314,7 @@ const Comp: React.FunctionComponent<{}> = () => {
                     Automated Rules are configurations that instruct Cryostat to create JDK Flight Recordings on
                     matching target JVM applications. Each Automated Rule specifies parameters for which Event Template
                     to use, how much data should be kept in the application recording buffer, and how frequently
-                    Cryostat should copy the application recording buffer into Cryostat's own archived storage.
+                    Cryostat should copy the application recording buffer into Cryostat&apos;s own archived storage.
                   </Text>
                   <FormGroup
                     label="Name"

--- a/src/app/Rules/RuleDeleteWarningModal.tsx
+++ b/src/app/Rules/RuleDeleteWarningModal.tsx
@@ -35,12 +35,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { Modal, ModalVariant, Button, Checkbox, Stack, Split } from '@patternfly/react-core';
 import * as React from 'react';
-import { Modal, ModalVariant, Button, Checkbox, Stack, Split, Text, TextContent } from '@patternfly/react-core';
-import { getFromWarningMap } from '../Modal/DeleteWarningUtils';
 import { useState } from 'react';
 import { DeleteWarningProps } from '../Modal/DeleteWarningModal';
-import { ServiceContext } from '@app/Shared/Services/Services';
+import { getFromWarningMap } from '../Modal/DeleteWarningUtils';
 
 export interface RuleDeleteWarningProps extends DeleteWarningProps {
   ruleName?: string;
@@ -68,7 +68,7 @@ export const RuleDeleteWarningModal = ({
     if (doNotAsk) {
       context.settings.setDeletionDialogsEnabledFor(warningType, false);
     }
-  }, [onAccept, onClose, doNotAsk, context, context.settings]);
+  }, [onAccept, onClose, doNotAsk, context.settings, warningType]);
 
   return (
     <Modal

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -35,8 +35,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
+import { LoadingView } from '@app/LoadingView/LoadingView';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
+import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   Button,
   Card,
@@ -66,16 +70,11 @@ import {
   Tbody,
   ActionsColumn,
 } from '@patternfly/react-table';
-import { useHistory, useRouteMatch } from 'react-router-dom';
+import * as React from 'react';
+import { Link, useHistory, useRouteMatch } from 'react-router-dom';
 import { first } from 'rxjs/operators';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
-import { LoadingView } from '@app/LoadingView/LoadingView';
-import { RuleUploadModal } from './RulesUploadModal';
-import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { RuleDeleteWarningModal } from './RuleDeleteWarningModal';
+import { RuleUploadModal } from './RulesUploadModal';
 
 export interface Rule {
   name: string;
@@ -109,9 +108,9 @@ export const ruleObjKeys = [
   'maxSizeBytes',
 ];
 
-export const isRule = (obj: Object): boolean => {
+export const isRule = (obj: object): boolean => {
   for (const key of ruleObjKeys) {
-    if (!obj.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
       return false;
     }
   } // Ignore unknown fields
@@ -125,7 +124,7 @@ export interface RuleToDeleteOrDisable {
 
 export interface RulesProps {}
 
-export const Rules: React.FunctionComponent<RulesProps> = ({}) => {
+export const Rules: React.FC<RulesProps> = (_) => {
   const context = React.useContext(ServiceContext);
   const routerHistory = useHistory();
   const addSubscription = useSubscriptions();
@@ -139,48 +138,52 @@ export const Rules: React.FunctionComponent<RulesProps> = ({}) => {
   const [ruleToWarn, setRuleToWarn] = React.useState<RuleToDeleteOrDisable | undefined>(undefined);
   const [cleanRuleEnabled, setCleanRuleEnabled] = React.useState(true);
 
-  const tableColumns = [
-    { title: 'Enabled' },
-    {
-      title: 'Name',
-      sortable: true,
-    },
-    { title: 'Description' },
-    {
-      title: 'Match Expression',
-      tooltip:
-        'A code-snippet expression which must evaluate to a boolean when applied to a given target. If the expression evaluates to true then the rule applies to that target.',
-    },
-    {
-      title: 'Event Specifier',
-      tooltip: 'The name and location of the Event Template applied by this rule.',
-    },
-    {
-      title: 'Archival Period',
-      tooltip:
-        'Period in seconds. Cryostat will connect to matching targets at this interval and copy the relevant recording data into its archives. Values less than 1 prevent data from being repeatedly copied into archives - recordings will be started and remain only in target JVM memory.',
-    },
-    {
-      title: 'Initial Delay',
-      tooltip:
-        'Initial delay in seconds. Cryostat will wait this amount of time before first copying recording data into its archives. Values less than 0 default to equal to the Archival Period. You can set a non-zero Initial Delay with a zero Archival Period, which will start a recording and copy it into archives exactly once after a set delay.',
-    },
-    {
-      title: 'Preserved Archives',
-      tooltip:
-        'The number of recording copies to be maintained in the Cryostat archives. Cryostat will continue retrieving further archived copies and trimming the oldest copies from the archive to maintain this limit. Values less than 1 prevent data from being copied into archives - recordings will be started and remain only in target JVM memory.',
-    },
-    {
-      title: 'Maximum Age',
-      tooltip:
-        'The maximum age in seconds for data kept in the JFR recordings started by this rule. Values less than 1 indicate no limit.',
-    },
-    {
-      title: 'Maximum Size',
-      tooltip:
-        'The maximum size in bytes for JFR recordings started by this rule. Values less than 1 indicate no limit.',
-    },
-  ] as RuleTableHeader[];
+  const tableColumns = React.useMemo(
+    () =>
+      [
+        { title: 'Enabled' },
+        {
+          title: 'Name',
+          sortable: true,
+        },
+        { title: 'Description' },
+        {
+          title: 'Match Expression',
+          tooltip:
+            'A code-snippet expression which must evaluate to a boolean when applied to a given target. If the expression evaluates to true then the rule applies to that target.',
+        },
+        {
+          title: 'Event Specifier',
+          tooltip: 'The name and location of the Event Template applied by this rule.',
+        },
+        {
+          title: 'Archival Period',
+          tooltip:
+            'Period in seconds. Cryostat will connect to matching targets at this interval and copy the relevant recording data into its archives. Values less than 1 prevent data from being repeatedly copied into archives - recordings will be started and remain only in target JVM memory.',
+        },
+        {
+          title: 'Initial Delay',
+          tooltip:
+            'Initial delay in seconds. Cryostat will wait this amount of time before first copying recording data into its archives. Values less than 0 default to equal to the Archival Period. You can set a non-zero Initial Delay with a zero Archival Period, which will start a recording and copy it into archives exactly once after a set delay.',
+        },
+        {
+          title: 'Preserved Archives',
+          tooltip:
+            'The number of recording copies to be maintained in the Cryostat archives. Cryostat will continue retrieving further archived copies and trimming the oldest copies from the archive to maintain this limit. Values less than 1 prevent data from being copied into archives - recordings will be started and remain only in target JVM memory.',
+        },
+        {
+          title: 'Maximum Age',
+          tooltip:
+            'The maximum age in seconds for data kept in the JFR recordings started by this rule. Values less than 1 indicate no limit.',
+        },
+        {
+          title: 'Maximum Size',
+          tooltip:
+            'The maximum size in bytes for JFR recordings started by this rule. Values less than 1 indicate no limit.',
+        },
+      ] as RuleTableHeader[],
+    []
+  );
 
   const getSortParams = React.useCallback(
     (columnIndex: number): ThProps['sort'] => ({
@@ -199,16 +202,16 @@ export const Rules: React.FunctionComponent<RulesProps> = ({}) => {
   const refreshRules = React.useCallback(() => {
     setIsLoading(true);
     addSubscription(
-      context.api.doGet('rules', 'v2').subscribe((v: any) => {
-        setRules(v.data.result);
+      context.api.getRules().subscribe((rules) => {
+        setRules(rules);
         setIsLoading(false);
       })
     );
-  }, [setIsLoading, addSubscription, context, context.api, setRules]);
+  }, [setIsLoading, addSubscription, context.api, setRules]);
 
   React.useEffect(() => {
     refreshRules();
-  }, [context, context.api]);
+  }, [refreshRules]);
 
   React.useEffect(() => {
     addSubscription(
@@ -249,11 +252,11 @@ export const Rules: React.FunctionComponent<RulesProps> = ({}) => {
       context.settings.autoRefreshPeriod() * context.settings.autoRefreshUnits()
     );
     return () => window.clearInterval(id);
-  }, []);
+  }, [context.settings, refreshRules]);
 
   const handleCreateRule = React.useCallback(() => {
     routerHistory.push(`${url}/create`);
-  }, [routerHistory]);
+  }, [routerHistory, url]);
 
   const handleUploadRule = React.useCallback(() => {
     setIsUploadModalOpen(true);
@@ -279,19 +282,19 @@ export const Rules: React.FunctionComponent<RulesProps> = ({}) => {
         }
       }
     },
-    [context.api, cleanRuleEnabled, addSubscription, handleDisableRule, setRuleToWarn, setWarningModalOpen]
+    [context.api, context.settings, cleanRuleEnabled, addSubscription, handleDisableRule, setRuleToWarn, setWarningModalOpen]
   );
 
   const handleDelete = React.useCallback(
-    (rule: Rule, clean: boolean = true) => {
+    (rule: Rule, clean = true) => {
       addSubscription(
         context.api
           .deleteRule(rule.name, clean)
           .pipe(first())
-          .subscribe(() => {} /* do nothing - notification will handle updating state */)
+          .subscribe(() => undefined /* do nothing - notification will handle updating state */)
       );
     },
-    [addSubscription, context, context.api]
+    [addSubscription, context.api]
   );
 
   const handleDeleteButton = React.useCallback(
@@ -307,10 +310,15 @@ export const Rules: React.FunctionComponent<RulesProps> = ({}) => {
   );
 
   const handleWarningModalAccept = React.useCallback(() => {
-    if (ruleToWarn?.type === 'DELETE') {
-      handleDelete(ruleToWarn!.rule, cleanRuleEnabled);
-    } else {
-      handleDisableRule(ruleToWarn!.rule, cleanRuleEnabled);
+    if (ruleToWarn) {
+      if (ruleToWarn?.type === 'DELETE') {
+        handleDelete(ruleToWarn.rule, cleanRuleEnabled);
+      } else {
+        handleDisableRule(ruleToWarn.rule, cleanRuleEnabled);
+      }
+    }
+    else {
+      console.error('ruleToWarn is undefined');
     }
   }, [handleDelete, handleDisableRule, ruleToWarn, cleanRuleEnabled]);
 
@@ -404,7 +412,7 @@ export const Rules: React.FunctionComponent<RulesProps> = ({}) => {
         </Td>
       </Tr>
     ));
-  }, [rules, sortBy, handleToggle, actionResolver]);
+  }, [rules, sortBy, tableColumns, handleToggle, actionResolver]);
 
   const viewContent = React.useMemo(() => {
     if (isLoading) {
@@ -446,7 +454,7 @@ export const Rules: React.FunctionComponent<RulesProps> = ({}) => {
         </TableComposable>
       );
     }
-  }, [isLoading, rules, ruleRows]);
+  }, [getSortParams, isLoading, rules, ruleRows, tableColumns]);
 
   return (
     <>

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -110,7 +110,7 @@ export const ruleObjKeys = [
 
 export const isRule = (obj: object): boolean => {
   for (const key of ruleObjKeys) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+    if (!Object.prototype.hasOwnProperty.call(obj, key)) {
       return false;
     }
   } // Ignore unknown fields

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -282,7 +282,15 @@ export const Rules: React.FC<RulesProps> = (_) => {
         }
       }
     },
-    [context.api, context.settings, cleanRuleEnabled, addSubscription, handleDisableRule, setRuleToWarn, setWarningModalOpen]
+    [
+      context.api,
+      context.settings,
+      cleanRuleEnabled,
+      addSubscription,
+      handleDisableRule,
+      setRuleToWarn,
+      setWarningModalOpen,
+    ]
   );
 
   const handleDelete = React.useCallback(
@@ -316,8 +324,7 @@ export const Rules: React.FC<RulesProps> = (_) => {
       } else {
         handleDisableRule(ruleToWarn.rule, cleanRuleEnabled);
       }
-    }
-    else {
+    } else {
       console.error('ruleToWarn is undefined');
     }
   }, [handleDelete, handleDisableRule, ruleToWarn, cleanRuleEnabled]);

--- a/src/app/Rules/RulesUploadModal.tsx
+++ b/src/app/Rules/RulesUploadModal.tsx
@@ -35,7 +35,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { CancelUploadModal } from '@app/Modal/CancelUploadModal';
 import { FUpload, MultiFileUpload, UploadCallbacks } from '@app/Shared/FileUploads';
 import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 import { ServiceContext } from '@app/Shared/Services/Services';
@@ -65,7 +64,7 @@ export const parseRule = (file: File): Observable<Rule> => {
   );
 };
 
-export const RuleUploadModal: React.FunctionComponent<RuleUploadModalProps> = (props) => {
+export const RuleUploadModal: React.FunctionComponent<RuleUploadModalProps> = ({ onClose, visible }) => {
   const addSubscription = useSubscriptions();
   const context = React.useContext(ServiceContext);
   const submitRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to submit trigger div
@@ -85,9 +84,9 @@ export const RuleUploadModal: React.FunctionComponent<RuleUploadModalProps> = (p
       abortRef.current && abortRef.current.click();
     } else {
       reset();
-      props.onClose();
+      onClose();
     }
-  }, [uploading, abortRef.current, reset, props.onClose]);
+  }, [uploading, reset, onClose]);
 
   const onFileSubmit = React.useCallback(
     (fileUploads: FUpload[], { getProgressUpdateCallback, onSingleSuccess, onSingleFailure }: UploadCallbacks) => {
@@ -124,12 +123,12 @@ export const RuleUploadModal: React.FunctionComponent<RuleUploadModalProps> = (p
           })
       );
     },
-    [setUploading, context.api, handleClose, addSubscription, setAllOks]
+    [setUploading, context.api, addSubscription, setAllOks]
   );
 
   const handleSubmit = React.useCallback(() => {
     submitRef.current && submitRef.current.click();
-  }, [submitRef.current]);
+  }, []);
 
   const onFilesChange = React.useCallback(
     (fileUploads: FUpload[]) => {
@@ -152,7 +151,7 @@ export const RuleUploadModal: React.FunctionComponent<RuleUploadModalProps> = (p
   return (
     <>
       <Modal
-        isOpen={props.visible}
+        isOpen={visible}
         variant={ModalVariant.large}
         showClose={true}
         onClose={handleClose}
@@ -160,13 +159,13 @@ export const RuleUploadModal: React.FunctionComponent<RuleUploadModalProps> = (p
         description="Select an Automated Rules definition file to upload. File must be in valid JSON format."
         help={
           <Popover
-            headerContent={<div>What's this?</div>}
+            headerContent={<div>What&quot;s this?</div>}
             bodyContent={
               <div>
                 Automated Rules are configurations that instruct Cryostat to create JDK Flight Recordings on matching
                 target JVM applications. Each Automated Rule specifies parameters for which Event Template to use, how
                 much data should be kept in the application recording buffer, and how frequently Cryostat should copy
-                the application recording buffer into Cryostat's own archived storage.
+                the application recording buffer into Cryostat&quot;s own archived storage.
               </div>
             }
           >

--- a/src/app/Rules/RulesUploadModal.tsx
+++ b/src/app/Rules/RulesUploadModal.tsx
@@ -64,7 +64,7 @@ export const parseRule = (file: File): Observable<Rule> => {
   );
 };
 
-export const RuleUploadModal: React.FunctionComponent<RuleUploadModalProps> = ({ onClose, visible }) => {
+export const RuleUploadModal: React.FC<RuleUploadModalProps> = ({ onClose, ...props }) => {
   const addSubscription = useSubscriptions();
   const context = React.useContext(ServiceContext);
   const submitRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to submit trigger div
@@ -151,7 +151,7 @@ export const RuleUploadModal: React.FunctionComponent<RuleUploadModalProps> = ({
   return (
     <>
       <Modal
-        isOpen={visible}
+        isOpen={props.visible}
         variant={ModalVariant.large}
         showClose={true}
         onClose={handleClose}

--- a/src/app/SecurityPanel/CertificateUploadModal.tsx
+++ b/src/app/SecurityPanel/CertificateUploadModal.tsx
@@ -49,7 +49,7 @@ export interface CertificateUploadModalProps {
   onClose: () => void;
 }
 
-export const CertificateUploadModal: React.FunctionComponent<CertificateUploadModalProps> = (props) => {
+export const CertificateUploadModal: React.FunctionComponent<CertificateUploadModalProps> = ({ visible, onClose }) => {
   const addSubscriptions = useSubscriptions();
   const context = React.useContext(ServiceContext);
   const submitRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to submit trigger div
@@ -77,13 +77,13 @@ export const CertificateUploadModal: React.FunctionComponent<CertificateUploadMo
       abortRef.current && abortRef.current.click();
     } else {
       reset();
-      props.onClose();
+      onClose();
     }
-  }, [uploading, abortRef.current, reset, props.onClose]);
+  }, [uploading, reset, onClose]);
 
   const handleSubmit = React.useCallback(() => {
     submitRef.current && submitRef.current.click();
-  }, [submitRef.current]);
+  }, []);
 
   const onFileSubmit = React.useCallback(
     (fileUploads: FUpload[], { getProgressUpdateCallback, onSingleSuccess, onSingleFailure }: UploadCallbacks) => {
@@ -121,14 +121,14 @@ export const CertificateUploadModal: React.FunctionComponent<CertificateUploadMo
           })
       );
     },
-    [setUploading, context.api, addSubscriptions, handleClose, setAllOks]
+    [setUploading, context.api, addSubscriptions, setAllOks]
   );
 
   const submitButtonLoadingProps = React.useMemo(
     () =>
       ({
         spinnerAriaValueText: 'Submitting',
-        spinnerAriaLabel: 'submitting-ssl-certitficates',
+        spinnerAriaLabel: 'submitting-ssl-certificates',
         isLoading: uploading,
       } as LoadingPropsType),
     [uploading]
@@ -136,7 +136,7 @@ export const CertificateUploadModal: React.FunctionComponent<CertificateUploadMo
 
   return (
     <Modal
-      isOpen={props.visible}
+      isOpen={visible}
       variant={ModalVariant.large}
       showClose={true}
       onClose={handleClose}

--- a/src/app/SecurityPanel/Credentials/CreateJmxCredentialModal.tsx
+++ b/src/app/SecurityPanel/Credentials/CreateJmxCredentialModal.tsx
@@ -35,7 +35,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
+import { JmxAuthForm } from '@app/AppLayout/JmxAuthForm';
+import { MatchExpressionEvaluator } from '@app/Shared/MatchExpressionEvaluator';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   FormGroup,
   Modal,
@@ -45,18 +48,19 @@ import {
   TextVariants,
   ValidatedOptions,
 } from '@patternfly/react-core';
-import { JmxAuthForm } from '@app/AppLayout/JmxAuthForm';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { MatchExpressionEvaluator } from '@app/Shared/MatchExpressionEvaluator';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
+import * as React from 'react';
 
 export interface CreateJmxCredentialModalProps {
   visible: boolean;
   onDismiss: () => void;
-  onSave: () => void;
+  onPropsSave: () => void;
 }
 
-export const CreateJmxCredentialModal: React.FunctionComponent<CreateJmxCredentialModalProps> = (props) => {
+export const CreateJmxCredentialModal: React.FunctionComponent<CreateJmxCredentialModalProps> = ({
+  visible,
+  onDismiss,
+  onPropsSave,
+}) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [matchExpression, setMatchExpression] = React.useState('');
@@ -70,26 +74,26 @@ export const CreateJmxCredentialModal: React.FunctionComponent<CreateJmxCredenti
         context.api.postCredentials(matchExpression, username, password).subscribe((ok) => {
           setLoading(false);
           if (ok) {
-            props.onSave();
+            onPropsSave();
           }
         })
       );
     },
-    [props.onSave, context.target, context.api, matchExpression, setLoading]
+    [addSubscription, onPropsSave, context.api, matchExpression, setLoading]
   );
 
   return (
     <Modal
-      isOpen={props.visible}
+      isOpen={visible}
       variant={ModalVariant.large}
       showClose={!loading}
-      onClose={props.onDismiss}
+      onClose={onDismiss}
       title="Store JMX Credentials"
       description="Creates stored credentials for target JVMs according to various properties.
         If a Target JVM requires JMX authentication, Cryostat will use stored credentials
         when attempting to open JMX connections to the target."
     >
-      <JmxAuthForm onSave={onSave} onDismiss={props.onDismiss} focus={false} loading={loading}>
+      <JmxAuthForm onSave={onSave} onDismiss={onDismiss} focus={false} loading={loading}>
         <MatchExpressionEvaluator matchExpression={matchExpression} onChange={setMatchExpressionValid} />
         <FormGroup
           label="Match Expression"

--- a/src/app/SecurityPanel/Credentials/MatchedTargetsTable.tsx
+++ b/src/app/SecurityPanel/Credentials/MatchedTargetsTable.tsx
@@ -35,24 +35,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { Target } from '@app/Shared/Services/Target.service';
-import { EmptyState, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { LoadingView } from '@app/LoadingView/LoadingView';
+import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { Target } from '@app/Shared/Services/Target.service';
+import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { EmptyState, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { InnerScrollContainer, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
-import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 import _ from 'lodash';
+import * as React from 'react';
 
 export interface MatchedTargetsTableProps {
   id: number;
   matchExpression: string;
 }
 
-export const MatchedTargetsTable: React.FunctionComponent<MatchedTargetsTableProps> = (props) => {
+export const MatchedTargetsTable: React.FunctionComponent<MatchedTargetsTableProps> = ({ id, matchExpression }) => {
   const context = React.useContext(ServiceContext);
 
   const [targets, setTargets] = React.useState([] as Target[]);
@@ -64,16 +64,16 @@ export const MatchedTargetsTable: React.FunctionComponent<MatchedTargetsTablePro
   const refreshTargetsList = React.useCallback(() => {
     setIsLoading(true);
     addSubscription(
-      context.api.getCredential(props.id).subscribe((v) => {
+      context.api.getCredential(id).subscribe((v) => {
         setTargets(v.targets);
         setIsLoading(false);
       })
     );
-  }, [setIsLoading, addSubscription, context, context.api, setTargets]);
+  }, [addSubscription, setIsLoading, context.api, setTargets, id]);
 
   React.useEffect(() => {
     refreshTargetsList();
-  }, []);
+  }, [refreshTargetsList]);
 
   React.useEffect(() => {
     addSubscription(
@@ -81,7 +81,7 @@ export const MatchedTargetsTable: React.FunctionComponent<MatchedTargetsTablePro
         const evt: TargetDiscoveryEvent = v.message.event;
         const target: Target = evt.serviceRef;
         if (evt.kind === 'FOUND') {
-          const match: boolean = eval(props.matchExpression);
+          const match: boolean = eval(matchExpression);
           if (match) {
             setTargets((old) => old.concat(target));
           }
@@ -90,7 +90,7 @@ export const MatchedTargetsTable: React.FunctionComponent<MatchedTargetsTablePro
         }
       })
     );
-  }, [addSubscription, context, context.notificationChannel, setTargets]);
+  }, [addSubscription, context, context.notificationChannel, setTargets, matchExpression]);
 
   const targetRows = React.useMemo(() => {
     return targets.map((target, idx) => {

--- a/src/app/SecurityPanel/Credentials/StoreJmxCredentials.tsx
+++ b/src/app/SecurityPanel/Credentials/StoreJmxCredentials.tsx
@@ -41,6 +41,7 @@ import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { StoredCredential } from '@app/Shared/Services/Api.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { Target } from '@app/Shared/Services/Target.service';
 import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
@@ -90,6 +91,8 @@ const reducer = (state, action) => {
       };
     }
     case Actions.HANDLE_TARGET_NOTIFICATION: {
+      /* eslint-disable-next-line unused-imports/no-unused-vars */
+      const target: Target = action.payload.target;
       const updated = [...state.counts];
       for (let i = 0; i < state.credentials.length; i++) {
         const match: boolean = eval(state.credentials[i].matchExpression);

--- a/src/app/SecurityPanel/ImportCertificate.tsx
+++ b/src/app/SecurityPanel/ImportCertificate.tsx
@@ -36,8 +36,8 @@
  * SOFTWARE.
  */
 
-import * as React from 'react';
 import { Button } from '@patternfly/react-core';
+import * as React from 'react';
 import { CertificateUploadModal } from './CertificateUploadModal';
 import { SecurityCard } from './SecurityPanel';
 

--- a/src/app/SecurityPanel/SecurityPanel.tsx
+++ b/src/app/SecurityPanel/SecurityPanel.tsx
@@ -35,15 +35,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { Card, CardBody, CardTitle, Text, TextVariants } from '@patternfly/react-core';
 import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
+import { Card, CardBody, CardTitle, Text, TextVariants } from '@patternfly/react-core';
+import * as React from 'react';
 import { StoreJmxCredentialsCard } from './Credentials/StoreJmxCredentials';
 import { ImportCertificate } from './ImportCertificate';
 
 export interface SecurityPanelProps {}
 
-export const SecurityPanel: React.FunctionComponent<SecurityPanelProps> = (props) => {
+export const SecurityPanel: React.FunctionComponent<SecurityPanelProps> = (_) => {
   const securityCards = [ImportCertificate, StoreJmxCredentialsCard].map((c) => ({
     title: c.title,
     description: c.description,

--- a/src/app/Settings/AutoRefresh.tsx
+++ b/src/app/Settings/AutoRefresh.tsx
@@ -36,10 +36,10 @@
  * SOFTWARE.
  */
 
-import * as React from 'react';
-import { Checkbox } from '@patternfly/react-core';
-import { ServiceContext } from '@app/Shared/Services/Services';
 import { DurationPicker } from '@app/DurationPicker/DurationPicker';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { Checkbox } from '@patternfly/react-core';
+import * as React from 'react';
 import { UserSetting } from './Settings';
 
 const defaultPreferences = {

--- a/src/app/Settings/AutomatedAnalysisConfig.tsx
+++ b/src/app/Settings/AutomatedAnalysisConfig.tsx
@@ -37,15 +37,9 @@
  */
 
 import { AutomatedAnalysisConfigForm } from '@app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm';
-import {
-  AutomatedAnalysisRecordingConfig,
-  defaultAutomatedAnalysisRecordingConfig,
-} from '@app/Shared/Services/Api.service';
+import { AutomatedAnalysisRecordingConfig } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { NO_TARGET, Target } from '@app/Shared/Services/Target.service';
 import { TargetSelect } from '@app/TargetSelect/TargetSelect';
-import { TargetView } from '@app/TargetView/TargetView';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   DescriptionList,
   DescriptionListDescription,
@@ -70,7 +64,7 @@ const Component = () => {
   const onSave = React.useCallback(() => {
     const newConfig = context.settings.automatedAnalysisRecordingConfig();
     setConfig(newConfig);
-  }, [context.settings, context.settings.automatedAnalysisRecordingConfig, setConfig]);
+  }, [context.settings, setConfig]);
 
   return (
     <Stack hasGutter>

--- a/src/app/Settings/CredentialsStorage.tsx
+++ b/src/app/Settings/CredentialsStorage.tsx
@@ -36,11 +36,11 @@
  * SOFTWARE.
  */
 
+import { getFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
+import { Select, SelectOption, SelectVariant, Text } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Select, SelectOption, SelectVariant, Text } from '@patternfly/react-core';
 import { UserSetting } from './Settings';
-import { getFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
 
 export interface Location {
   key: string;
@@ -63,7 +63,7 @@ export class Locations {
 const locations = [Locations.BROWSER_SESSION, Locations.BACKEND];
 
 const getLocation = (key: string): Location => {
-  for (let l of locations) {
+  for (const l of locations) {
     if (l.key === key) {
       return l;
     }
@@ -77,17 +77,17 @@ const Component = () => {
 
   const handleSelect = React.useCallback(
     (_, selection) => {
-      let location = getLocation(selection);
+      const location = getLocation(selection);
       setSelection(location.key);
       setExpanded(false);
       saveToLocalStorage('JMX_CREDENTIAL_LOCATION', selection);
     },
-    [getLocation, setSelection, setExpanded, saveToLocalStorage]
+    [setSelection, setExpanded]
   );
 
   React.useEffect(() => {
     handleSelect(undefined, getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BACKEND.key));
-  }, [handleSelect, getFromLocalStorage]);
+  }, [handleSelect]);
 
   return (
     <>

--- a/src/app/Settings/DeletionDialogControl.tsx
+++ b/src/app/Settings/DeletionDialogControl.tsx
@@ -36,11 +36,11 @@
  * SOFTWARE.
  */
 
-import * as React from 'react';
-import { Divider, ExpandableSection, Switch, Stack, StackItem } from '@patternfly/react-core';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { UserSetting } from './Settings';
 import { DeleteOrDisableWarningType, getFromWarningMap } from '@app/Modal/DeleteWarningUtils';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { Divider, ExpandableSection, Switch, Stack, StackItem } from '@patternfly/react-core';
+import * as React from 'react';
+import { UserSetting } from './Settings';
 
 const Component = () => {
   const context = React.useContext(ServiceContext);
@@ -63,7 +63,7 @@ const Component = () => {
       context.settings.setDeletionDialogsEnabled(newState);
       setState(newState);
     },
-    [state, setState]
+    [context.settings, setState, state]
   );
 
   const allChecked = React.useMemo(() => {
@@ -83,7 +83,7 @@ const Component = () => {
         />
       </StackItem>
     ));
-  }, [state]);
+  }, [handleCheckboxChange, state]);
 
   return (
     <>

--- a/src/app/Settings/FeatureLevels.tsx
+++ b/src/app/Settings/FeatureLevels.tsx
@@ -36,12 +36,12 @@
  * SOFTWARE.
  */
 
-import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { UserSetting } from './Settings';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Select, SelectOption } from '@patternfly/react-core';
+import * as React from 'react';
+import { UserSetting } from './Settings';
 
 const Component = () => {
   const context = React.useContext(ServiceContext);
@@ -51,7 +51,7 @@ const Component = () => {
 
   React.useLayoutEffect(() => {
     addSubscription(context.settings.featureLevel().subscribe((level) => setState(level)));
-  }, [addSubscription, context.settings.featureLevel, setState]);
+  }, [addSubscription, context.settings, setState]);
 
   const handleToggle = React.useCallback(() => {
     setOpen((v) => !v);
@@ -63,7 +63,7 @@ const Component = () => {
       context.settings.setFeatureLevel(v);
       setOpen(false);
     },
-    [setState, setOpen, context.settings.setFeatureLevel]
+    [setState, setOpen, context.settings]
   );
 
   return (

--- a/src/app/Settings/NotificationControl.tsx
+++ b/src/app/Settings/NotificationControl.tsx
@@ -35,8 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
-import * as React from 'react';
+import { NotificationCategory, messageKeys } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   Divider,
   ExpandableSection,
@@ -47,10 +48,8 @@ import {
   Form,
   FormGroup,
 } from '@patternfly/react-core';
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { NotificationCategory, messageKeys } from '@app/Shared/Services/NotificationChannel.service';
+import * as React from 'react';
 import { UserSetting } from './Settings';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
 
 const min = 0;
 const max = 10;
@@ -64,7 +63,7 @@ const Component = () => {
 
   React.useEffect(() => {
     addSubscription(context.settings.visibleNotificationsCount().subscribe(setVisibleNotificationsCount));
-  }, [addSubscription, context.settings.visibleNotificationsCount, setVisibleNotificationsCount]);
+  }, [addSubscription, context.settings, setVisibleNotificationsCount]);
 
   const handleCheckboxChange = React.useCallback(
     (checked, element) => {
@@ -82,7 +81,7 @@ const Component = () => {
       context.settings.setNotificationsEnabled(newState);
       setState(newState);
     },
-    [state, setState]
+    [context.settings, setState, state]
   );
 
   const handleChange = React.useCallback(
@@ -95,7 +94,7 @@ const Component = () => {
       }
       context.settings.setVisibleNotificationCount(value);
     },
-    [visibleNotificationsCount, context.settings.setVisibleNotificationCount]
+    [visibleNotificationsCount, context.settings]
   );
 
   const handleVisibleStep = React.useCallback(
@@ -103,7 +102,7 @@ const Component = () => {
       const v = visibleNotificationsCount + delta;
       context.settings.setVisibleNotificationCount(v);
     },
-    [visibleNotificationsCount, context.settings.setVisibleNotificationCount]
+    [visibleNotificationsCount, context.settings]
   );
 
   const allChecked = React.useMemo(() => {
@@ -118,7 +117,7 @@ const Component = () => {
       result.set(k, v?.title || k);
     });
     return result;
-  }, [messageKeys]);
+  }, []);
 
   const switches = React.useMemo(() => {
     return Array.from(state.entries(), ([key, value]) => (
@@ -126,7 +125,7 @@ const Component = () => {
         <Switch id={key} label={labels.get(key)} isChecked={value} onChange={handleCheckboxChange} />
       </StackItem>
     ));
-  }, [state, labels]);
+  }, [handleCheckboxChange, state, labels]);
 
   return (
     <>

--- a/src/app/Settings/Settings.tsx
+++ b/src/app/Settings/Settings.tsx
@@ -36,21 +36,20 @@
  * SOFTWARE.
  */
 
-import * as React from 'react';
-import { Card, CardBody, CardTitle, Text, TextVariants } from '@patternfly/react-core';
 import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
-
-import { FeatureLevels } from './FeatureLevels';
-import { NotificationControl } from './NotificationControl';
+import { Card, CardBody, CardTitle, Text, TextVariants } from '@patternfly/react-core';
+import * as React from 'react';
+import { AutomatedAnalysisConfig } from './AutomatedAnalysisConfig';
+import { AutoRefresh } from './AutoRefresh';
 import { CredentialsStorage } from './CredentialsStorage';
 import { DeletionDialogControl } from './DeletionDialogControl';
+import { FeatureLevels } from './FeatureLevels';
+import { NotificationControl } from './NotificationControl';
 import { WebSocketDebounce } from './WebSocketDebounce';
-import { AutoRefresh } from './AutoRefresh';
-import { AutomatedAnalysisConfig } from './AutomatedAnalysisConfig';
 
 export interface SettingsProps {}
 
-export const Settings: React.FunctionComponent<SettingsProps> = (props) => {
+export const Settings: React.FC<SettingsProps> = (_) => {
   const settings = [
     NotificationControl,
     AutomatedAnalysisConfig,

--- a/src/app/Settings/WebSocketDebounce.tsx
+++ b/src/app/Settings/WebSocketDebounce.tsx
@@ -36,9 +36,9 @@
  * SOFTWARE.
  */
 
-import * as React from 'react';
-import { NumberInput } from '@patternfly/react-core';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { NumberInput } from '@patternfly/react-core';
+import * as React from 'react';
 import { UserSetting } from './Settings';
 
 const defaultPreferences = {

--- a/src/app/Shared/FeatureFlag/FeatureFlag.tsx
+++ b/src/app/Shared/FeatureFlag/FeatureFlag.tsx
@@ -57,7 +57,7 @@ export const DynamicFeatureFlag: React.FunctionComponent<DynamicFeatureFlagProps
 
   React.useLayoutEffect(() => {
     addSubscription(context.settings.featureLevel().subscribe((featureLevel) => setActiveLevel(featureLevel)));
-  }, [addSubscription, context.settings.featureLevel, setActiveLevel]);
+  }, [addSubscription, context.settings, setActiveLevel]);
 
   const toRender = React.useMemo(() => {
     if (levels.includes(activeLevel)) {

--- a/src/app/Shared/FeatureFlag/FeatureFlag.tsx
+++ b/src/app/Shared/FeatureFlag/FeatureFlag.tsx
@@ -35,10 +35,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
+import * as React from 'react';
 
 export interface DynamicFeatureFlagProps {
   levels: FeatureLevel[];

--- a/src/app/Shared/FileUploads.tsx
+++ b/src/app/Shared/FileUploads.tsx
@@ -72,8 +72,8 @@ export interface MultiFileUploadProps {
   submitRef?: React.RefObject<HTMLDivElement>;
   abortRef?: React.RefObject<HTMLDivElement>;
   uploading: boolean;
-  displayAccepts: String[];
-  dropZoneAccepts?: String[]; // Infer from displayAccepts, if not specified
+  displayAccepts: string[];
+  dropZoneAccepts?: string[]; // Infer from displayAccepts, if not specified
   onFilesChange?: (files: FUpload[]) => void;
   onFileSubmit: (fileUploads: FUpload[], uploadCallbacks: UploadCallbacks) => void;
   titleIcon?: React.ReactNode;
@@ -210,7 +210,7 @@ export const MultiFileUpload: React.FunctionComponent<MultiFileUploadProps> = ({
   );
 
   const onSingleSuccess = React.useCallback(
-    (filename: String) => {
+    (filename: string) => {
       setFileUploads((old) => {
         const match = old.find((f) => f.file.name === filename);
         if (match) {
@@ -311,7 +311,7 @@ export const MultiFileUpload: React.FunctionComponent<MultiFileUploadProps> = ({
                 file={fileUpload.file}
                 key={fileUpload.file.name}
                 onClearClick={() => handleFileRemove(fileUpload.file.name, uploading)}
-                customFileHandler={(_) => {}} // To disable built-in file reader and default styling
+                customFileHandler={(_) => undefined} // To disable built-in file reader and default styling
                 progressValue={fileUpload.progress?.progressValue}
                 progressVariant={fileUpload.progress?.progressVariant}
                 progressHelperText={fileUpload.error?.message || fileUpload.helperText}

--- a/src/app/Shared/MatchExpressionEvaluator.tsx
+++ b/src/app/Shared/MatchExpressionEvaluator.tsx
@@ -69,7 +69,11 @@ export interface MatchExpressionEvaluatorProps {
   onChange?: (validated: ValidatedOptions) => void;
 }
 
-export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEvaluatorProps> = (props) => {
+export const MatchExpressionEvaluator: React.FC<MatchExpressionEvaluatorProps> = ({
+  inlineHint,
+  matchExpression,
+  onChange,
+}) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [target, setTarget] = React.useState(undefined as Target | undefined);
@@ -81,12 +85,12 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
   }, [addSubscription, context.target, setTarget]);
 
   React.useEffect(() => {
-    if (!props.matchExpression || !target?.connectUrl) {
+    if (!matchExpression || !target?.connectUrl) {
       setValid(ValidatedOptions.default);
       return;
     }
     try {
-      const f = new Function('target', `return ${props.matchExpression}`);
+      const f = new Function('target', `return ${matchExpression}`);
       const res = f(target);
       if (typeof res === 'boolean') {
         setValid(res ? ValidatedOptions.success : ValidatedOptions.warning);
@@ -98,13 +102,13 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
       setValid(ValidatedOptions.error);
       return;
     }
-  }, [target, props.matchExpression, setValid]);
+  }, [target, matchExpression, setValid]);
 
   React.useEffect(() => {
-    if (!!props.onChange) {
-      props.onChange(valid);
+    if (onChange) {
+      onChange(valid);
     }
-  }, [props.onChange, valid]);
+  }, [onChange, valid]);
 
   const statusLabel = React.useMemo(() => {
     switch (valid) {
@@ -157,7 +161,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
   const onSaveToClipboard = React.useCallback(() => {
     setCopied(true);
     navigator.clipboard.writeText(exampleExpression);
-  }, [setCopied, navigator.clipboard, exampleExpression]);
+  }, [setCopied, exampleExpression]);
 
   const actions = React.useMemo(() => {
     return (
@@ -178,7 +182,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
         </CodeBlockAction>
       </>
     );
-  }, [exampleExpression, copied, onSaveToClipboard, setCopied]);
+  }, [copied, onSaveToClipboard, setCopied]);
 
   return (
     <>
@@ -190,7 +194,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
           <Split hasGutter isWrappable>
             <SplitItem>{statusLabel}</SplitItem>
             <SplitItem>
-              {!props.inlineHint ? (
+              {inlineHint ? (
                 <Tooltip
                   content={
                     <div>
@@ -207,7 +211,7 @@ export const MatchExpressionEvaluator: React.FunctionComponent<MatchExpressionEv
             </SplitItem>
           </Split>
         </StackItem>
-        {props.inlineHint ? (
+        {inlineHint ? (
           <StackItem>
             <Text>Hint: try an expression like</Text>
             <CodeBlock actions={actions}>

--- a/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
+++ b/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
@@ -51,7 +51,7 @@ export const enumValues = new Set(Object.values(DashboardConfigAction));
 
 export interface DashboardAddConfigActionPayload {
   name: string;
-  props: any;
+  props: object;
 }
 
 export interface DashboardDeleteConfigActionPayload {
@@ -60,7 +60,7 @@ export interface DashboardDeleteConfigActionPayload {
 
 export const dashboardCardConfigAddCardIntent = createAction(
   DashboardConfigAction.CARD_ADD,
-  (name: string, props: any) => ({
+  (name: string, props: object) => ({
     payload: {
       name,
       props,
@@ -76,7 +76,7 @@ export const dashboardCardConfigDeleteCardIntent = createAction(DashboardConfigA
 
 export interface CardConfig {
   name: string;
-  props: any;
+  props: object;
 }
 
 const INITIAL_STATE = getPersistedState('DASHBOARD_CFG', _version, {

--- a/src/app/Shared/Redux/Filters/AutomatedAnalysisFilterSlice.tsx
+++ b/src/app/Shared/Redux/Filters/AutomatedAnalysisFilterSlice.tsx
@@ -35,14 +35,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+// eslint-disable-line @typescript-eslint/no-non-null-assertion
+// because the category should never be null when inside the reducer cases
 
 import {
   AutomatedAnalysisFiltersCategories,
   AutomatedAnalysisGlobalFiltersCategories,
 } from '@app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters';
-import { getPersistedState } from '../utils';
 import { createAction, createReducer } from '@reduxjs/toolkit';
 import { WritableDraft } from 'immer/dist/internal';
+import { getPersistedState } from '../utils';
 import { UpdateFilterOptions } from './Common';
 
 const _version = '1';
@@ -250,7 +252,7 @@ export const automatedAnalysisFilterReducer = createReducer(INITIAL_STATE, (buil
     })
     .addCase(automatedAnalysisAddFilterIntent, (state, { payload }) => {
       const oldAutomatedAnalysisFilter = getAutomatedAnalysisFilter(state.state, payload.target);
-      let newAutomatedAnalysisFilter: TargetAutomatedAnalysisFilters = {
+      const newAutomatedAnalysisFilter: TargetAutomatedAnalysisFilters = {
         ...oldAutomatedAnalysisFilter,
         selectedCategory: payload.category,
         filters: createOrUpdateAutomatedAnalysisFilter(oldAutomatedAnalysisFilter.filters, {
@@ -266,7 +268,7 @@ export const automatedAnalysisFilterReducer = createReducer(INITIAL_STATE, (buil
     .addCase(automatedAnalysisDeleteFilterIntent, (state, { payload }) => {
       const oldAutomatedAnalysisFilter = getAutomatedAnalysisFilter(state.state, payload.target);
 
-      let newAutomatedAnalysisFilter: TargetAutomatedAnalysisFilters = {
+      const newAutomatedAnalysisFilter: TargetAutomatedAnalysisFilters = {
         ...oldAutomatedAnalysisFilter,
         selectedCategory: payload.category,
         filters: createOrUpdateAutomatedAnalysisFilter(oldAutomatedAnalysisFilter.filters, {
@@ -284,7 +286,7 @@ export const automatedAnalysisFilterReducer = createReducer(INITIAL_STATE, (buil
     .addCase(automatedAnalysisDeleteCategoryFiltersIntent, (state, { payload }) => {
       const oldAutomatedAnalysisFilter = getAutomatedAnalysisFilter(state.state, payload.target);
 
-      let newAutomatedAnalysisFilter: TargetAutomatedAnalysisFilters = {
+      const newAutomatedAnalysisFilter: TargetAutomatedAnalysisFilters = {
         ...oldAutomatedAnalysisFilter,
         selectedCategory: payload.category,
         filters: createOrUpdateAutomatedAnalysisFilter(oldAutomatedAnalysisFilter.filters, {

--- a/src/app/Shared/Redux/Filters/AutomatedAnalysisFilterSlice.tsx
+++ b/src/app/Shared/Redux/Filters/AutomatedAnalysisFilterSlice.tsx
@@ -35,9 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-// eslint-disable-line @typescript-eslint/no-non-null-assertion
-// because the category should never be null when inside the reducer cases
-
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   AutomatedAnalysisFiltersCategories,
   AutomatedAnalysisGlobalFiltersCategories,
@@ -73,12 +71,12 @@ export const allowedAutomatedAnalysisFilters = Object.keys(emptyAutomatedAnalysi
 export interface AutomatedAnalysisFilterActionPayload {
   target: string;
   category?: string;
-  filter?: any;
+  filter?: unknown;
 }
 
 export const automatedAnalysisAddGlobalFilterIntent = createAction(
   AutomatedAnalysisFilterAction.GLOBAL_FILTER_ADD,
-  (category: string, filter: any) => ({
+  (category: string, filter: unknown) => ({
     payload: {
       category: category,
       filter: filter,
@@ -88,7 +86,7 @@ export const automatedAnalysisAddGlobalFilterIntent = createAction(
 
 export const automatedAnalysisAddFilterIntent = createAction(
   AutomatedAnalysisFilterAction.FILTER_ADD,
-  (target: string, category: string, filter: any) => ({
+  (target: string, category: string, filter: unknown) => ({
     payload: {
       target: target,
       category: category,
@@ -99,7 +97,7 @@ export const automatedAnalysisAddFilterIntent = createAction(
 
 export const automatedAnalysisDeleteFilterIntent = createAction(
   AutomatedAnalysisFilterAction.FILTER_DELETE,
-  (target: string, category: string, filter: any) => ({
+  (target: string, category: string, filter: unknown) => ({
     payload: {
       target: target,
       category: category,
@@ -181,12 +179,12 @@ export const createOrUpdateAutomatedAnalysisFilter = (
   old: AutomatedAnalysisFiltersCategories,
   { filterValue, filterKey, deleted = false, deleteOptions }: UpdateFilterOptions
 ): AutomatedAnalysisFiltersCategories => {
-  let newFilterValues: any[];
+  let newFilterValues: unknown[];
 
   if (!old[filterKey]) {
     newFilterValues = [filterValue];
   } else {
-    const oldFilterValues = old[filterKey] as any[];
+    const oldFilterValues = old[filterKey];
     if (deleted) {
       if (deleteOptions && deleteOptions.all) {
         newFilterValues = [];

--- a/src/app/Shared/Redux/Filters/Common.tsx
+++ b/src/app/Shared/Redux/Filters/Common.tsx
@@ -38,7 +38,7 @@
 
 export interface UpdateFilterOptions {
   filterKey: string;
-  filterValue?: any;
+  filterValue?: unknown;
   deleted?: boolean;
   deleteOptions?: {
     all: boolean;

--- a/src/app/Shared/Redux/Filters/RecordingFilterSlice.tsx
+++ b/src/app/Shared/Redux/Filters/RecordingFilterSlice.tsx
@@ -37,9 +37,9 @@
  */
 
 import { RecordingFiltersCategories } from '@app/Recordings/RecordingFilters';
-import { getPersistedState } from '../utils';
 import { createAction, createReducer } from '@reduxjs/toolkit';
 import { WritableDraft } from 'immer/dist/internal';
+import { getPersistedState } from '../utils';
 import { UpdateFilterOptions } from './Common';
 
 const _version = '1';
@@ -78,13 +78,13 @@ export const allowedArchivedRecordingFilters = Object.keys(emptyArchivedRecordin
 export interface RecordingFilterActionPayload {
   target: string;
   category?: string;
-  filter?: any;
+  filter?: unknown;
   isArchived?: boolean;
 }
 
 export const recordingAddFilterIntent = createAction(
   RecordingFilterAction.FILTER_ADD,
-  (target: string, category: string, filter: any, isArchived: boolean) => ({
+  (target: string, category: string, filter: unknown, isArchived: boolean) => ({
     payload: {
       target: target,
       category: category,
@@ -96,7 +96,7 @@ export const recordingAddFilterIntent = createAction(
 
 export const recordingDeleteFilterIntent = createAction(
   RecordingFilterAction.FILTER_DELETE,
-  (target: string, category: string, filter: any, isArchived: boolean) => ({
+  (target: string, category: string, filter: unknown, isArchived: boolean) => ({
     payload: {
       target: target,
       category: category,
@@ -168,11 +168,11 @@ export const createOrUpdateRecordingFilter = (
   old: RecordingFiltersCategories,
   { filterValue, filterKey, deleted = false, deleteOptions }: UpdateFilterOptions
 ): RecordingFiltersCategories => {
-  let newFilterValues: any[];
+  let newFilterValues: unknown[];
   if (!old[filterKey]) {
     newFilterValues = [filterValue];
   } else {
-    const oldFilterValues = old[filterKey] as any[];
+    const oldFilterValues = old[filterKey] as unknown[];
     if (deleted) {
       if (deleteOptions && deleteOptions.all) {
         newFilterValues = [];

--- a/src/app/Shared/Redux/Filters/RecordingFilterSlice.tsx
+++ b/src/app/Shared/Redux/Filters/RecordingFilterSlice.tsx
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+/* eslint-disable  @typescript-eslint/no-non-null-assertion */
 import { RecordingFiltersCategories } from '@app/Recordings/RecordingFilters';
 import { createAction, createReducer } from '@reduxjs/toolkit';
 import { WritableDraft } from 'immer/dist/internal';

--- a/src/app/Shared/Redux/Middlewares/PersistMiddleware.tsx
+++ b/src/app/Shared/Redux/Middlewares/PersistMiddleware.tsx
@@ -35,7 +35,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 import { saveToLocalStorage } from '@app/utils/LocalStorage';
 import { Middleware } from '@reduxjs/toolkit';
 import { enumValues as DashboardConfigActions } from '../Configurations/DashboardConfigSlicer';
@@ -43,7 +42,8 @@ import { enumValues as AutomatedAnalysisFilterActions } from '../Filters/Automat
 import { enumValues as RecordingFilterActions } from '../Filters/RecordingFilterSlice';
 import { RootState } from '../ReduxStore';
 
-export const persistMiddleware: Middleware<{}, RootState> =  // FIXME: Don't use {} as a type (eslint)
+/* eslint-disable-next-line  @typescript-eslint/ban-types*/
+export const persistMiddleware: Middleware<{}, RootState> =
   ({ getState }) =>
   (next) =>
   (action) => {

--- a/src/app/Shared/Redux/Middlewares/PersistMiddleware.tsx
+++ b/src/app/Shared/Redux/Middlewares/PersistMiddleware.tsx
@@ -43,7 +43,7 @@ import { enumValues as AutomatedAnalysisFilterActions } from '../Filters/Automat
 import { enumValues as RecordingFilterActions } from '../Filters/RecordingFilterSlice';
 import { RootState } from '../ReduxStore';
 
-export const persistMiddleware: Middleware<{}, RootState> =
+export const persistMiddleware: Middleware<{}, RootState> =  // FIXME: Don't use {} as a type (eslint)
   ({ getState }) =>
   (next) =>
   (action) => {

--- a/src/app/Shared/Redux/utils.tsx
+++ b/src/app/Shared/Redux/utils.tsx
@@ -38,6 +38,7 @@
 
 import { getFromLocalStorage, LocalStorageKeyStrings } from '@app/utils/LocalStorage';
 
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export const getPersistedState = (key: LocalStorageKeyStrings, _version: string, defaultConfig: any): any => {
   const persisted = getFromLocalStorage(key, undefined);
   if (!persisted || persisted._version !== _version) {

--- a/src/app/Shared/SerializedTarget.tsx
+++ b/src/app/Shared/SerializedTarget.tsx
@@ -35,10 +35,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { CodeBlock, CodeBlockCode } from '@patternfly/react-core';
 import { Target } from '@app/Shared/Services/Target.service';
 import { NoTargetSelected } from '@app/TargetView/NoTargetSelected';
+import { CodeBlock, CodeBlockCode } from '@patternfly/react-core';
+import * as React from 'react';
 
 export interface SerializedTargetProps {
   target?: Target;

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -35,6 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+/* eslint-disable  @typescript-eslint/no-explicit-any */
 import { Notifications } from '@app/Notifications/Notifications';
 import { RecordingLabel } from '@app/RecordingMetadata/RecordingLabel';
 import { Rule } from '@app/Rules/Rules';
@@ -1253,7 +1254,7 @@ interface RulesResponse extends ApiV2Response {
 }
 
 interface XMLHttpResponse {
-  body: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  body: any;
   headers: object;
   respType: XMLHttpRequestResponseType;
   status: number;

--- a/src/app/Shared/Services/JmxCredentials.service.tsx
+++ b/src/app/Shared/Services/JmxCredentials.service.tsx
@@ -35,9 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { Observable, of } from 'rxjs';
-import { getFromLocalStorage } from '@app/utils/LocalStorage';
 import { Locations } from '@app/Settings/CredentialsStorage';
+import { getFromLocalStorage } from '@app/utils/LocalStorage';
+import { Observable, of } from 'rxjs';
 import { ApiService } from './Api.service';
 
 export interface Credential {
@@ -52,7 +52,7 @@ export class JmxCredentials {
   constructor(private readonly api: () => ApiService) {}
 
   setCredential(targetId: string, username: string, password: string): Observable<boolean> {
-    let location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BACKEND.key);
+    const location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BACKEND.key);
     switch (location) {
       case Locations.BACKEND.key:
         return this.api().postCredentials(`target.connectUrl == "${targetId}"`, username, password);
@@ -66,7 +66,7 @@ export class JmxCredentials {
   }
 
   getCredential(targetId: string): Observable<Credential | undefined> {
-    let location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BACKEND.key);
+    const location = getFromLocalStorage('JMX_CREDENTIAL_LOCATION', Locations.BACKEND.key);
     switch (location) {
       case Locations.BACKEND.key:
         // if this is stored on the backend then Cryostat should be using those and not prompting us to request from the user

--- a/src/app/Shared/Services/Services.tsx
+++ b/src/app/Shared/Services/Services.tsx
@@ -35,16 +35,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { NotificationsInstance } from '@app/Notifications/Notifications';
-import { TargetService, TargetInstance } from './Target.service';
-import { TargetsService } from './Targets.service';
+import * as React from 'react';
 import { ApiService } from './Api.service';
+import { JmxCredentials } from './JmxCredentials.service';
+import { LoginService } from './Login.service';
 import { NotificationChannel } from './NotificationChannel.service';
 import { ReportService } from './Report.service';
 import { SettingsService } from './Settings.service';
-import { LoginService } from './Login.service';
-import { JmxCredentials } from './JmxCredentials.service';
+import { TargetService, TargetInstance } from './Target.service';
+import { TargetsService } from './Targets.service';
 
 export interface Services {
   target: TargetService;

--- a/src/app/Shared/Services/Settings.service.tsx
+++ b/src/app/Shared/Services/Settings.service.tsx
@@ -53,7 +53,7 @@ export enum FeatureLevel {
   PRODUCTION = 2,
 }
 
-export function enumKeys<O extends Object, K extends keyof O = keyof O>(obj: O): K[] {
+export function enumKeys<O extends object, K extends keyof O = keyof O>(obj: O): K[] {
   return Object.keys(obj).filter((k) => Number.isNaN(+k)) as K[];
 }
 
@@ -139,9 +139,9 @@ export class SettingsService {
   deletionDialogsEnabled(): Map<DeleteOrDisableWarningType, boolean> {
     const value = getFromLocalStorage('DELETION_DIALOGS_ENABLED', undefined);
     if (typeof value === 'object') {
-      const obj = new Map(Array.from(Object.entries(value)));
+      const obj = new Map<string, AutomatedAnalysisRecordingConfig>(Array.from(Object.entries(value)));
       const res = new Map<DeleteOrDisableWarningType, boolean>();
-      obj.forEach((v: any) => {
+      obj.forEach((v) => {
         res.set(v[0] as DeleteOrDisableWarningType, v[1] as boolean);
       });
       for (const t in DeleteOrDisableWarningType) {
@@ -190,10 +190,9 @@ export class SettingsService {
   notificationsEnabled(): Map<NotificationCategory, boolean> {
     const value = getFromLocalStorage('NOTIFICATIONS_ENABLED', undefined);
     if (typeof value === 'object') {
-      const obj = new Map(Array.from(Object.entries(value)));
       const res = new Map<NotificationCategory, boolean>();
-      obj.forEach((v: any) => {
-        res.set(v[0] as NotificationCategory, v[1] as boolean);
+      value.forEach((v: [NotificationCategory, boolean]) => {
+        res.set(v[0], v[1]);
       });
       for (const t in NotificationCategory) {
         if (!res.has(NotificationCategory[t])) {

--- a/src/app/Shared/Services/Target.service.tsx
+++ b/src/app/Shared/Services/Target.service.tsx
@@ -61,10 +61,10 @@ export interface Target {
   jvmId?: string; // present in responses, but we do not need to provide it in requests
   connectUrl: string;
   alias: string;
-  labels?: {};
+  labels?: object;
   annotations?: {
-    cryostat: {};
-    platform: {};
+    cryostat: object;
+    platform: object;
   };
 }
 

--- a/src/app/Shared/Services/Targets.service.tsx
+++ b/src/app/Shared/Services/Targets.service.tsx
@@ -36,14 +36,14 @@
  * SOFTWARE.
  */
 
-import * as _ from 'lodash';
-import { ApiService } from './Api.service';
-import { Target } from './Target.service';
 import { Notifications } from '@app/Notifications/Notifications';
-import { NotificationCategory, NotificationChannel } from './NotificationChannel.service';
+import * as _ from 'lodash';
 import { Observable, BehaviorSubject, of, EMPTY } from 'rxjs';
 import { catchError, concatMap, first, map, tap } from 'rxjs/operators';
+import { ApiService } from './Api.service';
 import { LoginService, SessionState } from './Login.service';
+import { NotificationCategory, NotificationChannel } from './NotificationChannel.service';
+import { Target } from './Target.service';
 
 export interface TargetDiscoveryEvent {
   kind: 'LOST' | 'FOUND';

--- a/src/app/TargetSelect/CreateTargetModal.tsx
+++ b/src/app/TargetSelect/CreateTargetModal.tsx
@@ -35,9 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { Target } from '@app/Shared/Services/Target.service';
-import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   ActionGroup,
@@ -63,7 +63,11 @@ export interface CreateTargetModalProps {
 const jmxServiceUrlFormat = /service:jmx:([a-zA-Z0-9-]+)/g;
 const hostPortPairFormat = /([a-zA-Z0-9-]+):([0-9]+)/g;
 
-export const CreateTargetModal: React.FunctionComponent<CreateTargetModalProps> = (props) => {
+export const CreateTargetModal: React.FunctionComponent<CreateTargetModalProps> = ({
+  visible,
+  onSuccess,
+  onDismiss,
+}) => {
   const addSubscription = useSubscriptions();
   const context = React.useContext(ServiceContext);
 
@@ -85,12 +89,12 @@ export const CreateTargetModal: React.FunctionComponent<CreateTargetModalProps> 
           setLoading(false);
           if (success) {
             resetForm();
-            props.onSuccess();
+            onSuccess();
           }
         })
       );
     },
-    [addSubscription, context.api, props.onSuccess, setLoading, resetForm]
+    [addSubscription, context.api, onSuccess, setLoading, resetForm]
   );
 
   const handleKeyDown = React.useCallback(
@@ -125,10 +129,10 @@ export const CreateTargetModal: React.FunctionComponent<CreateTargetModalProps> 
   return (
     <>
       <Modal
-        isOpen={props.visible}
+        isOpen={visible}
         variant={ModalVariant.small}
         showClose={true}
-        onClose={props.onDismiss}
+        onClose={onDismiss}
         title="Create Target"
         description="Create a custom target connection"
       >

--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -35,10 +35,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { ServiceContext } from '@app/Shared/Services/Services';
+import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { NotificationsContext } from '@app/Notifications/Notifications';
+import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
+import { SerializedTarget } from '@app/Shared/SerializedTarget';
+import { ServiceContext } from '@app/Shared/Services/Services';
 import { isEqualTarget, NO_TARGET, Target } from '@app/Shared/Services/Target.service';
+import { NoTargetSelected } from '@app/TargetView/NoTargetSelected';
+import { getFromLocalStorage, removeFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import {
   Button,
@@ -53,14 +58,8 @@ import {
   SelectVariant,
 } from '@patternfly/react-core';
 import { ContainerNodeIcon, PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import { CreateTargetModal } from './CreateTargetModal';
-import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
-import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
-import { getFromLocalStorage, removeFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
-import { SerializedTarget } from '@app/Shared/SerializedTarget';
-import { NoTargetSelected } from '@app/TargetView/NoTargetSelected';
-import { first } from 'rxjs';
-import { LoadingPropsType } from '@app/Shared/ProgressIndicator';
 
 export const CUSTOM_TARGETS_REALM = 'Custom Targets';
 

--- a/src/app/TargetView/NoTargetSelected.tsx
+++ b/src/app/TargetView/NoTargetSelected.tsx
@@ -35,9 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { Card, CardBody, CardTitle, Text, TextVariants } from '@patternfly/react-core';
 import { DisconnectedIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 
 export const NoTargetSelected: React.FunctionComponent = () => {
   return (

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -35,14 +35,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
 import { BreadcrumbPage, BreadcrumbTrail } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { TargetSelect } from '@app/TargetSelect/TargetSelect';
-import { NoTargetSelected } from './NoTargetSelected';
-import { Grid, GridItem } from '@patternfly/react-core';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
+import { TargetSelect } from '@app/TargetSelect/TargetSelect';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { Grid, GridItem } from '@patternfly/react-core';
+import * as React from 'react';
+import { NoTargetSelected } from './NoTargetSelected';
 
 interface TargetViewProps {
   pageTitle: string;

--- a/src/app/TemplateSelector/SelectTemplateSelectorForm.tsx
+++ b/src/app/TemplateSelector/SelectTemplateSelectorForm.tsx
@@ -35,16 +35,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { FormSelect, FormSelectOption, FormSelectOptionGroup, ValidatedOptions } from '@patternfly/react-core';
-import * as React from 'react';
+//
 import { EventTemplate } from '@app/CreateRecording/CreateRecording';
 import { TemplateType } from '@app/Shared/Services/Api.service';
+import { FormSelect, FormSelectOption, FormSelectOptionGroup, ValidatedOptions } from '@patternfly/react-core';
+import * as React from 'react';
 
 export interface TemplateSelectionGroup {
   groupLabel: string;
   disabled?: boolean;
   options: {
-    value: any;
+    value: string;
     label: string;
     disabled?: boolean;
   }[];
@@ -58,13 +59,19 @@ export interface SelectTemplateSelectorFormProps {
   onSelect: (template?: string, templateType?: TemplateType) => void;
 }
 
-export const SelectTemplateSelectorForm: React.FunctionComponent<SelectTemplateSelectorFormProps> = (props) => {
+export const SelectTemplateSelectorForm: React.FunctionComponent<SelectTemplateSelectorFormProps> = ({
+  selected,
+  templates,
+  disabled,
+  validated,
+  onSelect,
+}) => {
   const groups = React.useMemo(
     () =>
       [
         {
           groupLabel: 'Target Templates',
-          options: props.templates
+          options: templates
             .filter((t) => t.type === 'TARGET')
             .map((t) => ({
               value: `${t.name},${t.type}`,
@@ -73,7 +80,7 @@ export const SelectTemplateSelectorForm: React.FunctionComponent<SelectTemplateS
         },
         {
           groupLabel: 'Custom Templates',
-          options: props.templates
+          options: templates
             .filter((t) => t.type === 'CUSTOM')
             .map((t) => ({
               value: `${t.name},${t.type}`,
@@ -81,27 +88,27 @@ export const SelectTemplateSelectorForm: React.FunctionComponent<SelectTemplateS
             })),
         },
       ] as TemplateSelectionGroup[],
-    [props.templates]
+    [templates]
   );
 
   const handleTemplateSelect = React.useCallback(
     (selected: string) => {
       if (!selected.length) {
-        props.onSelect(undefined, undefined);
+        onSelect(undefined, undefined);
       } else {
         const str = selected.split(',');
-        props.onSelect(str[0], str[1] as TemplateType);
+        onSelect(str[0], str[1] as TemplateType);
       }
     },
-    [props.onSelect]
+    [onSelect]
   );
 
   return (
     <>
       <FormSelect
-        isDisabled={props.disabled}
-        value={props.selected}
-        validated={props.validated || ValidatedOptions.default}
+        isDisabled={disabled}
+        value={selected}
+        validated={validated || ValidatedOptions.default}
         onChange={handleTemplateSelect}
         aria-label="Event Template Input"
         id="recording-template"

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -35,16 +35,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import '@patternfly/react-core/dist/styles/base.css';
-import { BrowserRouter as Router } from 'react-router-dom';
-import { AppLayout } from '@app/AppLayout/AppLayout';
-import { AppRoutes } from '@app/routes';
 import '@app/app.css';
-import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
-import { Provider } from 'react-redux';
-import { store } from '@app/Shared/Redux/ReduxStore';
+import '@patternfly/react-core/dist/styles/base.css';
+
+import { AppLayout } from '@app/AppLayout/AppLayout';
 import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
+import { AppRoutes } from '@app/routes';
+import { store } from '@app/Shared/Redux/ReduxStore';
+import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
+import * as React from 'react';
+import { Provider } from 'react-redux';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 const App: React.FunctionComponent = () => (
   <ServiceContext.Provider value={defaultServices}>

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -37,26 +37,26 @@
  */
 
 import React, { lazy, Suspense } from 'react';
+import { Route, RouteComponentProps, Switch } from 'react-router-dom';
+import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
+import { LoadingView } from './LoadingView/LoadingView';
+import { SessionState } from './Shared/Services/Login.service';
+import { ServiceContext } from './Shared/Services/Services';
+import { useDocumentTitle } from './utils/useDocumentTitle';
+import { useSubscriptions } from './utils/useSubscriptions';
+import { accessibleRouteChangeHandler } from './utils/utils';
+const About = lazy(() => import('@app/About/About'));
+const Archives = lazy(() => import('@app/Archives/Archives'));
 const CreateRecording = lazy(() => import('@app/CreateRecording/CreateRecording'));
 const Dashboard = lazy(() => import('@app/Dashboard/Dashboard'));
 const Events = lazy(() => import('@app/Events/Events'));
 const Login = lazy(() => import('@app/Login/Login'));
 const NotFound = lazy(() => import('@app/NotFound/NotFound'));
 const Recordings = lazy(() => import('@app/Recordings/Recordings'));
-const Archives = lazy(() => import('@app/Archives/Archives'));
-const Rules = lazy(() => import('@app/Rules/Rules'));
 const CreateRule = lazy(() => import('@app/Rules/CreateRule'));
+const Rules = lazy(() => import('@app/Rules/Rules'));
 const Settings = lazy(() => import('@app/Settings/Settings'));
 const SecurityPanel = lazy(() => import('@app/SecurityPanel/SecurityPanel'));
-const About = lazy(() => import('@app/About/About'));
-import { ServiceContext } from '@app/Shared/Services/Services';
-import { useDocumentTitle } from '@app/utils/useDocumentTitle';
-import { accessibleRouteChangeHandler } from '@app/utils/utils';
-import { Route, RouteComponentProps, Switch } from 'react-router-dom';
-import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
-import { SessionState } from './Shared/Services/Login.service';
-import { useSubscriptions } from './utils/useSubscriptions';
-import LoadingView from './LoadingView/LoadingView';
 
 let routeFocusTimer: number;
 const OVERVIEW = 'Overview';
@@ -209,9 +209,10 @@ const PageNotFound = ({ title }: { title: string }) => {
   return <Route component={NotFound} />;
 };
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface AppRoutesProps {}
 
-const AppRoutes: React.FunctionComponent<AppRoutesProps> = (props) => {
+const AppRoutes: React.FunctionComponent<AppRoutesProps> = (_) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [showDashboard, setShowDashboard] = React.useState(false);

--- a/src/app/utils/LocalStorage.ts
+++ b/src/app/utils/LocalStorage.ts
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export enum LocalStorageKey {
   FEATURE_LEVEL,
   DASHBOARD_CFG,

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -51,7 +51,7 @@ export const openTabForUrl = (url: string) => {
   anchor.remove();
 };
 
-export const createBlobURL = (content: any, contentType: string, timeout: number = 1000) => {
+export const createBlobURL = (content: string, contentType: string, timeout = 1000) => {
   const blob = new Blob([content], { type: contentType });
   const url = window.URL.createObjectURL(blob);
   setTimeout(() => window.URL.revokeObjectURL(url), timeout);
@@ -97,7 +97,7 @@ export interface AutomatedAnalysisTimerObject {
 
 export const calculateAnalysisTimer = (reportTime: number): AutomatedAnalysisTimerObject => {
   let interval, timerQuantity, timerUnits;
-  let now = Date.now();
+  const now = Date.now();
   const reportMillis = now - reportTime;
   if (reportMillis < MINUTE_MILLIS) {
     timerQuantity = Math.round(reportMillis / SECOND_MILLIS);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,9 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { App } from '@app/index';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { App } from '@app/index';
 
 if (process.env.NODE_ENV !== 'production') {
   const config = {

--- a/src/test/About/About.test.tsx
+++ b/src/test/About/About.test.tsx
@@ -35,12 +35,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { About } from '@app/About/About';
+import { CRYOSTAT_TRADEMARK } from '@app/About/AboutDescription';
+import { cleanup, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { cleanup, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { CRYOSTAT_TRADEMARK } from '@app/About/AboutDescription';
-import { About } from '@app/About/About';
 import { renderDefault } from '../Common';
 
 jest.mock('@app/BreadcrumbPage/BreadcrumbPage', () => {

--- a/src/test/Agent/AgentLiveProbes.test.tsx
+++ b/src/test/Agent/AgentLiveProbes.test.tsx
@@ -35,11 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
-import { cleanup, screen, within } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { of } from 'rxjs';
+import { AgentLiveProbes } from '@app/Agent/AgentLiveProbes';
+import { DeleteActiveProbes } from '@app/Modal/DeleteWarningUtils';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 import { EventProbe } from '@app/Shared/Services/Api.service';
 import {
   MessageMeta,
@@ -48,10 +46,12 @@ import {
   NotificationMessage,
 } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
-import { DeleteActiveProbes } from '@app/Modal/DeleteWarningUtils';
-import { AgentLiveProbes } from '@app/Agent/AgentLiveProbes';
+import '@testing-library/jest-dom';
+import { cleanup, screen, within } from '@testing-library/react';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { of } from 'rxjs';
 import { renderWithServiceContext } from '../Common';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };

--- a/src/test/Archives/AllArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllArchivedRecordingsTable.test.tsx
@@ -35,17 +35,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+import { AllArchivedRecordingsTable } from '@app/Archives/AllArchivedRecordingsTable';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
+import { ArchivedRecording, RecordingDirectory } from '@app/Shared/Services/Api.service';
+import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
+import '@testing-library/jest-dom';
+import { cleanup, screen, within } from '@testing-library/react';
 import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { cleanup, screen, within } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { of } from 'rxjs';
-import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
-import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
-import { AllArchivedRecordingsTable } from '@app/Archives/AllArchivedRecordingsTable';
-import { ArchivedRecording, RecordingDirectory } from '@app/Shared/Services/Api.service';
 import { renderWithServiceContext } from '../Common';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl1 = 'service:jmx:rmi://someUrl1';
 const mockJvmId1 = 'fooJvmId1';
@@ -112,7 +113,7 @@ const mockRecordingDirectory3Added: RecordingDirectory = {
 
 jest.mock('@app/Recordings/ArchivedRecordingsTable', () => {
   return {
-    ArchivedRecordingsTable: jest.fn((props) => {
+    ArchivedRecordingsTable: jest.fn((_) => {
       return <div>Archived Recordings Table</div>;
     }),
   };
@@ -247,7 +248,7 @@ describe('<AllArchivedRecordingsTable />', () => {
     let rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(3);
 
-    let firstTarget = rows[0];
+    const firstTarget = rows[0];
     const expand = within(firstTarget).getByLabelText('Details');
     await user.click(expand);
 
@@ -255,7 +256,7 @@ describe('<AllArchivedRecordingsTable />', () => {
     rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(4);
 
-    let expandedTable = rows[1];
+    const expandedTable = rows[1];
     expect(within(expandedTable).getByText('Archived Recordings Table')).toBeTruthy();
 
     await user.click(expand);
@@ -268,8 +269,8 @@ describe('<AllArchivedRecordingsTable />', () => {
   it('increments the count when an archived recording is saved', async () => {
     renderWithServiceContext(<AllArchivedRecordingsTable />);
 
-    let tableBody = screen.getAllByRole('rowgroup')[1];
-    let rows = within(tableBody).getAllByRole('row');
+    const tableBody = screen.getAllByRole('rowgroup')[1];
+    const rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(3);
 
     const thirdTarget = rows[2];
@@ -280,8 +281,8 @@ describe('<AllArchivedRecordingsTable />', () => {
   it('decrements the count when an archived recording is deleted', async () => {
     renderWithServiceContext(<AllArchivedRecordingsTable />);
 
-    let tableBody = screen.getAllByRole('rowgroup')[1];
-    let rows = within(tableBody).getAllByRole('row');
+    const tableBody = screen.getAllByRole('rowgroup')[1];
+    const rows = within(tableBody).getAllByRole('row');
 
     const thirdTarget = rows[2];
     expect(within(thirdTarget).getByText(`${mockConnectUrl3}`)).toBeTruthy();

--- a/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
@@ -35,17 +35,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { AllTargetsArchivedRecordingsTable } from '@app/Archives/AllTargetsArchivedRecordingsTable';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
+import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
+import { Target } from '@app/Shared/Services/Target.service';
+import '@testing-library/jest-dom';
+import { cleanup, screen, within } from '@testing-library/react';
 import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { cleanup, screen, within } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { of } from 'rxjs';
-import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
-import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
-import { AllTargetsArchivedRecordingsTable } from '@app/Archives/AllTargetsArchivedRecordingsTable';
-import { Target } from '@app/Shared/Services/Target.service';
 import { renderWithServiceContext } from '../Common';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl1 = 'service:jmx:rmi://someUrl1';
 const mockAlias1 = 'fooTarget1';
@@ -156,7 +156,7 @@ const mockNewTargetCountResponse = {
 
 jest.mock('@app/Recordings/ArchivedRecordingsTable', () => {
   return {
-    ArchivedRecordingsTable: jest.fn((props) => {
+    ArchivedRecordingsTable: jest.fn((_) => {
       return <div>Archived Recordings Table</div>;
     }),
   };
@@ -319,7 +319,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     let rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(2);
 
-    let firstTarget = rows[0];
+    const firstTarget = rows[0];
     const expand = within(firstTarget).getByLabelText('Details');
     await user.click(expand);
 
@@ -327,7 +327,7 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(3);
 
-    let expandedTable = rows[1];
+    const expandedTable = rows[1];
     expect(within(expandedTable).getByText('Archived Recordings Table')).toBeTruthy();
 
     await user.click(expand);
@@ -377,8 +377,8 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
   it('increments the count when an archived recording is saved', async () => {
     renderWithServiceContext(<AllTargetsArchivedRecordingsTable />);
 
-    let tableBody = screen.getAllByRole('rowgroup')[1];
-    let rows = within(tableBody).getAllByRole('row');
+    const tableBody = screen.getAllByRole('rowgroup')[1];
+    const rows = within(tableBody).getAllByRole('row');
     expect(rows).toHaveLength(3);
 
     const thirdTarget = rows[2];
@@ -391,8 +391,8 @@ describe('<AllTargetsArchivedRecordingsTable />', () => {
     const checkbox = screen.getByLabelText('all-targets-hide-check');
     await user.click(checkbox);
 
-    let tableBody = screen.getAllByRole('rowgroup')[1];
-    let rows = within(tableBody).getAllByRole('row');
+    const tableBody = screen.getAllByRole('rowgroup')[1];
+    const rows = within(tableBody).getAllByRole('row');
 
     const firstTarget = rows[0];
     expect(within(firstTarget).getByText(`${mockAlias1} (${mockConnectUrl1})`)).toBeTruthy();

--- a/src/test/Archives/Archives.test.tsx
+++ b/src/test/Archives/Archives.test.tsx
@@ -35,16 +35,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
-import * as React from 'react';
-import { cleanup, screen, within } from '@testing-library/react';
-import renderer, { act } from 'react-test-renderer';
-import '@testing-library/jest-dom';
-import { of } from 'rxjs';
 import { Archives } from '@app/Archives/Archives';
-import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
-import { renderWithServiceContext } from '../Common';
 import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
+import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
+import { cleanup, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { of } from 'rxjs';
+import { renderWithServiceContext } from '../Common';
 
 jest.mock('@app/Recordings/ArchivedRecordingsTable', () => {
   return {

--- a/src/test/Common.tsx
+++ b/src/test/Common.tsx
@@ -36,17 +36,17 @@
  * SOFTWARE.
  */
 
-import React, { PropsWithChildren } from 'react';
-import { render } from '@testing-library/react';
-import { Provider } from 'react-redux';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 import { setupStore } from '@app/Shared/Redux/ReduxStore';
 import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
-import { Router } from 'react-router-dom';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
+import React, { PropsWithChildren } from 'react';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
 // userEvent functions are recommended to be called in tests (i.e it()).
 // See https://testing-library.com/docs/user-event/intro#writing-tests-with-userevent
-import userEvent from '@testing-library/user-event';
 
 export const renderDefault = (
   ui: React.ReactElement,
@@ -56,7 +56,7 @@ export const renderDefault = (
     ...renderOptions
   } = {}
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<{}>) => {
+  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
     return <NotificationsContext.Provider value={notifications}>{children}</NotificationsContext.Provider>;
   };
   return { user, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
@@ -72,7 +72,7 @@ export const renderWithReduxStore = (
     ...renderOptions
   } = {}
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<{}>) => {
+  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
     return (
       <NotificationsContext.Provider value={notifications}>
         <Provider store={store}>{children}</Provider>
@@ -91,7 +91,7 @@ export const renderWithServiceContext = (
     ...renderOptions
   } = {}
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<{}>) => {
+  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
     return (
       <ServiceContext.Provider value={services}>
         <NotificationsContext.Provider value={notifications}>{children}</NotificationsContext.Provider>
@@ -110,7 +110,7 @@ export const renderWithRouter = (
     ...renderOptions
   } = {}
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<{}>) => {
+  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
     return (
       <NotificationsContext.Provider value={notifications}>
         <Router location={history.location} history={history}>
@@ -133,7 +133,7 @@ export const renderWithServiceContextAndReduxStore = (
     ...renderOptions
   } = {}
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<{}>) => {
+  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
     return (
       <ServiceContext.Provider value={services}>
         <NotificationsContext.Provider value={notifications}>
@@ -155,7 +155,7 @@ export const renderWithServiceContextAndRouter = (
     ...renderOptions
   } = {}
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<{}>) => {
+  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
     return (
       <ServiceContext.Provider value={services}>
         <NotificationsContext.Provider value={notifications}>
@@ -181,7 +181,7 @@ export const renderWithServiceContextAndReduxStoreWithRouter = (
     ...renderOptions
   } = {}
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<{}>) => {
+  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
     return (
       <ServiceContext.Provider value={services}>
         <NotificationsContext.Provider value={notifications}>

--- a/src/test/CreateRecording/CustomRecordingForm.test.tsx
+++ b/src/test/CreateRecording/CustomRecordingForm.test.tsx
@@ -35,14 +35,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
-import * as React from 'react';
-import { createMemoryHistory } from 'history';
-import { screen, cleanup, act as doAct } from '@testing-library/react';
-import renderer, { act } from 'react-test-renderer';
-import { ServiceContext, Services } from '@app/Shared/Services/Services';
-import { defaultServices } from '@app/Shared/Services/Services';
+import { CustomRecordingForm } from '@app/CreateRecording/CustomRecordingForm';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 import { EventTemplate, RecordingAttributes, RecordingOptions } from '@app/Shared/Services/Api.service';
+import { ServiceContext, Services, defaultServices } from '@app/Shared/Services/Services';
+import { TargetService } from '@app/Shared/Services/Target.service';
+import { screen, cleanup, act as doAct } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
 import { of, Subject } from 'rxjs';
 import { renderWithServiceContext } from '../Common';
 
@@ -51,10 +52,6 @@ jest.mock('@patternfly/react-core', () => ({
   ...jest.requireActual('@patternfly/react-core'),
   Tooltip: ({ children }) => <>{children}</>,
 }));
-
-import { CustomRecordingForm } from '@app/CreateRecording/CustomRecordingForm';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
-import { TargetService } from '@app/Shared/Services/Target.service';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };

--- a/src/test/CreateRecording/SnapshotRecordingForm.test.tsx
+++ b/src/test/CreateRecording/SnapshotRecordingForm.test.tsx
@@ -36,17 +36,16 @@
  * SOFTWARE.
  */
 
-import * as React from 'react';
-import { createMemoryHistory } from 'history';
+import { SnapshotRecordingForm } from '@app/CreateRecording/SnapshotRecordingForm';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
+import { ServiceContext, Services, defaultServices } from '@app/Shared/Services/Services';
+import { TargetService } from '@app/Shared/Services/Target.service';
 import { screen, cleanup, act as doAct } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { ServiceContext, Services } from '@app/Shared/Services/Services';
-import { defaultServices } from '@app/Shared/Services/Services';
 import { of, Subject } from 'rxjs';
 import { renderWithServiceContext } from '../Common';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
-import { TargetService } from '@app/Shared/Services/Target.service';
-import { SnapshotRecordingForm } from '@app/CreateRecording/SnapshotRecordingForm';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };

--- a/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigDrawer.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigDrawer.test.tsx
@@ -70,8 +70,8 @@ describe('<AutomatedAnalysisConfigDrawer />', () => {
       <AutomatedAnalysisConfigDrawer
         drawerContent={drawerContent}
         isContentAbove={false}
-        onCreate={() => {}}
-        onError={() => {}}
+        onCreate={() => undefined}
+        onError={() => undefined}
       />
     );
 
@@ -91,8 +91,8 @@ describe('<AutomatedAnalysisConfigDrawer />', () => {
       <AutomatedAnalysisConfigDrawer
         drawerContent={drawerContent}
         isContentAbove={false}
-        onCreate={() => {}}
-        onError={() => {}}
+        onCreate={() => undefined}
+        onError={() => undefined}
       />
     );
 
@@ -113,7 +113,7 @@ describe('<AutomatedAnalysisConfigDrawer />', () => {
         drawerContent={drawerContent}
         isContentAbove={false}
         onCreate={onCreateFunction}
-        onError={() => {}}
+        onError={() => undefined}
       />
     );
 

--- a/src/test/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel.test.tsx
@@ -37,11 +37,9 @@
  */
 
 import { ClickableAutomatedAnalysisLabel } from '@app/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel';
-import { AutomatedAnalysisNameFilter } from '@app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter';
-import { CategorizedRuleEvaluations, RuleEvaluation } from '@app/Shared/Services/Report.service';
+import { RuleEvaluation } from '@app/Shared/Services/Report.service';
 import { cleanup, screen, within } from '@testing-library/react';
 import React from 'react';
-import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../../Common';
 
 const mockRuleEvaluation1: RuleEvaluation = {
@@ -72,15 +70,6 @@ const mockNaRuleEvaluation: RuleEvaluation = {
   topic: 'fakeTopic',
 };
 
-const mockEvaluations1: RuleEvaluation[] = [mockRuleEvaluation1];
-
-const mockEvaluations2: RuleEvaluation[] = [mockRuleEvaluation2, mockRuleEvaluation3, mockNaRuleEvaluation];
-
-const mockCategorizedEvaluations: CategorizedRuleEvaluations[] = [
-  [mockRuleEvaluation1.topic, mockEvaluations1],
-  [mockRuleEvaluation2.topic, mockEvaluations2],
-];
-
 describe('<ClickableAutomatedAnalysisLabel />', () => {
   afterEach(cleanup);
 
@@ -95,7 +84,6 @@ describe('<ClickableAutomatedAnalysisLabel />', () => {
 
     expect(screen.getByText(mockRuleEvaluation1.name)).toBeInTheDocument();
 
-    await user.hover(screen.getByText(mockRuleEvaluation1.name));
     await user.click(screen.getByText(mockRuleEvaluation1.name));
 
     const closeButton = screen.getByRole('button', {
@@ -124,7 +112,6 @@ describe('<ClickableAutomatedAnalysisLabel />', () => {
 
     expect(screen.getByText(mockRuleEvaluation2.name)).toBeInTheDocument();
 
-    await user.hover(screen.getByText(mockRuleEvaluation2.name));
     await user.click(screen.getByText(mockRuleEvaluation2.name));
 
     const closeButton = screen.getByRole('button', {
@@ -153,7 +140,6 @@ describe('<ClickableAutomatedAnalysisLabel />', () => {
 
     expect(screen.getByText(mockRuleEvaluation3.name)).toBeInTheDocument();
 
-    await user.hover(screen.getByText(mockRuleEvaluation3.name));
     await user.click(screen.getByText(mockRuleEvaluation3.name));
 
     const closeButton = screen.getByRole('button', {
@@ -182,7 +168,6 @@ describe('<ClickableAutomatedAnalysisLabel />', () => {
 
     expect(screen.getByText(mockNaRuleEvaluation.name)).toBeInTheDocument();
 
-    await user.hover(screen.getByText(mockNaRuleEvaluation.name));
     await user.click(screen.getByText(mockNaRuleEvaluation.name));
 
     const closeButton = screen.getByRole('button', {

--- a/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.test.tsx
@@ -82,7 +82,7 @@ const mockCategorizedEvaluations: CategorizedRuleEvaluations[] = [
 
 const allMockEvaluations = mockEvaluations1.concat(mockEvaluations2);
 
-const onNameInput = jest.fn((nameInput) => {
+const onNameInput = jest.fn((_nameInput) => {
   /**Do nothing. Used for checking renders */
 });
 

--- a/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.test.tsx
@@ -89,20 +89,8 @@ describe('<AutomatedAnalysisScoreFilter />', () => {
 
   afterEach(cleanup);
 
-  // it('renders correctly', async () => {
-  //   let tree;
-  //   await act(async () => {
-  //     tree = renderer.create(
-  //       <Provider store={setupStore(preloadedState)}>
-  //         <AutomatedAnalysisScoreFilter targetConnectUrl={mockTargetConnectUrl} />
-  //       </Provider>
-  //     );
-  //   });
-  //   expect(tree.toJSON()).toMatchSnapshot();
-  // });
-
   it('resets to 0 and 100 when clicking reset buttons', async () => {
-    const { user } = renderWithReduxStore(<AutomatedAnalysisScoreFilter targetConnectUrl={mockTargetConnectUrl} />, {
+    const { user } = renderWithReduxStore(<AutomatedAnalysisScoreFilter />, {
       preloadState: preloadedState,
     });
     const resetTo0Button = screen.getByRole('button', {
@@ -125,7 +113,7 @@ describe('<AutomatedAnalysisScoreFilter />', () => {
   });
 
   it('responds to score filter changes', async () => {
-    const { user } = renderWithReduxStore(<AutomatedAnalysisScoreFilter targetConnectUrl={mockTargetConnectUrl} />, {
+    const { user } = renderWithReduxStore(<AutomatedAnalysisScoreFilter />, {
       preloadState: preloadedState,
     });
     const sliderValue = screen.getByRole('spinbutton', {

--- a/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.test.tsx
@@ -82,7 +82,7 @@ const mockCategorizedEvaluations: CategorizedRuleEvaluations[] = [
 
 const allMockEvaluations = mockEvaluations1.concat(mockEvaluations2);
 
-const onTopicInput = jest.fn((nameInput) => {
+const onTopicInput = jest.fn((_nameInput) => {
   /**Do nothing. Used for checking renders */
 });
 

--- a/src/test/Dashboard/Dashboard.test.tsx
+++ b/src/test/Dashboard/Dashboard.test.tsx
@@ -36,15 +36,14 @@
  * SOFTWARE.
  */
 import { Dashboard } from '@app/Dashboard/Dashboard';
-import { act } from 'react-test-renderer';
-import renderer from 'react-test-renderer';
-import React from 'react';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
+import { store } from '@app/Shared/Redux/ReduxStore';
 import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
 import { Target } from '@app/Shared/Services/Target.service';
-import { of } from 'rxjs';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
+import React from 'react';
 import { Provider } from 'react-redux';
-import { store } from '@app/Shared/Redux/ReduxStore';
+import renderer, { act } from 'react-test-renderer';
+import { of } from 'rxjs';
 
 const mockFooConnectUrl = 'service:jmx:rmi://someFooUrl';
 
@@ -58,11 +57,11 @@ const mockFooTarget: Target = {
 };
 
 jest.mock('@app/TargetSelect/TargetSelect', () => ({
-  TargetSelect: (props) => <div>Target Select</div>,
+  TargetSelect: (_) => <div>Target Select</div>,
 }));
 
 jest.mock('@app/Dashboard/AddCard', () => ({
-  AddCard: (props) => <div>Add Card</div>,
+  AddCard: (_) => <div>Add Card</div>,
 }));
 
 jest

--- a/src/test/Events/EventTemplates.test.tsx
+++ b/src/test/Events/EventTemplates.test.tsx
@@ -35,19 +35,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
-import { act as doAct, cleanup, screen, within } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { of, Subject } from 'rxjs';
+import { EventTemplates } from '@app/Events/EventTemplates';
+import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 import { EventTemplate } from '@app/Shared/Services/Api.service';
 import { MessageMeta, MessageType, NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/Services';
-import { EventTemplates } from '@app/Events/EventTemplates';
-import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { TargetService } from '@app/Shared/Services/Target.service';
+import '@testing-library/jest-dom';
+import { act as doAct, cleanup, screen, within } from '@testing-library/react';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { of, Subject } from 'rxjs';
 import { renderWithServiceContextAndRouter } from '../Common';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };

--- a/src/test/Events/EventTypes.test.tsx
+++ b/src/test/Events/EventTypes.test.tsx
@@ -35,16 +35,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
-import { act as doAct, cleanup, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { of, Subject } from 'rxjs';
+import { EventType, EventTypes } from '@app/Events/EventTypes';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/Services';
 import { TargetService } from '@app/Shared/Services/Target.service';
-import { EventType, EventTypes } from '@app/Events/EventTypes';
+import { act as doAct, cleanup, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { of, Subject } from 'rxjs';
 import { renderWithServiceContext } from '../Common';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };

--- a/src/test/LoadingView/LoadingView.test.tsx
+++ b/src/test/LoadingView/LoadingView.test.tsx
@@ -36,10 +36,10 @@
  * SOFTWARE.
  */
 
+import { LoadingView } from '@app/LoadingView/LoadingView';
+import { cleanup, render, screen } from '@testing-library/react';
 import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { cleanup, render, screen } from '@testing-library/react';
-import LoadingView from '@app/LoadingView/LoadingView';
 
 describe('<LoadingView />', () => {
   afterEach(cleanup);

--- a/src/test/RecordingMetadata/BulkEditLabels.test.tsx
+++ b/src/test/RecordingMetadata/BulkEditLabels.test.tsx
@@ -35,17 +35,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
-import { cleanup, screen } from '@testing-library/react';
-import { of } from 'rxjs';
-import '@testing-library/jest-dom';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 import { BulkEditLabels } from '@app/RecordingMetadata/BulkEditLabels';
-import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { ActiveRecording, ArchivedRecording, RecordingState } from '@app/Shared/Services/Api.service';
 import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
+import '@testing-library/jest-dom';
+import { cleanup, screen } from '@testing-library/react';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { of } from 'rxjs';
 import { renderWithServiceContext } from '../Common';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 jest.mock('@patternfly/react-core', () => ({
   ...jest.requireActual('@patternfly/react-core'),
@@ -254,7 +254,7 @@ describe('<BulkEditLabels />', () => {
 
     await user.click(editButton);
 
-    let addLabelButton = screen.getByRole('button', { name: 'Add Label' });
+    const addLabelButton = screen.getByRole('button', { name: 'Add Label' });
     expect(addLabelButton).toBeInTheDocument();
     expect(addLabelButton).toBeVisible();
 
@@ -294,13 +294,13 @@ describe('<BulkEditLabels />', () => {
       <BulkEditLabels checkedIndices={activeCheckedIndices} isTargetRecording={true} />
     );
 
-    let editButton = screen.getByRole('button', { name: 'Edit Labels' });
+    const editButton = screen.getByRole('button', { name: 'Edit Labels' });
     expect(editButton).toBeInTheDocument();
     expect(editButton).toBeVisible();
 
     await user.click(editButton);
 
-    let addLabelButton = screen.getByRole('button', { name: 'Add Label' });
+    const addLabelButton = screen.getByRole('button', { name: 'Add Label' });
     expect(addLabelButton).toBeInTheDocument();
     expect(addLabelButton).toBeVisible();
 
@@ -337,13 +337,13 @@ describe('<BulkEditLabels />', () => {
       <BulkEditLabels checkedIndices={archivedCheckedIndices} isTargetRecording={false} />
     );
 
-    let editButton = screen.getByRole('button', { name: 'Edit Labels' });
+    const editButton = screen.getByRole('button', { name: 'Edit Labels' });
     expect(editButton).toBeInTheDocument();
     expect(editButton).toBeVisible();
 
     await user.click(editButton);
 
-    let addLabelButton = screen.getByRole('button', { name: 'Add Label' });
+    const addLabelButton = screen.getByRole('button', { name: 'Add Label' });
     expect(addLabelButton).toBeInTheDocument();
     expect(addLabelButton).toBeVisible();
 

--- a/src/test/RecordingMetadata/ClickableLabel.test.tsx
+++ b/src/test/RecordingMetadata/ClickableLabel.test.tsx
@@ -73,13 +73,12 @@
  * SOFTWARE.
  */
 
-import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
-import { cleanup, screen } from '@testing-library/react';
-
-import '@testing-library/jest-dom';
 import { ClickableLabel } from '@app/RecordingMetadata/ClickableLabel';
 import { RecordingLabel } from '@app/RecordingMetadata/RecordingLabel';
+import '@testing-library/jest-dom';
+import { cleanup, screen } from '@testing-library/react';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../Common';
 
 const mockLabel = {
@@ -88,7 +87,7 @@ const mockLabel = {
 } as RecordingLabel;
 const mockLabelAsString = 'someLabel: someValue';
 
-const onLabelClick = jest.fn((label: RecordingLabel) => {
+const onLabelClick = jest.fn((_label: RecordingLabel) => {
   /**Do nothing. Used for checking renders */
 });
 

--- a/src/test/RecordingMetadata/LabelCell.test.tsx
+++ b/src/test/RecordingMetadata/LabelCell.test.tsx
@@ -35,16 +35,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
-import { cleanup, screen } from '@testing-library/react';
 
-import '@testing-library/jest-dom';
 import { LabelCell } from '@app/RecordingMetadata/LabelCell';
 import { RecordingLabel } from '@app/RecordingMetadata/RecordingLabel';
-import { Target } from '@app/Shared/Services/Target.service';
-import userEvent from '@testing-library/user-event';
 import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
+import { Target } from '@app/Shared/Services/Target.service';
+import '@testing-library/jest-dom';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../Common';
 
 const mockFooTarget: Target = {
@@ -71,7 +71,7 @@ const mockLabelStringList = mockLabelStringDisplayList.map((s: string) => s.repl
 describe('<LabelCell />', () => {
   let onUpdateLabels: (target: string, updateFilterOptions: UpdateFilterOptions) => void;
   beforeEach(() => {
-    onUpdateLabels = jest.fn((target: string, options: UpdateFilterOptions) => {});
+    onUpdateLabels = jest.fn((_target: string, _options: UpdateFilterOptions) => undefined);
   });
 
   afterEach(cleanup);

--- a/src/test/RecordingMetadata/RecordingLabelFields.test.tsx
+++ b/src/test/RecordingMetadata/RecordingLabelFields.test.tsx
@@ -35,14 +35,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import * as tlr from '@testing-library/react';
-import renderer, { act } from 'react-test-renderer';
-import { cleanup, screen } from '@testing-library/react';
 import { RecordingLabel } from '@app/RecordingMetadata/RecordingLabel';
-import '@testing-library/jest-dom';
 import { RecordingLabelFields, RecordingLabelFieldsProps } from '@app/RecordingMetadata/RecordingLabelFields';
 import { ValidatedOptions } from '@patternfly/react-core';
+import '@testing-library/jest-dom';
+import * as tlr from '@testing-library/react';
+import { cleanup, screen } from '@testing-library/react';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../Common';
 
 const mockUploadedRecordingLabels = {
@@ -276,6 +276,7 @@ describe('<RecordingLabelFields />', () => {
     });
 
     expect(labelUploadInput.files).not.toBe(null);
+    /* eslint-disable  @typescript-eslint/no-non-null-assertion */
     expect(labelUploadInput.files![0]).toStrictEqual(mockMetadataFile);
 
     expect(mockProps.setLabels).toHaveBeenCalledTimes(1);

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -35,13 +35,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { createMemoryHistory } from 'history';
-import { act, cleanup, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { of, Subject } from 'rxjs';
+import { DeleteActiveRecordings, DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
+import { ActiveRecordingsTable } from '@app/Recordings/ActiveRecordingsTable';
+import {
+  emptyActiveRecordingFilters,
+  emptyArchivedRecordingFilters,
+  TargetRecordingFilters,
+} from '@app/Shared/Redux/Filters/RecordingFilterSlice';
+import { RootState } from '@app/Shared/Redux/ReduxStore';
 import { ActiveRecording, RecordingState } from '@app/Shared/Services/Api.service';
 import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
+import { defaultServices, Services } from '@app/Shared/Services/Services';
+import { TargetService } from '@app/Shared/Services/Target.service';
+import { act, cleanup, screen, within } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import * as React from 'react';
+import { of, Subject } from 'rxjs';
+import { renderWithServiceContextAndReduxStoreWithRouter } from '../Common';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };
@@ -93,18 +104,6 @@ jest.mock('@app/Recordings/RecordingFilters', () => {
     }),
   };
 });
-
-import { ActiveRecordingsTable } from '@app/Recordings/ActiveRecordingsTable';
-import { defaultServices, Services } from '@app/Shared/Services/Services';
-import { DeleteActiveRecordings, DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
-import {
-  emptyActiveRecordingFilters,
-  emptyArchivedRecordingFilters,
-  TargetRecordingFilters,
-} from '@app/Shared/Redux/Filters/RecordingFilterSlice';
-import { RootState } from '@app/Shared/Redux/ReduxStore';
-import { renderWithServiceContextAndReduxStoreWithRouter } from '../Common';
-import { TargetService } from '@app/Shared/Services/Target.service';
 
 jest.spyOn(defaultServices.api, 'archiveRecording').mockReturnValue(of(true));
 jest.spyOn(defaultServices.api, 'deleteRecording').mockReturnValue(of(true));

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -35,24 +35,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { createMemoryHistory } from 'history';
-import { of, Subject } from 'rxjs';
-import { Text } from '@patternfly/react-core';
-import { screen, within, waitFor, cleanup } from '@testing-library/react';
-import * as tlr from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { ArchivedRecording, UPLOADS_SUBDIRECTORY } from '@app/Shared/Services/Api.service';
-import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
-import { ArchivedRecordingsTable } from '@app/Recordings/ArchivedRecordingsTable';
-import { defaultServices } from '@app/Shared/Services/Services';
 import { DeleteArchivedRecordings, DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
+import { ArchivedRecordingsTable } from '@app/Recordings/ArchivedRecordingsTable';
 import {
   emptyActiveRecordingFilters,
   emptyArchivedRecordingFilters,
   TargetRecordingFilters,
 } from '@app/Shared/Redux/Filters/RecordingFilterSlice';
 import { RootState } from '@app/Shared/Redux/ReduxStore';
+import { ArchivedRecording, UPLOADS_SUBDIRECTORY } from '@app/Shared/Services/Api.service';
+import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
+import { defaultServices } from '@app/Shared/Services/Services';
+import { Text } from '@patternfly/react-core';
+import '@testing-library/jest-dom';
+import * as tlr from '@testing-library/react';
+import { screen, within, cleanup } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import * as React from 'react';
+import { of, Subject } from 'rxjs';
 import { renderWithServiceContextAndReduxStoreWithRouter } from '../Common';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
@@ -109,7 +109,7 @@ const history = createMemoryHistory({ initialEntries: ['/archives'] });
 
 jest.mock('@app/RecordingMetadata/BulkEditLabels', () => {
   return {
-    BulkEditLabels: (props: any) => <Text>Edit Recording Labels</Text>,
+    BulkEditLabels: (_) => <Text>Edit Recording Labels</Text>,
   };
 });
 
@@ -659,6 +659,7 @@ describe('<ArchivedRecordingsTable />', () => {
     await user.upload(labelUploadInput, mockMetadataFile);
 
     expect(labelUploadInput.files).not.toBe(null);
+    /* eslint-disable  @typescript-eslint/no-non-null-assertion */
     expect(labelUploadInput.files![0]).toStrictEqual(mockMetadataFile);
 
     const submitButton = within(modal).getByText('Submit');
@@ -741,6 +742,7 @@ describe('<ArchivedRecordingsTable />', () => {
     });
 
     expect(labelUploadInput.files).not.toBe(null);
+    /* eslint-disable  @typescript-eslint/no-non-null-assertion */
     expect(labelUploadInput.files![0]).toStrictEqual(invalidMetadataFile);
 
     const warningTitle = screen.getByText('Invalid Selection');
@@ -753,7 +755,7 @@ describe('<ArchivedRecordingsTable />', () => {
   });
 
   it('should show error view if failing to retrieve recordings', async () => {
-    jest.spyOn(defaultServices.api, 'graphql').mockImplementationOnce((query) => {
+    jest.spyOn(defaultServices.api, 'graphql').mockImplementationOnce((_query) => {
       throw new Error('Something wrong');
     });
 

--- a/src/test/Recordings/Filters/DateTimePicker.test.tsx
+++ b/src/test/Recordings/Filters/DateTimePicker.test.tsx
@@ -40,13 +40,13 @@
 const mockCurrentDate = new Date('14 Sep 2022 00:00:00 UTC');
 jest.useFakeTimers('modern').setSystemTime(mockCurrentDate);
 
-import React from 'react';
-import { cleanup, screen, waitFor, within } from '@testing-library/react';
-import { renderDefault } from '../../Common';
-import userEvent from '@testing-library/user-event';
 import { DateTimePicker } from '@app/Recordings/Filters/DateTimePicker';
+import { cleanup, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { renderDefault } from '../../Common';
 
-const onDateTimeSelect = jest.fn((date) => {});
+const onDateTimeSelect = jest.fn((_date) => undefined);
 
 describe('<DateTimePicker />', () => {
   afterEach(cleanup);
@@ -300,7 +300,7 @@ describe('<DateTimePicker />', () => {
   });
 
   it('should disable search icon when no date is selected', async () => {
-    const { user } = renderDefault(<DateTimePicker onSubmit={onDateTimeSelect} />, {
+    renderDefault(<DateTimePicker onSubmit={onDateTimeSelect} />, {
       user: userEvent.setup({ advanceTimers: jest.advanceTimersByTime }),
     });
 

--- a/src/test/Recordings/Filters/DurationFilter.test.tsx
+++ b/src/test/Recordings/Filters/DurationFilter.test.tsx
@@ -61,8 +61,8 @@ const mockRecording: ActiveRecording = {
   maxAge: 0,
 };
 
-const onDurationInput = jest.fn((durationInput) => {});
-const onContinuousSelect = jest.fn((continuous) => {});
+const onDurationInput = jest.fn((_durationInput) => undefined);
+const onContinuousSelect = jest.fn((_continuous) => undefined);
 
 describe('<DurationFilter />', () => {
   let emptyFilteredDuration: string[];
@@ -122,14 +122,14 @@ describe('<DurationFilter />', () => {
   });
 
   it('should select continous when clicking unchecked continuous box', async () => {
-    const submitContinous = jest.fn((continous) => {
+    const submitContinuous = jest.fn((_continous) => {
       filteredDurationsWithoutCont.push('continuous');
     });
 
     const { user } = renderDefault(
       <DurationFilter
         durations={filteredDurationsWithoutCont}
-        onContinuousDurationSelect={submitContinous}
+        onContinuousDurationSelect={submitContinuous}
         onDurationInput={onDurationInput}
       />
     );
@@ -141,21 +141,21 @@ describe('<DurationFilter />', () => {
 
     await user.click(checkBox);
 
-    expect(submitContinous).toHaveBeenCalledTimes(1);
-    expect(submitContinous).toHaveBeenCalledWith(true);
+    expect(submitContinuous).toHaveBeenCalledTimes(1);
+    expect(submitContinuous).toHaveBeenCalledWith(true);
 
     expect(filteredDurationsWithoutCont).toStrictEqual([`${mockRecording.duration}`, 'continuous']);
   });
 
   it('should unselect continous when clicking checked continuous box', async () => {
-    const submitContinous = jest.fn((continous) => {
+    const submitContinuous = jest.fn((_continous) => {
       filteredDurationsWithCont = filteredDurationsWithCont.filter((v) => v !== 'continuous');
     });
 
     const { user } = renderDefault(
       <DurationFilter
         durations={filteredDurationsWithCont}
-        onContinuousDurationSelect={submitContinous}
+        onContinuousDurationSelect={submitContinuous}
         onDurationInput={onDurationInput}
       />
     );
@@ -167,8 +167,8 @@ describe('<DurationFilter />', () => {
 
     await user.click(checkBox);
 
-    expect(submitContinous).toHaveBeenCalledTimes(1);
-    expect(submitContinous).toHaveBeenCalledWith(false);
+    expect(submitContinuous).toHaveBeenCalledTimes(1);
+    expect(submitContinuous).toHaveBeenCalledWith(false);
     expect(filteredDurationsWithCont).toStrictEqual([`${mockRecording.duration}`]);
   });
 

--- a/src/test/Recordings/Filters/LabelFilter.test.tsx
+++ b/src/test/Recordings/Filters/LabelFilter.test.tsx
@@ -77,7 +77,7 @@ const mockRecordingWithoutLabel = {
 } as ActiveRecording;
 const mockRecordingList = [mockRecording, mockAnotherRecording, mockRecordingWithoutLabel];
 
-const onLabelInput = jest.fn((label) => {
+const onLabelInput = jest.fn((_label) => {
   /**Do nothing. Used for checking renders */
 });
 

--- a/src/test/Recordings/Filters/NameFilter.test.tsx
+++ b/src/test/Recordings/Filters/NameFilter.test.tsx
@@ -63,7 +63,7 @@ const mockRecording: ActiveRecording = {
 const mockAnotherRecording = { ...mockRecording, name: 'anotherRecording' };
 const mockRecordingList = [mockRecording, mockAnotherRecording];
 
-const onNameInput = jest.fn((nameInput) => {
+const onNameInput = jest.fn((_nameInput) => {
   /**Do nothing. Used for checking renders */
 });
 

--- a/src/test/Recordings/Filters/RecordingStateFilter.test.tsx
+++ b/src/test/Recordings/Filters/RecordingStateFilter.test.tsx
@@ -66,7 +66,7 @@ const mockAnotherRecording = {
   state: RecordingState.STOPPED,
 } as ActiveRecording;
 
-const onStateSelectToggle = jest.fn((state) => {
+const onStateSelectToggle = jest.fn((_state) => {
   /**Do nothing. Used for checking renders */
 });
 

--- a/src/test/Recordings/RecordingFilters.test.tsx
+++ b/src/test/Recordings/RecordingFilters.test.tsx
@@ -104,7 +104,7 @@ const mockArchivedRecordingList = [
 const activeCategoryOptions = Object.keys({} as RecordingFiltersCategories);
 const archivedCategoryOptions = ['Name', 'Label'];
 
-const updateFilters = jest.fn((target: string, options: UpdateFilterOptions) => {});
+const updateFilters = jest.fn((_target: string, _options: UpdateFilterOptions) => undefined);
 
 describe('<RecordingFilters />', () => {
   let preloadedState: RootState;
@@ -334,7 +334,7 @@ describe('<RecordingFilters />', () => {
 
     await user.click(selectedItem);
 
-    let categoryMenu = await screen.findByRole('menu');
+    const categoryMenu = await screen.findByRole('menu');
     expect(categoryMenu).toBeInTheDocument();
     expect(categoryMenu).toBeVisible();
 
@@ -479,7 +479,7 @@ describe('<RecordingFilters />', () => {
     );
 
     activeCategoryOptions.forEach((category) => {
-      let chipGroup = screen.queryByRole('group', { name: category });
+      const chipGroup = screen.queryByRole('group', { name: category });
       expect(chipGroup).not.toBeInTheDocument();
     });
   });

--- a/src/test/Recordings/RecordingLabelsPanel.test.tsx
+++ b/src/test/Recordings/RecordingLabelsPanel.test.tsx
@@ -35,10 +35,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { RecordingLabelsPanel } from '@app/Recordings/RecordingLabelsPanel';
+import { ArchivedRecording } from '@app/Shared/Services/Api.service';
+import { Drawer, DrawerContent } from '@patternfly/react-core';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { renderDefault } from '../Common';
 
 jest.mock('@app/RecordingMetadata/BulkEditLabels', () => {
   return {
@@ -52,11 +56,6 @@ jest.mock('@app/RecordingMetadata/BulkEditLabels', () => {
     }),
   };
 });
-
-import { RecordingLabelsPanel } from '@app/Recordings/RecordingLabelsPanel';
-import { ArchivedRecording } from '@app/Shared/Services/Api.service';
-import { Drawer, DrawerContent } from '@patternfly/react-core';
-import { renderDefault } from '../Common';
 
 const mockRecordingLabels = {
   someLabel: 'someValue',
@@ -72,12 +71,12 @@ const mockRecording: ArchivedRecording = {
 };
 
 describe('<RecordingLabelsPanel />', () => {
-  let isTargetRecording = true;
-  let checkedIndices = [];
-  let recordings = [mockRecording];
+  const isTargetRecording = true;
+  const checkedIndices = [];
+  const recordings = [mockRecording];
 
   const props = {
-    setShowPanel: jest.fn(() => (showPanel: boolean) => {}),
+    setShowPanel: jest.fn(() => (_showPanel: boolean) => undefined),
     isTargetRecording: isTargetRecording,
     checkedIndices: checkedIndices,
     recordings: recordings,

--- a/src/test/Recordings/Recordings.test.tsx
+++ b/src/test/Recordings/Recordings.test.tsx
@@ -35,20 +35,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
+import { Recordings } from '@app/Recordings/Recordings';
+import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
+import { Target } from '@app/Shared/Services/Target.service';
 import { cleanup, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';
-import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
-import { Recordings } from '@app/Recordings/Recordings';
-import { Target } from '@app/Shared/Services/Target.service';
 import { renderWithServiceContext } from '../Common';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 jest.mock('@app/Recordings/ActiveRecordingsTable', () => {
   return {
-    ActiveRecordingsTable: jest.fn((props) => {
+    ActiveRecordingsTable: jest.fn((_) => {
       return <div>Active Recordings Table</div>;
     }),
   };
@@ -56,7 +56,7 @@ jest.mock('@app/Recordings/ActiveRecordingsTable', () => {
 
 jest.mock('@app/Recordings/ArchivedRecordingsTable', () => {
   return {
-    ArchivedRecordingsTable: jest.fn((props) => {
+    ArchivedRecordingsTable: jest.fn((_) => {
       return <div>Archived Recordings Table</div>;
     }),
   };

--- a/src/test/Recordings/RecordingsTable.test.tsx
+++ b/src/test/Recordings/RecordingsTable.test.tsx
@@ -35,12 +35,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { cleanup, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { RecordingsTable } from '@app/Recordings/RecordingsTable';
 import { Button, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import { Tbody, Tr, Td } from '@patternfly/react-table';
-import { RecordingsTable } from '@app/Recordings/RecordingsTable';
+import '@testing-library/jest-dom';
+import { cleanup, screen } from '@testing-library/react';
+import * as React from 'react';
 import { renderDefault } from '../Common';
 
 const FakeToolbar = () => {
@@ -76,7 +76,7 @@ const fakeTableRows = (
   </Tbody>
 );
 
-const mockHeaderCheckCallback = jest.fn((event, checked) => {
+const mockHeaderCheckCallback = jest.fn((_event, _checked) => {
   /* do nothing */
 });
 
@@ -230,7 +230,7 @@ describe('<RecordingsTable />', () => {
       </RecordingsTable>
     );
 
-    let headerCheckAll = screen.getByLabelText('Select all rows');
+    const headerCheckAll = screen.getByLabelText('Select all rows');
     expect(headerCheckAll).not.toHaveAttribute('checked');
     await user.click(headerCheckAll);
     expect(mockHeaderCheckCallback).toHaveBeenCalledTimes(1);
@@ -253,7 +253,7 @@ describe('<RecordingsTable />', () => {
       </RecordingsTable>
     );
 
-    let headerCheckAll = screen.getByLabelText('Select all rows');
+    const headerCheckAll = screen.getByLabelText('Select all rows');
     expect(headerCheckAll).toHaveAttribute('checked');
   });
 });

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -117,7 +117,7 @@ describe('<CreateRule />', () => {
     const subj = new Subject<void>();
     const mockTargetSvc = {
       target: () => of(mockTarget),
-      setTarget: (target) => {},
+      setTarget: (_) => undefined,
       authFailure: () => subj.asObservable(),
     } as TargetService;
     const services: Services = {

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -35,23 +35,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import { Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
-import { of, Subject } from 'rxjs';
-import '@testing-library/jest-dom';
-import renderer, { act } from 'react-test-renderer';
-import { act as doAct, cleanup, screen, within } from '@testing-library/react';
+import { DeleteAutomatedRules, DeleteOrDisableWarningType, DisableAutomatedRules } from '@app/Modal/DeleteWarningUtils';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 import { Rules, Rule } from '@app/Rules/Rules';
-import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/Services';
 import {
   NotificationCategory,
   NotificationChannel,
   NotificationMessage,
 } from '@app/Shared/Services/NotificationChannel.service';
-import { DeleteAutomatedRules, DeleteOrDisableWarningType, DisableAutomatedRules } from '@app/Modal/DeleteWarningUtils';
+import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/Services';
+import '@testing-library/jest-dom';
+import { act as doAct, cleanup, screen, within } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import * as React from 'react';
+import { Router } from 'react-router-dom';
+import renderer, { act } from 'react-test-renderer';
+import { of, Subject } from 'rxjs';
 import { renderWithServiceContextAndRouter } from '../Common';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockRule: Rule = {
   name: 'mockRule',

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -65,8 +65,8 @@ const mockRule: Rule = {
   maxAgeSeconds: 0,
   maxSizeBytes: 0,
 };
-const mockRuleListResponse = { data: { result: [mockRule] as Rule[] } };
-const mockRuleListEmptyResponse = { data: { result: [] as Rule[] } };
+const mockRuleListResponse = [mockRule] as Rule[];
+const mockRuleListEmptyResponse = [] as Rule[];
 
 const mockFileUpload = new File([JSON.stringify(mockRule)], `${mockRule.name}.json`, { type: 'application/json' });
 mockFileUpload.text = jest.fn(() => Promise.resolve(JSON.stringify(mockRule)));
@@ -86,8 +86,9 @@ jest.mock('react-router-dom', () => ({
 const downloadSpy = jest.spyOn(defaultServices.api, 'downloadRule').mockReturnValue();
 const uploadSpy = jest.spyOn(defaultServices.api, 'uploadRule').mockReturnValue(of(true));
 const updateSpy = jest.spyOn(defaultServices.api, 'updateRule').mockReturnValue(of(true));
+
 jest
-  .spyOn(defaultServices.api, 'doGet')
+  .spyOn(defaultServices.api, 'getRules')
   .mockReturnValueOnce(of(mockRuleListEmptyResponse)) // renders correctly empty
   .mockReturnValue(of(mockRuleListResponse));
 

--- a/src/test/SecurityPanel/Credentials/StoreJmxCredentials.test.tsx
+++ b/src/test/SecurityPanel/Credentials/StoreJmxCredentials.test.tsx
@@ -35,22 +35,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { DeleteJMXCredentials, DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
+import { CreateJmxCredentialModalProps } from '@app/SecurityPanel/Credentials/CreateJmxCredentialModal';
+import { StoreJmxCredentials } from '@app/SecurityPanel/Credentials/StoreJmxCredentials';
+import { MatchedCredential, StoredCredential } from '@app/Shared/Services/Api.service';
+import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
+import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
+import { Target } from '@app/Shared/Services/Target.service';
+import { Modal, ModalVariant } from '@patternfly/react-core';
+import { cleanup, screen, within } from '@testing-library/react';
 import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
-import { cleanup, screen, within } from '@testing-library/react';
 import { of, throwError } from 'rxjs';
-import { MatchedCredential, StoredCredential } from '@app/Shared/Services/Api.service';
-import { Modal, ModalVariant } from '@patternfly/react-core';
-import { NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
-import { StoreJmxCredentials } from '@app/SecurityPanel/Credentials/StoreJmxCredentials';
-import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
-import { DeleteJMXCredentials, DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
-import { Target } from '@app/Shared/Services/Target.service';
-import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 
 import { renderWithServiceContext } from '../../Common';
-import { CreateJmxCredentialModalProps } from '@app/SecurityPanel/Credentials/CreateJmxCredentialModal';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockCredential: StoredCredential = {
   id: 0,
@@ -85,7 +84,6 @@ const mockAnotherMatchedCredentialResponse: MatchedCredential = {
 };
 
 const mockCredentialNotification = { message: mockCredential } as NotificationMessage;
-const evt = { kind: 'LOST', serviceRef: mockTarget } as TargetDiscoveryEvent;
 
 const mockLostTargetNotification = {
   message: { event: { kind: 'LOST', serviceRef: mockAnotherTarget } },

--- a/src/test/Settings/CredentialsStorage.test.tsx
+++ b/src/test/Settings/CredentialsStorage.test.tsx
@@ -35,12 +35,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
-import { cleanup, screen, waitFor, within } from '@testing-library/react';
-import { renderDefault } from '../Common';
+/* eslint @typescript-eslint/no-explicit-any: 0 */
 import { CredentialsStorage } from '@app/Settings/CredentialsStorage';
 import { getFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
+import { cleanup, screen, waitFor, within } from '@testing-library/react';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { renderDefault } from '../Common';
 
 jest.mock('@app/utils/LocalStorage', () => {
   const map = new Map<any, any>();

--- a/src/test/Settings/Settings.test.tsx
+++ b/src/test/Settings/Settings.test.tsx
@@ -35,12 +35,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import '@testing-library/jest-dom';
-import renderer, { act } from 'react-test-renderer';
-import { cleanup } from '@testing-library/react';
-import { Text } from '@patternfly/react-core';
 import { Settings } from '@app/Settings/Settings';
+import { Text } from '@patternfly/react-core';
+import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
 
 jest.mock('@app/Settings/NotificationControl', () => ({
   NotificationControl: {

--- a/src/test/Shared/Services/JmxCredentials.service.test.tsx
+++ b/src/test/Shared/Services/JmxCredentials.service.test.tsx
@@ -35,10 +35,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { JmxCredentials } from '@app/Shared/Services/JmxCredentials.service';
+/* eslint @typescript-eslint/no-explicit-any: 0 */
 import { ApiService } from '@app/Shared/Services/Api.service';
-import { firstValueFrom, Observable, of } from 'rxjs';
+import { JmxCredentials } from '@app/Shared/Services/JmxCredentials.service';
 import { getFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
+import { firstValueFrom, Observable, of } from 'rxjs';
 
 jest.mock('@app/utils/LocalStorage', () => {
   const map = new Map<any, any>();
@@ -57,7 +58,7 @@ jest.mock('@app/utils/LocalStorage', () => {
 });
 
 const mockApi = {
-  postCredentials: (expr: string, user: string, pass: string): Observable<boolean> => of(true),
+  postCredentials: (_expr: string, _user: string, _pass: string): Observable<boolean> => of(true),
 } as ApiService;
 const postCredentialsSpy = jest.spyOn(mockApi, 'postCredentials');
 

--- a/src/test/TargetSelect/TargetSelect.test.tsx
+++ b/src/test/TargetSelect/TargetSelect.test.tsx
@@ -35,17 +35,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import * as React from 'react';
-import renderer, { act } from 'react-test-renderer';
-import { cleanup, screen, waitFor, within } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { createMemoryHistory } from 'history';
-import { of } from 'rxjs';
-import { CUSTOM_TARGETS_REALM, TargetSelect } from '@app/TargetSelect/TargetSelect';
+import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
 import { Target } from '@app/Shared/Services/Target.service';
+import { CUSTOM_TARGETS_REALM, TargetSelect } from '@app/TargetSelect/TargetSelect';
+import { cleanup, screen, waitFor, within } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import * as React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import '@testing-library/jest-dom';
+import { of } from 'rxjs';
 import { renderWithServiceContext } from '../Common';
-import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';
 
 const mockFooConnectUrl = 'service:jmx:rmi://someFooUrl';
 const mockBarConnectUrl = 'service:jmx:rmi://someBarUrl';
@@ -170,8 +170,8 @@ describe('<TargetSelect />', () => {
     expect(codeElement).toBeTruthy();
     expect(codeElement).toBeInTheDocument();
     expect(codeElement).toBeVisible();
-    expect(codeElement!.textContent).toBeTruthy();
-    const codeContent = codeElement!.textContent!.replace(/[\s]/g, '');
+    expect(codeElement?.textContent).toBeTruthy();
+    const codeContent = codeElement?.textContent?.replace(/[\s]/g, '');
     expect(codeContent).toEqual(JSON.stringify(mockFooTarget, null, 0).replace(/[\s]/g, ''));
   });
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #740

## Description of the change:
* [x] Apply yarn format:apply to automatically fix fixable eslint issues
* [x] Manually go through all eslint warnings to fix them
* [x] Re-enable yarn eslint within ci.yaml as part of the CI automation process

Things to note:
1. Changed instances of React.FunctionComponent to use React.FC instead. Same code, just shorter for readability.
2. Eslint has been enabled in the CI and hence must pass in order for the build to pass CI. Rules include:
  -  import order enforced: imports should be in alphabetical order 
```
import { something... } from '@app/Events/...'
import { something } from '@patternfly/...'
import * from 'react'
import * from 'react-router-dom'
import {...} from './Dashboard/something...'
```
  - no explicit any: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-explicit-any.md
  - objects themselves shouldn't call object property methods (https://eslint.org/docs/latest/rules/no-prototype-builtins)
  - The empty interface rule has been disabled since some props interface types are empty. Empty props should be named with `_`. See this comment: https://github.com/cryostatio/cryostat-web/pull/780#discussion_r1055192891

>   I just notice that it seems when callback and memo needs function props as dependencies, eslint needs props itself to also be in the dependency list, and then having props in the dep list doesn't need the props.[functionProp] to be in the list either. However, non-function properties don't need this, and we directly list props.whateverFieldProp as a hook dependency. This can be done this way so that the props don't have to be destructured if the props itself isn't large (e.g. 10 props).

  - unused vars should be either `_` or prepended with the underscore e.g. `_myvariable` (this includes props -> empty prop objects should be named `_` until the FC prop interface contains any.
  - Others... see .eslintrc for list of enabled ad disabled rules

## Motivation for the change:
This change is helpful because the front-end should adhere to some useful eslint rules.

## How to manually test:
1. None
