### PR TITLE
chore(logo): use react router Link into logo

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -96,12 +96,13 @@ import { FeatureLevel } from '@app/Shared/Services/Settings.service';
 import { DynamicFeatureFlag, FeatureFlag } from '@app/Shared/FeatureFlag/FeatureFlag';
 import build from '@app/build.json';
 import { openTabForUrl } from '@app/utils/utils';
+import { Link } from 'react-router-dom';
 
-interface IAppLayout {
+interface AppLayoutProps {
   children: React.ReactNode;
 }
 
-const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
+const AppLayout: React.FunctionComponent<AppLayoutProps> = ({ children }) => {
   const serviceContext = React.useContext(ServiceContext);
   const notificationsContext = React.useContext(NotificationsContext);
   const addSubscription = useSubscriptions();
@@ -449,8 +450,10 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
             </PageToggleButton>
           </MastheadToggle>
           <MastheadMain>
-            <MastheadBrand href="/">
-              <Brand alt="Cryostat" src={cryostatLogo} className="cryostat-logo" />
+            <MastheadBrand>
+              <Link to="/">
+                <Brand alt="Cryostat" src={cryostatLogo} className="cryostat-logo" />
+              </Link>
             </MastheadBrand>
             <DynamicFeatureFlag levels={[FeatureLevel.DEVELOPMENT, FeatureLevel.BETA]} component={levelBadge} />
           </MastheadMain>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #779 

## Description of the change:

Logo is now using href which causes the reloading of the entire app. We can just use react router `Link` to achive this without reloading.

## Motivation for the change:

To avoid reloading the entire app.

## How to manually test:

1. Run `CRYOSTAT_IMAGE=quay.io... sh smoketest.sh`
2. Go to another tab (i.e Recordings). Click logo. Routes should be switched instead of reloading.
3. Clicking on logo while on "/" has no visual changes as route does not change.
