### PR TITLE
build(webpack): cache production builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ yarn-error.log
 stats.json
 coverage
 storybook-static
+.build_cache

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
-const ForkTsCheckerPlugin = require('fork-ts-checker-webpack-plugin');
 const PreloadWebpackPlugin = require('@vue/preload-webpack-plugin');
 
 const BG_IMAGES_DIRNAME = 'bgimages';
@@ -14,7 +13,6 @@ module.exports = (env) => {
       app: path.resolve(__dirname, 'src', 'index.tsx')
     },
     plugins: [
-      new ForkTsCheckerPlugin(),
       new HtmlWebpackPlugin({
         template: path.resolve(__dirname, 'src', 'index.html'),
         favicon: './src/app/assets/favicon.ico',

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -9,6 +9,11 @@ const DotenvPlugin = require('dotenv-webpack');
 module.exports = merge(common('production'), {
   mode: 'production',
   devtool: 'eval-source-map',
+  cache: {
+    type: 'filesystem',
+    compression: 'gzip',
+    cacheDirectory: path.resolve(__dirname, '.build_cache'),
+  },
   optimization: {
     minimizer: [
       new TerserJSPlugin({}),


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #790 

## Description of the change:

Enable production build cache.

## Motivation for the change:

See #790 

## How to manually test:

Build with:

```bash
yarn build:notests
```

Then, rebuild without changing any source files and observe the time taken.
