### PR TITLE
fix(target): update target selection cache

### DIFF
--- a/src/app/TargetSelect/TargetSelect.tsx
+++ b/src/app/TargetSelect/TargetSelect.tsx
@@ -83,13 +83,14 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   const [warningModalOpen, setWarningModalOpen] = React.useState(false);
 
   const setCachedTargetSelection = React.useCallback(
-    (target, errorCallback?) => saveToLocalStorage('TARGET', target, errorCallback),
+    (targetConnectUrl: string, errorCallback?: () => void) =>
+      saveToLocalStorage('TARGET', targetConnectUrl, errorCallback),
     []
   );
 
   const removeCachedTargetSelection = React.useCallback(() => removeFromLocalStorage('TARGET'), []);
 
-  const getCachedTargetSelection = React.useCallback(() => getFromLocalStorage('TARGET', NO_TARGET), []);
+  const getCachedTargetSelection = React.useCallback(() => getFromLocalStorage('TARGET', NO_TARGET.connectUrl), []);
 
   const resetTargetSelection = React.useCallback(() => {
     context.target.setTarget(NO_TARGET);
@@ -102,13 +103,13 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
 
   const onSelect = React.useCallback(
     // ATTENTION: do not add onSelect as deps for effect hook as it updates with selected states
-    (evt, selection, isPlaceholder) => {
+    (_, selection, isPlaceholder) => {
       if (isPlaceholder) {
         resetTargetSelection();
       } else {
-        if (!isEqualTarget(selection, selected)) {
+        if (!isEqualTarget(selection as Target, selected)) {
           context.target.setTarget(selection);
-          setCachedTargetSelection(selection, () => {
+          setCachedTargetSelection((selection as Target).connectUrl, () => {
             notifications.danger('Cannot set target');
             context.target.setTarget(NO_TARGET);
           });
@@ -120,15 +121,15 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = (props) 
   );
 
   const selectTargetFromCache = React.useCallback(
-    (targets) => {
+    (targets: Target[]) => {
       if (!targets.length) {
         // Ignore first emitted value
         return;
       }
-      const cachedTarget = getCachedTargetSelection();
-      const cachedTargetExists = targets.some((target: Target) => isEqualTarget(cachedTarget, target));
-      if (cachedTargetExists) {
-        context.target.setTarget(cachedTarget);
+      const cachedTargetConnectUrl = getCachedTargetSelection();
+      const matchedTarget = targets.find((t) => t.connectUrl === cachedTargetConnectUrl);
+      if (matchedTarget) {
+        context.target.setTarget(matchedTarget);
       } else {
         resetTargetSelection();
       }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Partial fixes: #805 
Related to: https://github.com/cryostatio/cryostat/pull/1327 (WS notifications should be sent).

## Description of the change:

Update target cache to save only connectUrl and should update currently selected target with new details.

## Motivation for the change:

See #805

## How to manually test:
1. `Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2.  Choose any target with credentials. Either enter credentials using Auth modal or add in Security Panel.
3. Expand the target details. See the jvmId being updated.
