### PR TITLE
feat(target): add target event kind for modified state

### DIFF
--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -109,6 +109,8 @@ export const messageKeys = new Map([
             return `Target "${target.alias}" appeared (${target.connectUrl})"`;
           case 'LOST':
             return `Target "${target.alias}" disappeared (${target.connectUrl})"`;
+          case 'MODIFIED':
+            return `Target "${target.alias}" was modified (${target.connectUrl})"`;
           default:
             return `Received a notification with category ${NotificationCategory.TargetJvmDiscovery} and unrecognized kind ${evt.kind}`;
         }

--- a/src/app/Shared/Services/Targets.service.tsx
+++ b/src/app/Shared/Services/Targets.service.tsx
@@ -78,8 +78,8 @@ export class TargetsService {
           {
             const idx = _.findIndex(this._targets$.getValue(), (t) => t.connectUrl === evt.serviceRef.connectUrl);
             if (idx >= 0) {
-              const tList = this._targets$.getValue().splice(idx, 1, evt.serviceRef);
-              this._targets$.next(tList);
+              this._targets$.getValue().splice(idx, 1, evt.serviceRef);
+              this._targets$.next(this._targets$.getValue());
             }
           }
           break;

--- a/src/app/Shared/Services/Targets.service.tsx
+++ b/src/app/Shared/Services/Targets.service.tsx
@@ -75,10 +75,12 @@ export class TargetsService {
           this._targets$.next(_.filter(this._targets$.getValue(), (t) => t.connectUrl !== evt.serviceRef.connectUrl));
           break;
         case 'MODIFIED':
-          const idx = _.findIndex(this._targets$.getValue(), (t) => t.connectUrl === evt.serviceRef.connectUrl);
-          if (idx >= 0) {
-            const tList = this._targets$.getValue().splice(idx, 1, evt.serviceRef);
-            this._targets$.next(tList);
+          {
+            const idx = _.findIndex(this._targets$.getValue(), (t) => t.connectUrl === evt.serviceRef.connectUrl);
+            if (idx >= 0) {
+              const tList = this._targets$.getValue().splice(idx, 1, evt.serviceRef);
+              this._targets$.next(tList);
+            }
           }
           break;
         default:

--- a/src/app/Shared/Services/Targets.service.tsx
+++ b/src/app/Shared/Services/Targets.service.tsx
@@ -46,7 +46,7 @@ import { NotificationCategory, NotificationChannel } from './NotificationChannel
 import { Target } from './Target.service';
 
 export interface TargetDiscoveryEvent {
-  kind: 'LOST' | 'FOUND';
+  kind: 'LOST' | 'FOUND' | 'MODIFIED';
   serviceRef: Target;
 }
 
@@ -73,6 +73,13 @@ export class TargetsService {
           break;
         case 'LOST':
           this._targets$.next(_.filter(this._targets$.getValue(), (t) => t.connectUrl !== evt.serviceRef.connectUrl));
+          break;
+        case 'MODIFIED':
+          const idx = _.findIndex(this._targets$.getValue(), (t) => t.connectUrl === evt.serviceRef.connectUrl);
+          if (idx >= 0) {
+            const tList = this._targets$.getValue().splice(idx, 1, evt.serviceRef);
+            this._targets$.next(tList);
+          }
           break;
         default:
           break;


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes #805 
Depends on https://github.com/cryostatio/cryostat/pull/1327

## Description of the change:

Added a new event kind for target's modified state.

## Motivation for the change:

This will help avoid `TargetSelect` deselect the target due `LOST` notification (previously consecutive `LOST` + `FOUND` on the same target = `MODIFIED`).

## How to manually test:
1. `Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2. Try select a target with authentication with no saved credentials.
3. Enter the credentials.
4. Observe the modified notification
5. Target is still selected.
