### PR TITLE
fix(dashboard): allow cards to overflow when resized

### DIFF
--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -93,8 +93,8 @@ export interface DashboardCardProps {
 const PLACEHOLDER_CARD_SIZE = {
   span: {
     minimum: 1,
-    default: 6,
-    maximum: 10,
+    default: 3,
+    maximum: 6,
   },
   height: {
     minimum: Number.NaN,

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -72,6 +72,16 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
   const minWidth = React.useRef<number | undefined>(undefined);
   const maxWidth = React.useRef<number | undefined>(undefined);
 
+  const nearEdgeMultiplier = React.useCallback((mousePos: number): number => {
+    const CLOSE_TO_EDGE = 0.995;
+    const EDGE_MULTIPLIER = 0.9;
+    if (mousePos > window.innerWidth * CLOSE_TO_EDGE) {
+      return EDGE_MULTIPLIER;
+    } else {
+      return 1;
+    }
+  }, []);
+
   const callbackMouseMove = React.useCallback(
     (e: MouseEvent) => {
       const mousePos = e.clientX;
@@ -91,7 +101,7 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
         }
 
         const minCardRight = cardRect.left + minWidth.current;
-        const maxCardRight = cardRect.left + maxWidth.current;
+        const maxCardRight = cardRect.left + maxWidth.current * nearEdgeMultiplier(mousePos);
 
         const newSize = mousePos;
 
@@ -108,7 +118,7 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
         console.error('cardRef.current is undefined');
       }
     },
-    [dispatch, cardRef, cardConfigs, dashboardId, cardSizes]
+    [dispatch, cardRef, cardConfigs, nearEdgeMultiplier, dashboardId, cardSizes]
   );
 
   const callbackMouseUp = React.useCallback(() => {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #729
Related to: #796 

## Description of the change:
This change allows cards to be resized when they are close to the edge of the screen.

## How to manually test:
1. Have 2 cards, and make the second card large enough to overflow to the next row. This wasn't able to be done before because of some refactoring.

