### PR TITLE
fix(archives): fix duplicate archived recording displays

### DIFF
--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -289,7 +289,9 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
         if (currentTarget.connectUrl != event.message.target) {
           return;
         }
-        setRecordings((old) => old.concat(event.message.recording));
+        setRecordings((old) =>
+          old.filter((r) => r.name !== event.message.recording.name).concat(event.message.recording)
+        );
       })
     );
   }, [addSubscription, context.notificationChannel, setRecordings, propsTarget]);

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -57,6 +57,8 @@ export const Recordings: React.FunctionComponent<RecordingsProps> = (_) => {
 
   const onTabSelect = React.useCallback((_, idx) => setActiveTab(Number(idx)), [setActiveTab]);
 
+  const targetAsObs = React.useMemo(() => context.target.target(), [context.target]);
+
   const cardBody = React.useMemo(() => {
     return archiveEnabled ? (
       <Tabs id="recordings" activeKey={activeTab} onSelect={onTabSelect}>
@@ -64,7 +66,7 @@ export const Recordings: React.FunctionComponent<RecordingsProps> = (_) => {
           <ActiveRecordingsTable archiveEnabled={true} />
         </Tab>
         <Tab id="archived-recordings" eventKey={1} title={<TabTitleText>Archived Recordings</TabTitleText>}>
-          <ArchivedRecordingsTable target={context.target.target()} isUploadsTable={false} isNestedTable={false} />
+          <ArchivedRecordingsTable target={targetAsObs} isUploadsTable={false} isNestedTable={false} />
         </Tab>
       </Tabs>
     ) : (
@@ -73,7 +75,7 @@ export const Recordings: React.FunctionComponent<RecordingsProps> = (_) => {
         <ActiveRecordingsTable archiveEnabled={false} />
       </>
     );
-  }, [archiveEnabled, activeTab, onTabSelect, context.target]);
+  }, [archiveEnabled, activeTab, onTabSelect, targetAsObs]);
 
   return (
     <TargetView pageTitle="Recordings">

--- a/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
@@ -190,40 +190,50 @@ jest
   .mockReturnValueOnce(of()) // renders correctly
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
+  .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // has the correct table elements
+  .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // hides targets with zero recordings
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
+  .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // correctly handles the search function
+  .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // expands targets to show their <ArchivedRecordingsTable />
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
+  .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // does not expand targets with zero recordings
+  .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of(mockTargetFoundNotification)) // adds a target upon receiving a notification
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
+  .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of(mockTargetLostNotification)) // removes a target upon receiving a notification
+  .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // increments the count when an archived recording is saved
   .mockReturnValueOnce(of(mockRecordingSavedNotification))
   .mockReturnValueOnce(of())
+  .mockReturnValueOnce(of())
 
   .mockReturnValueOnce(of()) // decrements the count when an archived recording is deleted
+  .mockReturnValueOnce(of())
   .mockReturnValueOnce(of())
   .mockReturnValueOnce(of(mockRecordingDeletedNotification));
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #811 

## Description of the change:

- [x] Fix hook deps for archive table target props.
- [x] Fix hook deps for `All Targets` table.
- [x] Fix count number updates for `All Targets` table (missing listener for ArchivedRecordingCreated type).

## Motivation for the change:

After some previous refactoring jobs, the Archive table now accepts a target prop that select a target to pull archive from. However, that seems to introduce problems with hook deps. 

#811 fixes the hook deps issue for upload table but `Archive table` & `All Targets` (additionally, count number is not updated correctly) suffers the same problem. `All Archives` table seems to be safe since it refreshes everything on any updates.

This leads to duplicate archive recording rows when testing with https://github.com/cryostatio/cryostat/pull/1333
