### PR TITLE
feat(dashboard): allow drag-and-drop reordering of dashboard cards

### DIFF
--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -68,6 +68,7 @@ import {
   WizardStep,
 } from '@patternfly/react-core/dist/js/next';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { nanoid } from 'nanoid';
 import * as React from 'react';
 import { useContext } from 'react';
 import { useDispatch } from 'react-redux';
@@ -119,7 +120,7 @@ export const AddCard: React.FC<AddCardProps> = (_) => {
   const handleAdd = React.useCallback(() => {
     setShowWizard(false);
     const config = getConfigByTitle(selection);
-    dispatch(dashboardCardConfigAddCardIntent(config.component.name, config.cardSizes.span.default, propsConfig));
+    dispatch(dashboardCardConfigAddCardIntent(`${config.component.name}-${nanoid()}`, config.component.name, config.cardSizes.span.default, propsConfig));
   }, [dispatch, setShowWizard, selection, propsConfig]);
 
   const handleStart = React.useCallback(() => {

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -120,7 +120,14 @@ export const AddCard: React.FC<AddCardProps> = (_) => {
   const handleAdd = React.useCallback(() => {
     setShowWizard(false);
     const config = getConfigByTitle(selection);
-    dispatch(dashboardCardConfigAddCardIntent(`${config.component.name}-${nanoid()}`, config.component.name, config.cardSizes.span.default, propsConfig));
+    dispatch(
+      dashboardCardConfigAddCardIntent(
+        `${config.component.name}-${nanoid()}`,
+        config.component.name,
+        config.cardSizes.span.default,
+        propsConfig
+      )
+    );
   }, [dispatch, setShowWizard, selection, propsConfig]);
 
   const handleStart = React.useCallback(() => {

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -750,24 +750,26 @@ export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (prop
       id="automated-analysis-card"
       isCompact
       isExpanded={isCardExpanded}
+      cardHeader={
+        <CardHeader
+          onExpand={onCardExpand}
+          toggleButtonProps={{
+            id: 'automated-analysis-toggle-details',
+            'aria-label': 'Details',
+            'aria-labelledby': 'automated-analysis-card-title toggle-details',
+            'aria-expanded': isCardExpanded,
+          }}
+        >
+          <CardActions>{...props.actions || []}</CardActions>
+          <Level hasGutter>
+            <LevelItem>
+              <CardTitle component="h4">Automated Analysis</CardTitle>
+            </LevelItem>
+            <LevelItem>{reportSource}</LevelItem>
+          </Level>
+        </CardHeader>
+      }
     >
-      <CardHeader
-        onExpand={onCardExpand}
-        toggleButtonProps={{
-          id: 'automated-analysis-toggle-details',
-          'aria-label': 'Details',
-          'aria-labelledby': 'automated-analysis-card-title toggle-details',
-          'aria-expanded': isCardExpanded,
-        }}
-      >
-        <CardActions>{...props.actions || []}</CardActions>
-        <Level hasGutter>
-          <LevelItem>
-            <CardTitle component="h4">Automated Analysis</CardTitle>
-          </LevelItem>
-          <LevelItem>{reportSource}</LevelItem>
-        </Level>
-      </CardHeader>
       <CardExpandableContent>
         <Stack hasGutter>
           <StackItem>{errorMessage ? null : toolbar}</StackItem>

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -100,7 +100,7 @@ import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { filter, first, map, tap } from 'rxjs';
 import { DashboardCardDescriptor, DashboardCardProps, DashboardCardSizes } from '../Dashboard';
-import { ResizableCard } from '../ResizableCard';
+import { DashboardCard } from '../DashboardCard';
 import { AutomatedAnalysisConfigDrawer } from './AutomatedAnalysisConfigDrawer';
 import { AutomatedAnalysisConfigForm } from './AutomatedAnalysisConfigForm';
 import {
@@ -744,12 +744,10 @@ export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (prop
   }, [usingArchivedReport, usingCachedReport, report, isLoading, errorMessage]);
 
   return (
-    <ResizableCard
+    <DashboardCard
       dashboardId={props.dashboardId}
       cardSizes={AutomatedAnalysisCardSizes}
-      className="dashboard-card"
       id="automated-analysis-card"
-      isRounded
       isCompact
       isExpanded={isCardExpanded}
     >
@@ -784,7 +782,7 @@ export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (prop
           </StackItem>
         </Stack>
       </CardExpandableContent>
-    </ResizableCard>
+    </DashboardCard>
   );
 };
 

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -43,15 +43,7 @@ import {
 import { dashboardCardConfigDeleteCardIntent, RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
 import { TargetView } from '@app/TargetView/TargetView';
-import {
-  CardActions,
-  CardBody,
-  CardHeader,
-  Grid,
-  GridItem,
-  gridSpans,
-  Text,
-} from '@patternfly/react-core';
+import { CardActions, CardBody, CardHeader, Grid, GridItem, gridSpans, Text } from '@patternfly/react-core';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Observable, of } from 'rxjs';
@@ -273,7 +265,7 @@ export const Dashboard: React.FC<DashboardProps> = (_) => {
 
   return (
     <TargetView pageTitle="Dashboard" compactSelect={false}>
-      <Grid id={"dashboard-grid"} hasGutter>
+      <Grid id={'dashboard-grid'} hasGutter>
         {cardConfigs.map((cfg, idx) => (
           <GridItem span={cfg.span} key={idx} order={{ default: idx.toString() }}>
             {React.createElement(getConfigByName(cfg.name).component, {
@@ -290,7 +282,7 @@ export const Dashboard: React.FC<DashboardProps> = (_) => {
           </GridItem>
         ))}
         <GridItem key={cardConfigs.length} order={{ default: cardConfigs.length.toString() }}>
-          <AddCard/>
+          <AddCard />
         </GridItem>
       </Grid>
     </TargetView>

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -272,7 +272,7 @@ export const Dashboard: React.FC<DashboardProps> = (_) => {
     <TargetView pageTitle="Dashboard" compactSelect={false}>
       <Grid id={'dashboard-grid'} hasGutter>
         {cardConfigs.map((cfg, idx) => (
-          <GridItem span={cfg.span} key={idx} order={{ default: idx.toString() }}>
+          <GridItem span={cfg.span} key={cfg.id} order={{ default: idx.toString() }}>
             {React.createElement(getConfigByName(cfg.name).component, {
               ...cfg.props,
               dashboardId: idx,

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -38,7 +38,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   CardConfig,
-  dashboardCardConfigReorderCardIntent,
   dashboardCardConfigResizeCardIntent,
 } from '@app/Shared/Redux/Configurations/DashboardConfigSlicer';
 import { dashboardCardConfigDeleteCardIntent, RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
@@ -48,10 +47,6 @@ import {
   CardActions,
   CardBody,
   CardHeader,
-  DragDrop,
-  Draggable,
-  DraggableItemPosition,
-  Droppable,
   Grid,
   GridItem,
   gridSpans,
@@ -62,8 +57,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Observable, of } from 'rxjs';
 import { AddCard } from './AddCard';
 import { AutomatedAnalysisCardDescriptor } from './AutomatedAnalysis/AutomatedAnalysisCard';
-import { DashboardCardActionMenu } from './DashboardCardActionMenu';
 import { DashboardCard } from './DashboardCard';
+import { DashboardCardActionMenu } from './DashboardCardActionMenu';
 
 export interface Sized<T> {
   minimum: T;
@@ -278,7 +273,7 @@ export const Dashboard: React.FC<DashboardProps> = (_) => {
 
   return (
     <TargetView pageTitle="Dashboard" compactSelect={false}>
-      <Grid hasGutter>
+      <Grid id={"dashboard-grid"} hasGutter>
         {cardConfigs.map((cfg, idx) => (
           <GridItem span={cfg.span} key={idx} order={{ default: idx.toString() }}>
             {React.createElement(getConfigByName(cfg.name).component, {

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -115,10 +115,15 @@ const PlaceholderCard: React.FunctionComponent<
   } & DashboardCardProps
 > = (props) => {
   return (
-    <DashboardCard dashboardId={props.dashboardId} cardSizes={PLACEHOLDER_CARD_SIZE}>
-      <CardHeader>
-        <CardActions>{...props.actions || []}</CardActions>
-      </CardHeader>
+    <DashboardCard
+      dashboardId={props.dashboardId}
+      cardSizes={PLACEHOLDER_CARD_SIZE}
+      cardHeader={
+        <CardHeader>
+          <CardActions>{...props.actions || []}</CardActions>
+        </CardHeader>
+      }
+    >
       <CardBody>
         <Text>title: {props.title}</Text>
         <Text>message: {props.message}</Text>

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -44,7 +44,19 @@ import {
 import { dashboardCardConfigDeleteCardIntent, RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
 import { TargetView } from '@app/TargetView/TargetView';
-import { CardActions, CardBody, CardHeader, DragDrop, Draggable, DraggableItemPosition, Droppable, Grid, GridItem, gridSpans, Text } from '@patternfly/react-core';
+import {
+  CardActions,
+  CardBody,
+  CardHeader,
+  DragDrop,
+  Draggable,
+  DraggableItemPosition,
+  Droppable,
+  Grid,
+  GridItem,
+  gridSpans,
+  Text,
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Observable, of } from 'rxjs';
@@ -116,10 +128,7 @@ const PlaceholderCard: React.FunctionComponent<
   } & DashboardCardProps
 > = (props) => {
   return (
-    <DashboardCard
-      dashboardId={props.dashboardId}
-      cardSizes={PLACEHOLDER_CARD_SIZE}
-    >
+    <DashboardCard dashboardId={props.dashboardId} cardSizes={PLACEHOLDER_CARD_SIZE}>
       <CardHeader>
         <CardActions>{...props.actions || []}</CardActions>
       </CardHeader>
@@ -267,47 +276,26 @@ export const Dashboard: React.FC<DashboardProps> = (_) => {
     [dispatch, cardConfigs]
   );
 
-  const handleDrop = React.useCallback((source, dest) => {
-    console.log('dropping', source, dest);
-    if (dest) {
-      dispatch(dashboardCardConfigReorderCardIntent(source.index, dest.index));
-      return true;
-    }
-    return false;
-  }, [dispatch]);
-
-  const handleDragMove = React.useCallback((source, dest) => {
-    console.log('dragging', source,
-    dest);
-    return true;
-  }, []);
-
-
-  const onDrag = (source: DraggableItemPosition): boolean => {
-    console.log('dragging', source);
-    return true;
-  }
-
   return (
     <TargetView pageTitle="Dashboard" compactSelect={false}>
-        <Grid hasGutter>
-          {cardConfigs.map((cfg, idx) => (
-              <GridItem span={cfg.span} key={idx} order={{default: idx.toString()}}>
-                  {React.createElement(getConfigByName(cfg.name).component, {
-                    ...cfg.props,
-                    dashboardId: idx,
-                    actions: [
-                      <DashboardCardActionMenu
-                        key={`${cfg.name}-actions`}
-                        onRemove={() => handleRemove(idx)}
-                        onResetSize={() => handleResetSize(idx)}
-                      />,
-                    ],
-                  })}
-              </GridItem>
-            ))}
-        <GridItem key={cardConfigs.length} order={{default: cardConfigs.length.toString()}}>
-            <AddCard />
+      <Grid hasGutter>
+        {cardConfigs.map((cfg, idx) => (
+          <GridItem span={cfg.span} key={idx} order={{ default: idx.toString() }}>
+            {React.createElement(getConfigByName(cfg.name).component, {
+              ...cfg.props,
+              dashboardId: idx,
+              actions: [
+                <DashboardCardActionMenu
+                  key={`${cfg.name}-actions`}
+                  onRemove={() => handleRemove(idx)}
+                  onResetSize={() => handleResetSize(idx)}
+                />,
+              ],
+            })}
+          </GridItem>
+        ))}
+        <GridItem key={cardConfigs.length} order={{ default: cardConfigs.length.toString() }}>
+          <AddCard/>
         </GridItem>
       </Grid>
     </TargetView>

--- a/src/app/Dashboard/DashboardCard.tsx
+++ b/src/app/Dashboard/DashboardCard.tsx
@@ -58,15 +58,26 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
 }: DashboardCardProps) => {
   const cardRef = React.useRef<HTMLDivElement>(null);
 
+  const memoizedResizableRef = React.useMemo(() => {
+    return <ResizableRef dashboardId={dashboardId} cardSizes={cardSizes} />
+  }, [dashboardId, cardSizes]);
+
+    
+
+  const memoized = React.useMemo(() => {
+    return (<div className={'dashboard-card-resizable-wrapper'} ref={cardRef}>
+    <Card className="dashboard-card" {...props}>
+      {children}
+    </Card>
+    {memoizedResizableRef}
+  </div>);
+  }, [children]);
+
+
   return (
     <DashboardCardContext.Provider value={cardRef}>
       <DraggableRef dashboardId={dashboardId}>
-        <div className={'resizable-ref'} ref={cardRef}>
-          <Card className="dashboard-card" {...props}>
-            {children}
-          </Card>
-          <ResizableRef dashboardId={dashboardId} cardSizes={cardSizes} />
-        </div>
+        {memoized}
       </DraggableRef>
     </DashboardCardContext.Provider>
   );

--- a/src/app/Dashboard/DashboardCard.tsx
+++ b/src/app/Dashboard/DashboardCard.tsx
@@ -40,30 +40,37 @@ import { Card, CardProps } from '@patternfly/react-core';
 import * as React from 'react';
 import { DashboardCardSizes } from './Dashboard';
 import { DraggableRef } from './DraggableRef';
+import { ResizableRef } from './ResizableRef';
+
+export const initCardRefStyle = { display: 'flex', justifyContent: 'space-between' };
 
 export const DashboardCardContext = React.createContext<React.RefObject<HTMLDivElement>>(React.createRef());
 
-export interface ResizableCardProps extends CardProps {
+export interface DashboardCardProps extends CardProps {
   dashboardId: number;
   cardSizes: DashboardCardSizes;
   children?: React.ReactNode;
 }
 
-export const ResizableCard: React.FC<ResizableCardProps> = ({
+export const DashboardCard: React.FC<DashboardCardProps> = ({
   children = null,
   dashboardId,
   cardSizes,
   ...props
-}: ResizableCardProps) => {
+}: DashboardCardProps) => {
   const cardRef = React.useRef<HTMLDivElement>(null);
 
   return (
     <DashboardCardContext.Provider value={cardRef}>
-      <div className="resizable-card" ref={cardRef} style={{ display: 'flex', justifyContent: 'space-between' }}>
-        <Card {...props}>{children}</Card>
-        <DraggableRef dashboardId={dashboardId} cardSizes={cardSizes} />
+      <div className="resizable-card" ref={cardRef} style={initCardRefStyle}>
+        <DraggableRef dashboardId={dashboardId}>
+          <Card className="dashboard-card" isRounded {...props} >
+            {children}
+          </Card>
+        </DraggableRef>
+        <ResizableRef dashboardId={dashboardId} cardSizes={cardSizes} />
       </div>
     </DashboardCardContext.Provider>
   );
 };
-ResizableCard.displayName = 'ResizableCard';
+DashboardCard.displayName = 'DashboardCard';

--- a/src/app/Dashboard/DashboardCard.tsx
+++ b/src/app/Dashboard/DashboardCard.tsx
@@ -58,26 +58,15 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
 }: DashboardCardProps) => {
   const cardRef = React.useRef<HTMLDivElement>(null);
 
-  const memoizedResizableRef = React.useMemo(() => {
-    return <ResizableRef dashboardId={dashboardId} cardSizes={cardSizes} />
-  }, [dashboardId, cardSizes]);
-
-    
-
-  const memoized = React.useMemo(() => {
-    return (<div className={'dashboard-card-resizable-wrapper'} ref={cardRef}>
-    <Card className="dashboard-card" {...props}>
-      {children}
-    </Card>
-    {memoizedResizableRef}
-  </div>);
-  }, [children]);
-
-
   return (
     <DashboardCardContext.Provider value={cardRef}>
       <DraggableRef dashboardId={dashboardId}>
-        {memoized}
+        <div className={'dashboard-card-resizable-wrapper'} ref={cardRef}>
+          <Card className="dashboard-card" {...props}>
+            {children}
+          </Card>
+          <ResizableRef dashboardId={dashboardId} cardSizes={cardSizes} />
+        </div>
       </DraggableRef>
     </DashboardCardContext.Provider>
   );

--- a/src/app/Dashboard/DashboardCard.tsx
+++ b/src/app/Dashboard/DashboardCard.tsx
@@ -40,7 +40,7 @@ import { Card, CardProps } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import * as React from 'react';
 import { DashboardCardSizes } from './Dashboard';
-import { draggableRef, DraggableRef } from './DraggableRef';
+import { draggableRefKlazz, DraggableRef } from './DraggableRef';
 import { ResizableRef } from './ResizableRef';
 
 export const DashboardCardContext = React.createContext<React.RefObject<HTMLDivElement>>(React.createRef());
@@ -66,7 +66,7 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
       <DraggableRef dashboardId={dashboardId}>
         <div className={'dashboard-card-resizable-wrapper'} ref={cardRef}>
           <Card className="dashboard-card" isRounded {...props}>
-            <div className={css(`${draggableRef}__grip`)} draggable>
+            <div className={css(`${draggableRefKlazz}__grip`)} draggable>
               {cardHeader}
             </div>
             {children}

--- a/src/app/Dashboard/DashboardCard.tsx
+++ b/src/app/Dashboard/DashboardCard.tsx
@@ -42,8 +42,6 @@ import { DashboardCardSizes } from './Dashboard';
 import { DraggableRef } from './DraggableRef';
 import { ResizableRef } from './ResizableRef';
 
-export const initCardRefStyle = { display: 'flex', justifyContent: 'space-between' };
-
 export const DashboardCardContext = React.createContext<React.RefObject<HTMLDivElement>>(React.createRef());
 
 export interface DashboardCardProps extends CardProps {
@@ -62,14 +60,14 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
 
   return (
     <DashboardCardContext.Provider value={cardRef}>
-      <div className="resizable-card" ref={cardRef} style={initCardRefStyle}>
-        <DraggableRef dashboardId={dashboardId}>
-          <Card className="dashboard-card" isRounded {...props} >
+      <DraggableRef dashboardId={dashboardId}>
+        <div className={'resizable-ref'} ref={cardRef}>
+          <Card className="dashboard-card" {...props}>
             {children}
           </Card>
-        </DraggableRef>
-        <ResizableRef dashboardId={dashboardId} cardSizes={cardSizes} />
-      </div>
+          <ResizableRef dashboardId={dashboardId} cardSizes={cardSizes} />
+        </div>
+      </DraggableRef>
     </DashboardCardContext.Provider>
   );
 };

--- a/src/app/Dashboard/DashboardCard.tsx
+++ b/src/app/Dashboard/DashboardCard.tsx
@@ -61,12 +61,29 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
 }: DashboardCardProps) => {
   const cardRef = React.useRef<HTMLDivElement>(null);
 
+  const onMouseEnter = React.useCallback((_e: React.MouseEvent<HTMLDivElement>) => {
+    if (cardRef.current) {
+      cardRef.current.classList.add(`${draggableRefKlazz}-hover`);
+    }
+  }, []);
+
+  const onMouseLeave = React.useCallback((_e: React.MouseEvent<HTMLDivElement>) => {
+    if (cardRef.current) {
+      cardRef.current.classList.remove(`${draggableRefKlazz}-hover`);
+    }
+  }, []);
+
   return (
     <DashboardCardContext.Provider value={cardRef}>
       <DraggableRef dashboardId={dashboardId}>
         <div className={'dashboard-card-resizable-wrapper'} ref={cardRef}>
           <Card className="dashboard-card" isRounded {...props}>
-            <div className={css(`${draggableRefKlazz}__grip`)} draggable>
+            <div
+              className={css(`${draggableRefKlazz}__grip`)}
+              onMouseEnter={onMouseEnter}
+              onMouseLeave={onMouseLeave}
+              draggable // draggable is required for drag events to fire
+            >
               {cardHeader}
             </div>
             {children}

--- a/src/app/Dashboard/DashboardCard.tsx
+++ b/src/app/Dashboard/DashboardCard.tsx
@@ -37,9 +37,10 @@
  */
 
 import { Card, CardProps } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
 import * as React from 'react';
 import { DashboardCardSizes } from './Dashboard';
-import { DraggableRef } from './DraggableRef';
+import { draggableRef, DraggableRef } from './DraggableRef';
 import { ResizableRef } from './ResizableRef';
 
 export const DashboardCardContext = React.createContext<React.RefObject<HTMLDivElement>>(React.createRef());
@@ -47,11 +48,13 @@ export const DashboardCardContext = React.createContext<React.RefObject<HTMLDivE
 export interface DashboardCardProps extends CardProps {
   dashboardId: number;
   cardSizes: DashboardCardSizes;
+  cardHeader: React.ReactNode;
   children?: React.ReactNode;
 }
 
 export const DashboardCard: React.FC<DashboardCardProps> = ({
   children = null,
+  cardHeader = null,
   dashboardId,
   cardSizes,
   ...props
@@ -62,7 +65,10 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
     <DashboardCardContext.Provider value={cardRef}>
       <DraggableRef dashboardId={dashboardId}>
         <div className={'dashboard-card-resizable-wrapper'} ref={cardRef}>
-          <Card className="dashboard-card" {...props}>
+          <Card className="dashboard-card" isRounded {...props}>
+            <div className={css(`${draggableRef}__grip`)} draggable>
+              {cardHeader}
+            </div>
             {children}
           </Card>
           <ResizableRef dashboardId={dashboardId} cardSizes={cardSizes} />

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -36,124 +36,216 @@
  * SOFTWARE.
  */
 import {
-  CardConfig,
-  dashboardCardConfigResizeCardIntent,
-} from '@app/Shared/Redux/Configurations/DashboardConfigSlicer';
-import { RootState } from '@app/Shared/Redux/ReduxStore';
-import { gridSpans } from '@patternfly/react-core';
-import _ from 'lodash';
-import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { DashboardCardSizes } from './Dashboard';
-import { DashboardCardContext } from './ResizableCard';
+    CardConfig,
+    dashboardCardConfigReorderCardIntent,
+    dashboardCardConfigResizeCardIntent,
+  } from '@app/Shared/Redux/Configurations/DashboardConfigSlicer';
+  import { RootState } from '@app/Shared/Redux/ReduxStore';
+  import { gridSpans } from '@patternfly/react-core';
+import { GripVerticalIcon } from '@patternfly/react-icons';
+  import _ from 'lodash';
+  import React from 'react';
+  import { useDispatch, useSelector } from 'react-redux';
+  import { DashboardCardSizes } from './Dashboard';
+  import { DashboardCardContext } from './DashboardCard';
 
-export interface DraggableRefProps {
-  dashboardId: number;
-  cardSizes: DashboardCardSizes;
-}
-
-function normalizeAsGridSpans(val: number, min: number, max: number, a: gridSpans, b: gridSpans): gridSpans {
-  if (val < min) val = min;
-  else if (val > max) val = max;
-  const ans = Math.round((b - a) * ((val - min) / (max - min)) + a);
-  return _.clamp(ans, a, b) as gridSpans;
-}
-
-export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
-  dashboardId,
-  cardSizes,
-  ..._props
-}: DraggableRefProps) => {
-  const cardConfigs: CardConfig[] = useSelector((state: RootState) => state.dashboardConfigs.list);
-  const dispatch = useDispatch();
-
-  const cardRef = React.useContext(DashboardCardContext);
-  const isResizing = React.useRef<boolean>(false);
-  const minWidth = React.useRef<number | undefined>(undefined);
-  const maxWidth = React.useRef<number | undefined>(undefined);
-
-  const nearEdgeMultiplier = React.useCallback((mousePos: number): number => {
-    const CLOSE_TO_EDGE = 0.995;
-    const EDGE_MULTIPLIER = 0.9;
-    if (mousePos > window.innerWidth * CLOSE_TO_EDGE) {
-      return EDGE_MULTIPLIER;
-    } else {
-      return 1;
+  function getDefaultBackground() {
+    const div = document.createElement('div');
+    document.head.appendChild(div);
+    const bg = window.getComputedStyle(div).backgroundColor;
+    document.head.removeChild(div);
+    return bg;
+  }
+  
+  function getInheritedBackgroundColor(el: HTMLElement): string {
+    const defaultStyle = getDefaultBackground();
+    const backgroundColor = window.getComputedStyle(el).backgroundColor;
+  
+    if (backgroundColor !== defaultStyle) {
+      return backgroundColor;
+    } else if (!el.parentElement) {
+      return defaultStyle;
     }
-  }, []);
+  
+    return getInheritedBackgroundColor(el.parentElement);
+  }
 
-  const callbackMouseMove = React.useCallback(
-    (e: MouseEvent) => {
-      const mousePos = e.clientX;
-      e.stopPropagation();
-      if (!isResizing.current) {
-        return;
-      }
-      if (cardRef.current) {
-        cardRef.current.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'end' });
-        const cardRect = cardRef.current.getBoundingClientRect();
+  function overlaps(ev: MouseEvent, rect: DOMRect) {
+    return (
+      ev.clientX > rect.x && ev.clientX < rect.x + rect.width && ev.clientY > rect.y && ev.clientY < rect.y + rect.height
+    );
+  }
 
-        if (minWidth.current === undefined) {
-          minWidth.current = cardSizes.span.minimum * (cardRect.width / cardConfigs[dashboardId].span);
+  const initStyle = {
+    borderTop: '20px solid pink',
+  };
+
+
+  interface DroppableItem {
+    node: HTMLElement;
+    rect: DOMRect;
+    isDraggingHost: boolean;
+  }
+  
+  // Reset per-element state
+  function resetDroppableItem(droppableItem: DroppableItem) {
+    droppableItem.node.style.borderTop = initStyle.borderTop;
+    droppableItem.node.style.paddingTop = initStyle.paddingTop;
+  }
+  
+  export interface DraggableRefProps {
+    children: React.ReactNode;
+    dashboardId: number;
+  }
+  
+  export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
+    children,
+    dashboardId,
+    ..._props
+  }: DraggableRefProps) => {
+    const cardConfigs: CardConfig[] = useSelector((state: RootState) => state.dashboardConfigs.list);
+    const cardRef = React.useContext(DashboardCardContext);
+    const dispatch = useDispatch();
+
+    let [refStyle, setRefStyle] = React.useState<{}>(initStyle);
+    /* eslint-enable prefer-const */
+    const [isDragging, setIsDragging] = React.useState(false);
+    const [isValidDrag, setIsValidDrag] = React.useState(true);
+    // Some state is better just to leave as vars passed around between various callbacks
+    // You can only drag around one item at a time anyways...
+    let startX = 0;
+    let startY = 0;
+    let index: number; // Index of this draggable
+    let hoveringDroppable: HTMLElement;
+    let hoveringIndex: number;
+    let mouseMoveListener: EventListener;
+    let mouseUpListener: EventListener;
+    // Makes it so dragging the _bottom_ of the item over the halfway of another moves it
+    let startYOffset = 0;
+
+    const onTransitionEnd = (_ev: React.TransitionEvent<HTMLElement>) => {
+        if (isDragging) {
+          setIsDragging(false);
+          setRefStyle(initStyle);
         }
-        if (maxWidth.current === undefined) {
-          maxWidth.current = cardSizes.span.maximum * (cardRect.width / cardConfigs[dashboardId].span);
+      };
+
+    const onMouseUpWhileDragging = React.useCallback((droppableItems) => {
+        droppableItems.forEach(resetDroppableItem);
+        document.removeEventListener('mousemove', mouseMoveListener);
+        document.removeEventListener('mouseup', mouseUpListener);
+        document.removeEventListener('contextmenu', mouseUpListener);
+        console.log(hoveringDroppable);
+        
+
+        if (hoveringDroppable) {
+          console.log("HOVERING DROPPABLE:" + hoveringIndex);
+          setIsDragging(false);
+          dispatch(dashboardCardConfigReorderCardIntent(dashboardId, hoveringIndex))
+        }
+        else {
+          setRefStyle({
+            ...initStyle,
+            transition: 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s',
+            transform: '',
+          });
         }
 
-        const minCardRight = cardRect.left + minWidth.current;
-        const maxCardRight = cardRect.left + maxWidth.current * nearEdgeMultiplier(mousePos);
 
-        const newSize = mousePos;
+          
+    }, [dispatch, setIsDragging, setRefStyle, isDragging, dashboardId]);
 
-        const gridSpan = normalizeAsGridSpans(
-          newSize,
-          minCardRight,
-          maxCardRight,
-          cardSizes.span.minimum,
-          cardSizes.span.maximum
-        ) as gridSpans;
+    const onMouseMoveWhileDragging = (ev: MouseEvent, draggableItems: DroppableItem[], blankDivRect: DOMRect) => {
+        hoveringDroppable = null;
+        draggableItems.forEach((draggableItem) => {
+            if(overlaps(ev, draggableItem.rect) && !draggableItem.isDraggingHost) {
+                draggableItem.node.style.borderTop = '20px solid purple';
+                hoveringDroppable = draggableItem.node;
+                hoveringIndex = parseInt(draggableItem.node.getAttribute('dashboard-card-order') as string);
+                
+            } else {
+                resetDroppableItem(draggableItem);
+            }
+        });
+        setRefStyle({
+            ...refStyle,
+            transform: `translate(${ev.pageX - startX}px, ${ev.pageY - startY}px)`
+          });
+        // hoveringIndex = null;
+        // if (hoveringDroppable) {
+        //     draggableItems.forEach((n, i) => {
+        //         n.node.style.transition = 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s';
+        //         const parent = n.node.closest('div.pf-l-grid__item');
+        //       });
+        // }
+    };
 
-        dispatch(dashboardCardConfigResizeCardIntent(dashboardId, gridSpan));
-      } else {
-        console.error('cardRef.current is undefined');
-      }
-    },
-    [dispatch, cardRef, cardConfigs, nearEdgeMultiplier, dashboardId, cardSizes]
-  );
+    const onDragStart = React.useCallback((ev: React.DragEvent<HTMLDivElement>) => {
+        ev.preventDefault();
+        if (isDragging) {
+            return;
+        }
+        const dragging = ev.target as HTMLElement;
+        const rect = dragging.getBoundingClientRect();
+        const draggableNodes = Array.from(document.querySelectorAll('div.draggable-ref'));
+        const draggableItems = draggableNodes.reduce((acc: any[], cur) => {
+            const isDraggingHost = cur.contains(dragging);
+            if (isDraggingHost) {
+              index = draggableNodes.indexOf(dragging);
+            }
+            const droppableItem = {
+              node: cur,
+              rect: cur.getBoundingClientRect(),
+              isDraggingHost,
+              draggableNodes: draggableNodes.map(node => (node === dragging ? node.cloneNode(false) : node)),
+              draggableNodesRects: draggableNodes.map(node => node.getBoundingClientRect())
+            };
+            acc.push(droppableItem);
+            return acc;
+        }, []);
 
-  const callbackMouseUp = React.useCallback(() => {
-    if (!isResizing.current) {
-      return;
-    }
-    isResizing.current = false;
-    document.body.style.removeProperty('cursor');
-    document.removeEventListener('mousemove', callbackMouseMove);
-    document.removeEventListener('mouseup', callbackMouseUp);
-  }, [callbackMouseMove]);
+        // Set initial style so future style mods take effect
+        refStyle = {
+            ...refStyle,
+            borderTop: '5px dashed #8a8d90',
+            top: rect.y,
+            left: rect.x,
+            width: rect.width,
+            height: rect.height,
+            position: 'fixed',
+            zIndex: 5000
+        } as any;
+        setRefStyle(refStyle);
+        // Store event details
+        startX = ev.pageX;
+        startY = ev.pageY;
+        startYOffset = startY - rect.y;
+        setIsDragging(true);
+        mouseMoveListener = ev => onMouseMoveWhileDragging(ev as MouseEvent, draggableItems, rect);
+        mouseUpListener = () => onMouseUpWhileDragging(draggableItems);
+        document.addEventListener('mousemove', mouseMoveListener);
+        document.addEventListener('mouseup', mouseUpListener);
 
-  const handleOnMouseDown = React.useCallback(
-    (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-      e.stopPropagation();
-      e.preventDefault();
-      document.body.style.setProperty('cursor', 'col-resize');
-      document.addEventListener('mousemove', callbackMouseMove);
-      document.addEventListener('mouseup', callbackMouseUp);
-      isResizing.current = true;
-      minWidth.current = undefined;
-      maxWidth.current = undefined;
-    },
-    [callbackMouseMove, callbackMouseUp]
-  );
+    }, [setRefStyle, setIsDragging, isDragging]);
 
-  return (
-    <div
-      onMouseDown={handleOnMouseDown}
-      style={{
-        cursor: 'col-resize',
-        position: 'relative',
-        borderRight: '4px outset black',
-        borderRadius: '16px',
-      }}
-    />
-  );
-};
+    const variableAttribute = React.useMemo(() =>  
+        {
+            return {['dashboard-card-order']: dashboardId};
+        }
+    , [dashboardId]);
+
+    return (
+        <div className={`draggable-ref${isDragging ? ' dragging' : ''}`}
+            {...variableAttribute}
+            draggable
+            onDragStart={onDragStart} 
+            onTransitionEnd={onTransitionEnd}
+            style={{ ...refStyle}}
+        >
+          <div className="draggable-ref__content">
+            {children}
+          </div>
+        </div>
+    );
+  };
+  

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -218,6 +218,11 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
             setDroppableItem(di, transition, `translate(0, ${overlapTranslateY}px`);
             insertPosition.current = idx;
             swap.current = true;
+            droppableItems.forEach((_di, _idx) => {
+              if (_idx !== dragIndex && _idx !== idx) {
+                resetDroppableItem(_di);
+              }
+            });
           } else {
             // mouse is hovering between two cards
             const gapIndex = (idx + 1) % droppableItems.length;

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -52,7 +52,10 @@ function inBetween(ev: MouseEvent, rect1: DOMRect, rect2: DOMRect): [boolean, it
   // Cases
   // same row -> between: no ends
   const singleRowBetween =
-    rect1.top === rect2.top && rect1.right <= ev.clientX + 20 && ev.clientX - 20 <= rect2.left && withinHeightRect1;
+    rect1.top === rect2.top &&
+    rect1.right <= ev.clientX + translateX &&
+    ev.clientX - translateX <= rect2.left &&
+    withinHeightRect1;
   // same row -> before: left end
   const singleRowBefore =
     rect1.top === rect2.top && ev.clientX <= rect2.left && rect1.left >= rect2.right && withinHeightRect1;
@@ -83,7 +86,7 @@ const initStyle = {};
 const transition = 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s';
 const delayedTransition = 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.3s';
 const overlapTranslateY = -15;
-const translateX = 20;
+const translateX = 30;
 
 function overlaps(ev: MouseEvent, rect: DOMRect) {
   return (

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -124,7 +124,7 @@ export interface DraggableRefProps {
   dashboardId: number;
 }
 
-export const draggableRef = `draggable-ref`;
+export const draggableRefKlazz = `draggable-ref`;
 
 export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
   children,
@@ -303,7 +303,7 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
       const dragging = ev.target as HTMLElement;
       const rect = dragging.getBoundingClientRect();
 
-      const draggableNodes: HTMLElement[] = Array.from(document.querySelectorAll(`div.${draggableRef}-ref`));
+      const draggableNodes: HTMLElement[] = Array.from(document.querySelectorAll(`div.${draggableRefKlazz}-ref`));
       const droppableItems: DroppableItem[] = draggableNodes.reduce((acc: DroppableItem[], cur) => {
         const isDraggingHost = cur.contains(dragging);
         const droppableItem: DroppableItem = {
@@ -345,7 +345,7 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
   return (
     <div
       ref={wrapperRef}
-      className={css(`${draggableRef}-wrapper`)}
+      className={css(`${draggableRefKlazz}-wrapper`)}
       onDragStart={onDragStart}
       onTransitionEnd={onTransitionEnd}
       style={{ ...refStyle }}

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -87,6 +87,8 @@ const overlapTranslateY = -15;
 const translateX = 20;
 
 function overlaps(ev: MouseEvent, rect: DOMRect) {
+  console.log('ASDFSA');
+
   return (
     ev.clientX - translateX > rect.left &&
     ev.clientX + translateX < rect.right &&
@@ -132,7 +134,6 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
   ..._props
 }: DraggableRefProps) => {
   const dispatch = useDispatch();
-  const draggableRef = React.useRef<HTMLDivElement>(null);
   const wrapperRef = React.useRef<HTMLDivElement>(null);
 
   const startCoords = React.useRef<[number, number]>([0, 0]);
@@ -217,10 +218,12 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
                 hoveringDroppable.current = nextItem.node;
                 hoveringIndex.current = hover;
                 swap.current = false;
+                // check which items should be translated
                 droppableItems.forEach((_item, _idx) => {
                   if (_item.isDraggingHost) {
                     return;
                   }
+                  // handle cases where the hovered card is the first or last card of a row is hovered in
                   if (draggedPosition == 'left') {
                     if (_idx >= hover && _idx < dragOrder && _item.rect.top == nextItem.rect.top) {
                       setDroppableItem(_item, delayedTransition, `translate(${translateX}px, 0px)`, true);
@@ -303,7 +306,7 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
       const dragging = ev.target as HTMLElement;
       const rect = dragging.getBoundingClientRect();
 
-      const draggableNodes: HTMLElement[] = Array.from(document.querySelectorAll(`div.${draggableRefKlazz}-ref`));
+      const draggableNodes: HTMLElement[] = Array.from(document.querySelectorAll(`div.${draggableRefKlazz}-wrapper`));
       const droppableItems: DroppableItem[] = draggableNodes.reduce((acc: DroppableItem[], cur) => {
         const isDraggingHost = cur.contains(dragging);
         const droppableItem: DroppableItem = {

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -86,7 +86,7 @@ const initStyle = {};
 const transition = 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s';
 const delayedTransition = 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.3s';
 const overlapTranslateY = -15;
-const translateX = 30;
+const translateX = 50;
 
 function overlaps(ev: MouseEvent, rect: DOMRect) {
   return (
@@ -108,7 +108,7 @@ interface DroppableItem {
 }
 
 function resetDroppableItem(droppableItem: DroppableItem) {
-  droppableItem.node.style.transition = '';
+  droppableItem.node.style.transition = transition;
   droppableItem.node.style.transform = '';
   droppableItem.isHovered = false;
 }
@@ -279,7 +279,7 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
                 }
               }
             } else {
-              if (!di.isDraggingHost && !di.isHovered) {
+              if (!di.isDraggingHost && hoveringDroppable.current == null) {
                 resetDroppableItem(di);
               }
             }

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -40,13 +40,13 @@ import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
-type itemPosition = 'left' | 'right' | 'else';
+type ItemPosition = 'left' | 'right' | 'inBetween';
 //
 // |-----------------| mouse |-----------------|
 // |   rect1.right   ^       ^   rect2.left    |
 // |                 |       |                 |
 // returns [inBetweenTwoRectangles, {insertedOnLeft, insertedOnRight, else}]
-function inBetween(ev: MouseEvent, rect1: DOMRect, rect2: DOMRect): [boolean, itemPosition] {
+const inBetween = (ev: MouseEvent, rect1: DOMRect, rect2: DOMRect): [boolean, ItemPosition] => {
   const withinHeightRect1 = ev.clientY > rect1.top && ev.clientY < rect1.bottom;
   const withinHeightRect2 = ev.clientY > rect2.top && ev.clientY < rect2.bottom;
   // Cases
@@ -74,7 +74,7 @@ function inBetween(ev: MouseEvent, rect1: DOMRect, rect2: DOMRect): [boolean, it
     return [true, 'right'];
   }
   // different rows -> between: no ends
-  return [singleRowBetween, 'else'];
+  return [singleRowBetween, 'inBetween'];
 }
 
 function getOrder(el: HTMLElement): number {
@@ -109,13 +109,15 @@ interface DroppableItem {
 }
 
 function resetDroppableItem(droppableItem: DroppableItem) {
-  droppableItem.node.style.transition = transition;
+  droppableItem.node.style.opacity = '1';
+  droppableItem.node.style.transition = transition + ', opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.1s';
   droppableItem.node.style.transform = '';
   droppableItem.isHovered = false;
 }
 
 function setDroppableItem(droppableItem: DroppableItem, transition: string, transform: string, isHovered?: boolean) {
-  droppableItem.node.style.transition = transition;
+  droppableItem.node.style.opacity = '0.5';
+  droppableItem.node.style.transition = transition + ', opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.1s';
   droppableItem.node.style.transform = transform;
   if (isHovered !== undefined) {
     droppableItem.isHovered = isHovered;
@@ -202,9 +204,7 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
             swap.current = true;
             // reset non overlapping items
             droppableItems.forEach((_item, _idx) => {
-              if (_idx == idx || _item.isDraggingHost) {
-                return;
-              }
+              if (_idx == idx || _item.isDraggingHost) return;
               resetDroppableItem(_item);
             });
           } else {

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -53,8 +53,8 @@ function inBetween(ev: MouseEvent, rect1: DOMRect, rect2: DOMRect): [boolean, it
   // same row -> between: no ends
   const singleRowBetween =
     rect1.top === rect2.top &&
-    rect1.right <= ev.clientX + translateX &&
-    ev.clientX - translateX <= rect2.left &&
+    rect1.right <= ev.clientX + rect1.width * offsetScale &&
+    ev.clientX - rect2.width * offsetScale <= rect2.left &&
     withinHeightRect1;
   // same row -> before: left end
   const singleRowBefore =
@@ -87,11 +87,12 @@ const transition = 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s';
 const delayedTransition = 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.3s';
 const overlapTranslateY = -15;
 const translateX = 50;
+const offsetScale = 0.33;
 
-function overlaps(ev: MouseEvent, rect: DOMRect) {
+function overlaps(ev: MouseEvent, rect: DOMRect): boolean {
   return (
-    ev.clientX - translateX > rect.left &&
-    ev.clientX + translateX < rect.right &&
+    ev.clientX - rect.width * offsetScale > rect.left &&
+    ev.clientX + rect.width * offsetScale < rect.right &&
     ev.clientY > rect.top &&
     ev.clientY < rect.bottom
   );
@@ -256,12 +257,10 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
                     return;
                   }
                   if (draggedPosition == 'left') {
-                    if (_idx > idx && _item.rect.top == di.rect.top) {
+                    if (_idx > idx && _item.rect.top == nextItem.rect.top) {
                       setDroppableItem(_item, delayedTransition, `translate(${translateX}px, 0px)`, true);
                     }
-                  }
-                  // correct
-                  else if (draggedPosition == 'right') {
+                  } else if (draggedPosition == 'right') {
                     if (_idx <= idx && _idx > dragOrder && _item.rect.top == di.rect.top) {
                       setDroppableItem(_item, delayedTransition, `translate(-${translateX}px, 0px)`, true);
                     }
@@ -274,11 +273,13 @@ export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
                   }
                 });
               } else {
-                if (!di.isDraggingHost && !di.isHovered) {
+                // dragged card is in the same position as the hovered card');
+                if (!di.isDraggingHost) {
                   resetDroppableItem(di);
                 }
               }
             } else {
+              // reset when the mouse is not hovering on a card or between two cards
               if (!di.isDraggingHost && hoveringDroppable.current == null) {
                 resetDroppableItem(di);
               }

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -36,216 +36,170 @@
  * SOFTWARE.
  */
 import {
-    CardConfig,
-    dashboardCardConfigReorderCardIntent,
-    dashboardCardConfigResizeCardIntent,
-  } from '@app/Shared/Redux/Configurations/DashboardConfigSlicer';
-  import { RootState } from '@app/Shared/Redux/ReduxStore';
-  import { gridSpans } from '@patternfly/react-core';
+  CardConfig,
+  dashboardCardConfigReorderCardIntent,
+} from '@app/Shared/Redux/Configurations/DashboardConfigSlicer';
+import { RootState } from '@app/Shared/Redux/ReduxStore';
 import { GripVerticalIcon } from '@patternfly/react-icons';
-  import _ from 'lodash';
-  import React from 'react';
-  import { useDispatch, useSelector } from 'react-redux';
-  import { DashboardCardSizes } from './Dashboard';
-  import { DashboardCardContext } from './DashboardCard';
+import { css } from '@patternfly/react-styles';
+import _ from 'lodash';
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
-  function getDefaultBackground() {
-    const div = document.createElement('div');
-    document.head.appendChild(div);
-    const bg = window.getComputedStyle(div).backgroundColor;
-    document.head.removeChild(div);
-    return bg;
-  }
-  
-  function getInheritedBackgroundColor(el: HTMLElement): string {
-    const defaultStyle = getDefaultBackground();
-    const backgroundColor = window.getComputedStyle(el).backgroundColor;
-  
-    if (backgroundColor !== defaultStyle) {
-      return backgroundColor;
-    } else if (!el.parentElement) {
-      return defaultStyle;
+function overlaps(ev: MouseEvent, rect: DOMRect) {
+  return (
+    ev.clientX > rect.x && ev.clientX < rect.x + rect.width && ev.clientY > rect.y && ev.clientY < rect.y + rect.height
+  );
+}
+
+const initStyle = {
+  // per card color? users can label their cards too?
+  backgroundColor: 'var(--pf-global--palette--blue-200)',
+  borderTopColor: 'var(--pf-global--BorderColor--100)'
+};
+
+interface DroppableItem {
+  node: HTMLElement;
+  rect: DOMRect;
+  isDraggingHost: boolean;
+}
+
+// Reset per-element state
+function resetDroppableItem(droppableItem: DroppableItem) {
+  droppableItem.node.style.backgroundColor = initStyle.backgroundColor;
+  droppableItem.node.style.borderTopColor = 'var(--pf-global--BorderColor--100)';
+}
+
+export interface DraggableRefProps {
+  children: React.ReactNode;
+  dashboardId: number;
+}
+
+export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
+  children,
+  dashboardId,
+  ..._props
+}: DraggableRefProps) => {
+  const dispatch = useDispatch();
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  let [refStyle, setRefStyle] = React.useState<{}>(initStyle);
+  /* eslint-enable prefer-const */
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [selected, setSelected] = React.useState(false);
+  let startX = 0;
+  let startY = 0;
+  let hoveringDroppable: HTMLElement | null;
+  let hoveringIndex: number | null;
+  let mouseMoveListener: EventListener;
+  let mouseUpListener: EventListener;
+
+  const onTransitionEnd = React.useCallback((_ev: React.TransitionEvent<HTMLElement>) => {
+    if (isDragging) {
+      setIsDragging(false);
+      setRefStyle(initStyle);
     }
-  
-    return getInheritedBackgroundColor(el.parentElement);
-  }
+  }, [setIsDragging, setRefStyle, isDragging]);
 
-  function overlaps(ev: MouseEvent, rect: DOMRect) {
-    return (
-      ev.clientX > rect.x && ev.clientX < rect.x + rect.width && ev.clientY > rect.y && ev.clientY < rect.y + rect.height
-    );
-  }
-
-  const initStyle = {
-    borderTop: '20px solid pink',
-  };
-
-
-  interface DroppableItem {
-    node: HTMLElement;
-    rect: DOMRect;
-    isDraggingHost: boolean;
-  }
-  
-  // Reset per-element state
-  function resetDroppableItem(droppableItem: DroppableItem) {
-    droppableItem.node.style.borderTop = initStyle.borderTop;
-    droppableItem.node.style.paddingTop = initStyle.paddingTop;
-  }
-  
-  export interface DraggableRefProps {
-    children: React.ReactNode;
-    dashboardId: number;
-  }
-  
-  export const DraggableRef: React.FunctionComponent<DraggableRefProps> = ({
-    children,
-    dashboardId,
-    ..._props
-  }: DraggableRefProps) => {
-    const cardConfigs: CardConfig[] = useSelector((state: RootState) => state.dashboardConfigs.list);
-    const cardRef = React.useContext(DashboardCardContext);
-    const dispatch = useDispatch();
-
-    let [refStyle, setRefStyle] = React.useState<{}>(initStyle);
-    /* eslint-enable prefer-const */
-    const [isDragging, setIsDragging] = React.useState(false);
-    const [isValidDrag, setIsValidDrag] = React.useState(true);
-    // Some state is better just to leave as vars passed around between various callbacks
-    // You can only drag around one item at a time anyways...
-    let startX = 0;
-    let startY = 0;
-    let index: number; // Index of this draggable
-    let hoveringDroppable: HTMLElement;
-    let hoveringIndex: number;
-    let mouseMoveListener: EventListener;
-    let mouseUpListener: EventListener;
-    // Makes it so dragging the _bottom_ of the item over the halfway of another moves it
-    let startYOffset = 0;
-
-    const onTransitionEnd = (_ev: React.TransitionEvent<HTMLElement>) => {
-        if (isDragging) {
-          setIsDragging(false);
-          setRefStyle(initStyle);
-        }
-      };
-
-    const onMouseUpWhileDragging = React.useCallback((droppableItems) => {
-        droppableItems.forEach(resetDroppableItem);
-        document.removeEventListener('mousemove', mouseMoveListener);
-        document.removeEventListener('mouseup', mouseUpListener);
-        document.removeEventListener('contextmenu', mouseUpListener);
-        console.log(hoveringDroppable);
-        
-
-        if (hoveringDroppable) {
-          console.log("HOVERING DROPPABLE:" + hoveringIndex);
-          setIsDragging(false);
-          dispatch(dashboardCardConfigReorderCardIntent(dashboardId, hoveringIndex))
-        }
-        else {
-          setRefStyle({
-            ...initStyle,
-            transition: 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s',
-            transform: '',
-          });
-        }
-
-
-          
-    }, [dispatch, setIsDragging, setRefStyle, isDragging, dashboardId]);
-
-    const onMouseMoveWhileDragging = (ev: MouseEvent, draggableItems: DroppableItem[], blankDivRect: DOMRect) => {
-        hoveringDroppable = null;
-        draggableItems.forEach((draggableItem) => {
-            if(overlaps(ev, draggableItem.rect) && !draggableItem.isDraggingHost) {
-                draggableItem.node.style.borderTop = '20px solid purple';
-                hoveringDroppable = draggableItem.node;
-                hoveringIndex = parseInt(draggableItem.node.getAttribute('dashboard-card-order') as string);
-                
-            } else {
-                resetDroppableItem(draggableItem);
-            }
-        });
+  const onMouseUpWhileDragging = React.useCallback(
+    (droppableItems) => {
+      droppableItems.forEach(resetDroppableItem);
+      document.removeEventListener('mousemove', mouseMoveListener);
+      document.removeEventListener('mouseup', mouseUpListener);
+      if (hoveringDroppable && hoveringIndex !== null) {
+        setIsDragging(false);
+        setRefStyle(initStyle);
+        dispatch(dashboardCardConfigReorderCardIntent(dashboardId, hoveringIndex));
+      } else {
         setRefStyle({
-            ...refStyle,
-            transform: `translate(${ev.pageX - startX}px, ${ev.pageY - startY}px)`
-          });
-        // hoveringIndex = null;
-        // if (hoveringDroppable) {
-        //     draggableItems.forEach((n, i) => {
-        //         n.node.style.transition = 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s';
-        //         const parent = n.node.closest('div.pf-l-grid__item');
-        //       });
-        // }
-    };
+          ...refStyle,
+          transition: 'transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s',
+          transform: '',
+        });
+      }
+      setSelected(false);
+    },
+    [dispatch, setIsDragging, setRefStyle, refStyle, dashboardId]
+  );
 
-    const onDragStart = React.useCallback((ev: React.DragEvent<HTMLDivElement>) => {
-        ev.preventDefault();
-        if (isDragging) {
-            return;
-        }
-        const dragging = ev.target as HTMLElement;
-        const rect = dragging.getBoundingClientRect();
-        const draggableNodes = Array.from(document.querySelectorAll('div.draggable-ref'));
-        const draggableItems = draggableNodes.reduce((acc: any[], cur) => {
-            const isDraggingHost = cur.contains(dragging);
-            if (isDraggingHost) {
-              index = draggableNodes.indexOf(dragging);
-            }
-            const droppableItem = {
-              node: cur,
-              rect: cur.getBoundingClientRect(),
-              isDraggingHost,
-              draggableNodes: draggableNodes.map(node => (node === dragging ? node.cloneNode(false) : node)),
-              draggableNodesRects: draggableNodes.map(node => node.getBoundingClientRect())
-            };
-            acc.push(droppableItem);
-            return acc;
-        }, []);
+  const onMouseMoveWhileDragging = React.useCallback((ev: MouseEvent, draggableItems: DroppableItem[]) => {
+    hoveringDroppable = null;
+    hoveringIndex = null;
+    draggableItems.forEach((draggableItem) => {
+      if (overlaps(ev, draggableItem.rect) && !draggableItem.isDraggingHost) {        
+        draggableItem.node.style.backgroundColor = 'var(--pf-global--palette--green-100)';
+        hoveringDroppable = draggableItem.node;
+        hoveringIndex = parseInt(draggableItem.node.getAttribute('dashboard-card-order') as string);
+      } else {
+        resetDroppableItem(draggableItem);
+      }
+    });
+    setRefStyle({
+      ...refStyle,
+      transform: `translate(${ev.pageX - startX}px, ${ev.pageY - startY}px)`,
+    });
+  }, [setRefStyle, refStyle]);
 
-        // Set initial style so future style mods take effect
-        refStyle = {
-            ...refStyle,
-            borderTop: '5px dashed #8a8d90',
-            top: rect.y,
-            left: rect.x,
-            width: rect.width,
-            height: rect.height,
-            position: 'fixed',
-            zIndex: 5000
-        } as any;
-        setRefStyle(refStyle);
-        // Store event details
-        startX = ev.pageX;
-        startY = ev.pageY;
-        startYOffset = startY - rect.y;
-        setIsDragging(true);
-        mouseMoveListener = ev => onMouseMoveWhileDragging(ev as MouseEvent, draggableItems, rect);
-        mouseUpListener = () => onMouseUpWhileDragging(draggableItems);
-        document.addEventListener('mousemove', mouseMoveListener);
-        document.addEventListener('mouseup', mouseUpListener);
+  const onDragStart = React.useCallback(
+    (ev: React.DragEvent<HTMLDivElement>) => {
+      ev.preventDefault();
+      if (isDragging) {
+        return;
+      }
+      const dragging = ev.target as HTMLElement;
+      const rect = dragging.getBoundingClientRect();
+      const draggableNodes = Array.from(document.querySelectorAll('div.draggable-ref'));
+      const draggableItems = draggableNodes.reduce((acc: any[], cur) => {
+        const isDraggingHost = cur.contains(dragging);
+        const droppableItem = {
+          node: cur,
+          rect: cur.getBoundingClientRect(),
+          isDraggingHost,
+        };
+        acc.push(droppableItem);
+        return acc;
+      }, []);
 
-    }, [setRefStyle, setIsDragging, isDragging]);
+      refStyle = {
+        ...refStyle,
+        top: rect.y,
+        left: rect.x,
+        width: rect.width,
+        height: rect.height,
+        position: 'fixed',
+        zIndex: 5000,
+      } as any;
+      startX = ev.pageX;
+      startY = ev.pageY;
+      setRefStyle(refStyle);
+      setIsDragging(true);
+      setSelected(true);
+      mouseMoveListener = (ev) => onMouseMoveWhileDragging(ev as MouseEvent, draggableItems);
+      mouseUpListener = () => onMouseUpWhileDragging(draggableItems);
+      document.addEventListener('mousemove', mouseMoveListener);
+      document.addEventListener('mouseup', mouseUpListener);
+    },
+    [setRefStyle, setIsDragging, setSelected, onMouseMoveWhileDragging, onMouseUpWhileDragging, isDragging]
+  );
 
-    const variableAttribute = React.useMemo(() =>  
-        {
-            return {['dashboard-card-order']: dashboardId};
-        }
-    , [dashboardId]);
+  const variableAttribute = React.useMemo(() => {
+    return { ['dashboard-card-order']: dashboardId };
+  }, [dashboardId]);
 
-    return (
-        <div className={`draggable-ref${isDragging ? ' dragging' : ''}`}
-            {...variableAttribute}
-            draggable
-            onDragStart={onDragStart} 
-            onTransitionEnd={onTransitionEnd}
-            style={{ ...refStyle}}
-        >
-          <div className="draggable-ref__content">
-            {children}
-          </div>
-        </div>
-    );
-  };
-  
+  return (
+    <div
+      className={css(
+        `draggable-ref`
+      )}
+      {...variableAttribute}
+      onDragStart={onDragStart}
+      onTransitionEnd={onTransitionEnd}
+      style={{ ...refStyle }}
+    >
+      <div ref={ref} draggable className={css('draggable-ref__grip')}>
+        <GripVerticalIcon />
+      </div>
+      <div className={css("draggable-ref__content", selected && 'draggable-ref__dragging')}>{children}</div>
+    </div>
+  );
+};

--- a/src/app/Dashboard/ResizableRef.tsx
+++ b/src/app/Dashboard/ResizableRef.tsx
@@ -147,13 +147,8 @@ export const ResizableRef: React.FunctionComponent<ResizableRefProps> = ({
 
   return (
     <div
+      className="resizable-ref"
       onMouseDown={handleOnMouseDown}
-      style={{
-        cursor: 'col-resize',
-        position: 'relative',
-        borderRight: '4px outset black',
-        borderRadius: '16px',
-      }}
     />
   );
 };

--- a/src/app/Dashboard/ResizableRef.tsx
+++ b/src/app/Dashboard/ResizableRef.tsx
@@ -145,10 +145,5 @@ export const ResizableRef: React.FunctionComponent<ResizableRefProps> = ({
     [callbackMouseMove, callbackMouseUp]
   );
 
-  return (
-    <div
-      className="resizable-ref"
-      onMouseDown={handleOnMouseDown}
-    />
-  );
+  return <div className="resizable-ref" onMouseDown={handleOnMouseDown} />;
 };

--- a/src/app/Dashboard/ResizableRef.tsx
+++ b/src/app/Dashboard/ResizableRef.tsx
@@ -1,0 +1,159 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import {
+  CardConfig,
+  dashboardCardConfigResizeCardIntent,
+} from '@app/Shared/Redux/Configurations/DashboardConfigSlicer';
+import { RootState } from '@app/Shared/Redux/ReduxStore';
+import { gridSpans } from '@patternfly/react-core';
+import _ from 'lodash';
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { DashboardCardSizes } from './Dashboard';
+import { DashboardCardContext } from './DashboardCard';
+
+export interface ResizableRefProps {
+  dashboardId: number;
+  cardSizes: DashboardCardSizes;
+}
+
+function normalizeAsGridSpans(val: number, min: number, max: number, a: gridSpans, b: gridSpans): gridSpans {
+  if (val < min) val = min;
+  else if (val > max) val = max;
+  const ans = Math.round((b - a) * ((val - min) / (max - min)) + a);
+  return _.clamp(ans, a, b) as gridSpans;
+}
+
+export const ResizableRef: React.FunctionComponent<ResizableRefProps> = ({
+  dashboardId,
+  cardSizes,
+  ..._props
+}: ResizableRefProps) => {
+  const cardConfigs: CardConfig[] = useSelector((state: RootState) => state.dashboardConfigs.list);
+  const dispatch = useDispatch();
+
+  const cardRef = React.useContext(DashboardCardContext);
+  const isResizing = React.useRef<boolean>(false);
+  const minWidth = React.useRef<number | undefined>(undefined);
+  const maxWidth = React.useRef<number | undefined>(undefined);
+
+  const nearEdgeMultiplier = React.useCallback((mousePos: number): number => {
+    const CLOSE_TO_EDGE = 0.995;
+    const EDGE_MULTIPLIER = 0.9;
+    if (mousePos > window.innerWidth * CLOSE_TO_EDGE) {
+      return EDGE_MULTIPLIER;
+    } else {
+      return 1;
+    }
+  }, []);
+
+  const callbackMouseMove = React.useCallback(
+    (e: MouseEvent) => {
+      const mousePos = e.clientX;
+      e.stopPropagation();
+      if (!isResizing.current) {
+        return;
+      }
+      if (cardRef.current) {
+        cardRef.current.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'end' });
+        const cardRect = cardRef.current.getBoundingClientRect();
+
+        if (minWidth.current === undefined) {
+          minWidth.current = cardSizes.span.minimum * (cardRect.width / cardConfigs[dashboardId].span);
+        }
+        if (maxWidth.current === undefined) {
+          maxWidth.current = cardSizes.span.maximum * (cardRect.width / cardConfigs[dashboardId].span);
+        }
+
+        const minCardRight = cardRect.left + minWidth.current;
+        const maxCardRight = cardRect.left + maxWidth.current * nearEdgeMultiplier(mousePos);
+
+        const newSize = mousePos;
+
+        const gridSpan = normalizeAsGridSpans(
+          newSize,
+          minCardRight,
+          maxCardRight,
+          cardSizes.span.minimum,
+          cardSizes.span.maximum
+        ) as gridSpans;
+
+        dispatch(dashboardCardConfigResizeCardIntent(dashboardId, gridSpan));
+      } else {
+        console.error('cardRef.current is undefined');
+      }
+    },
+    [dispatch, cardRef, cardConfigs, nearEdgeMultiplier, dashboardId, cardSizes]
+  );
+
+  const callbackMouseUp = React.useCallback(() => {
+    if (!isResizing.current) {
+      return;
+    }
+    isResizing.current = false;
+    document.body.style.removeProperty('cursor');
+    document.removeEventListener('mousemove', callbackMouseMove);
+    document.removeEventListener('mouseup', callbackMouseUp);
+  }, [callbackMouseMove]);
+
+  const handleOnMouseDown = React.useCallback(
+    (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      e.stopPropagation();
+      e.preventDefault();
+      document.body.style.setProperty('cursor', 'col-resize');
+      document.addEventListener('mousemove', callbackMouseMove);
+      document.addEventListener('mouseup', callbackMouseUp);
+      isResizing.current = true;
+      minWidth.current = undefined;
+      maxWidth.current = undefined;
+    },
+    [callbackMouseMove, callbackMouseUp]
+  );
+
+  return (
+    <div
+      onMouseDown={handleOnMouseDown}
+      style={{
+        cursor: 'col-resize',
+        position: 'relative',
+        borderRight: '4px outset black',
+        borderRadius: '16px',
+      }}
+    />
+  );
+};

--- a/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
+++ b/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
@@ -118,7 +118,7 @@ const INITIAL_STATE = getPersistedState('DASHBOARD_CFG', _version, {
   list: [] as CardConfig[],
 });
 
-function move(arr: any[], from: number, to: number) {
+function move(arr: [], from: number, to: number) {
   arr.splice(to, 0, arr.splice(from, 1)[0]);
   return arr;
 }

--- a/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
+++ b/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
@@ -36,11 +36,12 @@
  * SOFTWARE.
  */
 
+import { move, swap } from '@app/utils/utils';
 import { gridSpans } from '@patternfly/react-core';
 import { createAction, createReducer } from '@reduxjs/toolkit';
 import { getPersistedState } from '../utils';
 
-const _version = '2';
+const _version = '3';
 
 // Common action string format: "resource(s)/action"
 export enum DashboardConfigAction {
@@ -67,8 +68,8 @@ export interface DashboardResizeConfigActionPayload {
 }
 
 export interface DashboardOrderConfigActionPayload {
-  idx: number;
-  order: number;
+  prevOrder: number;
+  nextOrder: number;
   swap: boolean;
 }
 
@@ -101,10 +102,10 @@ export const dashboardCardConfigResizeCardIntent = createAction(
 
 export const dashboardCardConfigReorderCardIntent = createAction(
   DashboardConfigAction.CARD_REORDER,
-  (idx: number, order: number, swap = false) => ({
+  (prevOrder: number, nextOrder: number, swap = false) => ({
     payload: {
-      idx,
-      order,
+      prevOrder,
+      nextOrder,
       swap,
     } as DashboardOrderConfigActionPayload,
   })
@@ -120,16 +121,6 @@ const INITIAL_STATE = getPersistedState('DASHBOARD_CFG', _version, {
   list: [] as CardConfig[],
 });
 
-export function move(arr: [], from: number, to: number) {
-  arr.splice(to, 0, arr.splice(from, 1)[0]);
-  return arr;
-}
-
-function swap(arr: [], from: number, to: number) {
-  arr[from] = arr.splice(to, 1, arr[from])[0];
-  return arr;
-}
-
 export const dashboardConfigReducer = createReducer(INITIAL_STATE, (builder) => {
   builder
     .addCase(dashboardCardConfigAddCardIntent, (state, { payload }) => {
@@ -143,9 +134,9 @@ export const dashboardConfigReducer = createReducer(INITIAL_STATE, (builder) => 
     })
     .addCase(dashboardCardConfigReorderCardIntent, (state, { payload }) => {
       if (payload.swap) {
-        swap(state.list, payload.idx, payload.order);
+        swap(state.list, payload.prevOrder, payload.nextOrder);
       } else {
-        move(state.list, payload.idx, payload.order);
+        move(state.list, payload.prevOrder, payload.nextOrder);
       }
     });
 });

--- a/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
+++ b/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
@@ -69,6 +69,7 @@ export interface DashboardResizeConfigActionPayload {
 export interface DashboardOrderConfigActionPayload {
   idx: number;
   order: number;
+  swap: boolean;
 }
 
 export const dashboardCardConfigAddCardIntent = createAction(
@@ -100,10 +101,11 @@ export const dashboardCardConfigResizeCardIntent = createAction(
 
 export const dashboardCardConfigReorderCardIntent = createAction(
   DashboardConfigAction.CARD_REORDER,
-  (idx: number, order: number) => ({
+  (idx: number, order: number, swap = false) => ({
     payload: {
       idx,
       order,
+      swap,
     } as DashboardOrderConfigActionPayload,
   })
 );
@@ -118,8 +120,13 @@ const INITIAL_STATE = getPersistedState('DASHBOARD_CFG', _version, {
   list: [] as CardConfig[],
 });
 
-function move(arr: [], from: number, to: number) {
+export function move(arr: [], from: number, to: number) {
   arr.splice(to, 0, arr.splice(from, 1)[0]);
+  return arr;
+}
+
+function swap(arr: [], from: number, to: number) {
+  arr[from] = arr.splice(to, 1, arr[from])[0];
   return arr;
 }
 
@@ -135,7 +142,11 @@ export const dashboardConfigReducer = createReducer(INITIAL_STATE, (builder) => 
       state.list[payload.idx].span = payload.span;
     })
     .addCase(dashboardCardConfigReorderCardIntent, (state, { payload }) => {
-      state.list = move(state.list, payload.idx, payload.order);
+      if (payload.swap) {
+        swap(state.list, payload.idx, payload.order);
+      } else {
+        move(state.list, payload.idx, payload.order);
+      }
     });
 });
 

--- a/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
+++ b/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
@@ -54,6 +54,7 @@ export enum DashboardConfigAction {
 export const enumValues = new Set(Object.values(DashboardConfigAction));
 
 export interface DashboardAddConfigActionPayload {
+  id: string;
   name: string;
   props: object;
 }
@@ -75,8 +76,9 @@ export interface DashboardOrderConfigActionPayload {
 
 export const dashboardCardConfigAddCardIntent = createAction(
   DashboardConfigAction.CARD_ADD,
-  (name: string, span: gridSpans, props: object) => ({
+  (id: string, name: string, span: gridSpans, props: object) => ({
     payload: {
+      id,
       name,
       span,
       props,
@@ -112,6 +114,7 @@ export const dashboardCardConfigReorderCardIntent = createAction(
 );
 
 export interface CardConfig {
+  id: string;
   name: string;
   span: gridSpans;
   props: object;

--- a/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
+++ b/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
@@ -121,7 +121,7 @@ const INITIAL_STATE = getPersistedState('DASHBOARD_CFG', _version, {
 function move(arr: any[], from: number, to: number) {
   arr.splice(to, 0, arr.splice(from, 1)[0]);
   return arr;
-};
+}
 
 export const dashboardConfigReducer = createReducer(INITIAL_STATE, (builder) => {
   builder

--- a/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
+++ b/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 
-import { move, swap } from '@app/utils/utils';
+import { moveDashboardCard, swapDashboardCard } from '@app/utils/utils';
 import { gridSpans } from '@patternfly/react-core';
 import { createAction, createReducer } from '@reduxjs/toolkit';
 import { getPersistedState } from '../utils';
@@ -137,9 +137,9 @@ export const dashboardConfigReducer = createReducer(INITIAL_STATE, (builder) => 
     })
     .addCase(dashboardCardConfigReorderCardIntent, (state, { payload }) => {
       if (payload.swap) {
-        swap(state.list, payload.prevOrder, payload.nextOrder);
+        swapDashboardCard(state.list, payload.prevOrder, payload.nextOrder);
       } else {
-        move(state.list, payload.prevOrder, payload.nextOrder);
+        moveDashboardCard(state.list, payload.prevOrder, payload.nextOrder);
       }
     });
 });

--- a/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
+++ b/src/app/Shared/Redux/Configurations/DashboardConfigSlicer.tsx
@@ -46,6 +46,7 @@ const _version = '2';
 export enum DashboardConfigAction {
   CARD_ADD = 'dashboard-card-config/add',
   CARD_REMOVE = 'dashboard-card-config/remove',
+  CARD_REORDER = 'dashboard-card-config/reorder',
   CARD_RESIZE = 'dashboard-card-config/resize',
 }
 
@@ -63,6 +64,11 @@ export interface DashboardDeleteConfigActionPayload {
 export interface DashboardResizeConfigActionPayload {
   idx: number;
   span: number;
+}
+
+export interface DashboardOrderConfigActionPayload {
+  idx: number;
+  order: number;
 }
 
 export const dashboardCardConfigAddCardIntent = createAction(
@@ -92,6 +98,16 @@ export const dashboardCardConfigResizeCardIntent = createAction(
   })
 );
 
+export const dashboardCardConfigReorderCardIntent = createAction(
+  DashboardConfigAction.CARD_REORDER,
+  (idx: number, order: number) => ({
+    payload: {
+      idx,
+      order,
+    } as DashboardOrderConfigActionPayload,
+  })
+);
+
 export interface CardConfig {
   name: string;
   span: gridSpans;
@@ -101,6 +117,11 @@ export interface CardConfig {
 const INITIAL_STATE = getPersistedState('DASHBOARD_CFG', _version, {
   list: [] as CardConfig[],
 });
+
+function move(arr: any[], from: number, to: number) {
+  arr.splice(to, 0, arr.splice(from, 1)[0]);
+  return arr;
+};
 
 export const dashboardConfigReducer = createReducer(INITIAL_STATE, (builder) => {
   builder
@@ -112,6 +133,9 @@ export const dashboardConfigReducer = createReducer(INITIAL_STATE, (builder) => 
     })
     .addCase(dashboardCardConfigResizeCardIntent, (state, { payload }) => {
       state.list[payload.idx].span = payload.span;
+    })
+    .addCase(dashboardCardConfigReorderCardIntent, (state, { payload }) => {
+      state.list = move(state.list, payload.idx, payload.order);
     });
 });
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -240,6 +240,30 @@ html, body, #root {
   margin-top: 0.5em;
 }
 
+.draggable-ref-wrapper__left {
+  opacity: 0.5;
+  transition: transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.1s;
+  transform: translate(-50px, 0px); 
+}
+
+.draggable-ref-wrapper__right {
+  opacity: 0.5;
+  transition: transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.1s;
+  transform: translate(50px, 0px); 
+}
+
+.draggable-ref-wrapper__overlap {
+  opacity: 0.5;
+  transform: translate(0px, -15px); 
+  transition: transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.1s;
+}
+
+.draggable-ref-wrapper__reset {
+  opacity: 1;
+  transform: '';
+  transition: transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.1s;
+}
+
 .draggable-ref-wrapper:active {
   box-shadow: 0 0.5rem 1rem 0 rgba(3, 3, 3, 0.16);
 }

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -240,13 +240,18 @@ html, body, #root {
   margin-top: 0.5em;
 }
 
-.dashboard-card {
-  width: 100%;
-  overflow: auto;
+.draggable-ref-wrapper:active {
+  box-shadow: 0 0.5rem 1rem 0 rgba(3, 3, 3, 0.16);
 }
 
 .dashboard-card-resizable-wrapper { 
   display: flex;
+}
+
+.dashboard-card {
+  position: relative;
+  width: 100%;
+  overflow: auto;
 }
 
 .pf-c-card.pf-m-rounded.dashboard-card {
@@ -263,15 +268,12 @@ html, body, #root {
 }
 
 .draggable-ref__grip {
-  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--palette--black-500); /* 1px */
-  border-bottom-left-radius: var(--pf-global--BorderRadius--sm);
-}
-
-.draggable-ref__grip {
   cursor: move;
   cursor: grab;
   cursor: -moz-grab;
   cursor: -webkit-grab;
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--palette--black-500); /* 1px */
+  border-bottom-left-radius: var(--pf-global--BorderRadius--sm);
 }
 
 .draggable-ref__grip:active {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -253,23 +253,25 @@ html, body, #root {
 .resizable-ref {
   cursor: col-resize;
   position: relative;
-  border-right: 4px outset var(--pf-global--BackgroundColor--dark-400);
-  border-bottom-right-radius: 16px;
+  border-right: var(--pf-global--BorderWidth--xl) outset var(--pf-global--BackgroundColor--dark-400);
+  border-bottom-right-radius: 3px;
 }
 
 .draggable-ref {
   border-radius: var(--pf-global--BorderRadius--sm); /* 3px */
-  border-width: var(--pf-global--BorderWidth--sm); /* 1px */
-  border-top-style: 'solid';
 }
 
 .draggable-ref__dragging {
-  border-left: 2px solid var(--pf-global--palette--blue-300);
-  border-right: 2px solid var(--pf-global--palette--blue-300);
-  border-bottom: 2px solid var(--pf-global--palette--blue-300);
+  border-bottom-left-radius: var(--pf-global--BorderRadius--sm);
+  border-bottom-right-radius: var(--pf-global--BorderRadius--sm);
+  border-left: var(--pf-global--BorderWidth--lg) solid var(--pf-global--palette--blue-300);
+  border-right: var(--pf-global--BorderWidth--lg) solid var(--pf-global--palette--blue-300);
+  border-bottom: var(--pf-global--BorderWidth--lg) solid var(--pf-global--palette--blue-300);
 }
 
 .draggable-ref__grip:hover {
+  border-top-left-radius: var(--pf-global--BorderRadius--sm);
+  border-top-right-radius: var(--pf-global--BorderRadius--sm);
   background-color: var(--pf-global--palette--blue-300);
 }
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -245,6 +245,31 @@ html, body, #root {
   overflow: auto;
 }
 
+.resizable-ref { 
+  display: flex;
+  justify-content: space-between 
+}
+
+.draggable-ref {
+  border-radius: 'var(--pf-global--BorderRadius--sm)'; /* 3px */
+  border-width: 'var(--pf-global--BorderWidth--sm)'; /* 1px */
+  border-top-style: 'solid';
+}
+
+.draggable-ref__dragging {
+  border-left: 2px solid var(--pf-global--palette--blue-300);
+  border-right: 2px solid var(--pf-global--palette--blue-300);
+  border-bottom: 2px solid var(--pf-global--palette--blue-300);
+}
+
+.draggable-ref__grip:hover {
+  background-color: var(--pf-global--palette--blue-300);
+}
+
+.draggable-ref__grip {
+  cursor: grab;
+}
+
 .xsm-icon {
   height: 0.8em;
   width: 0.8em;

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -258,13 +258,14 @@ html, body, #root {
 .resizable-ref {
   cursor: col-resize;
   position: relative;
-  border-right: var(--pf-global--BorderWidth--xl) solid var(--pf-global--BackgroundColor--dark-400);
-  border-top-right-radius: var(--pf-global--BorderRadius--sm);;
-  border-bottom-right-radius: var(--pf-global--BorderRadius--sm);;
+  border-right: var(--pf-global--BorderWidth--lg) solid var(--pf-global--palette--black-500); /* 3px */
+  border-top-right-radius: var(--pf-global--BorderRadius--sm); /* 3px */
+  border-bottom-right-radius: var(--pf-global--BorderRadius--sm);
 }
 
 .draggable-ref__grip {
-  border-bottom: var(--pf-global--BorderWidth--lg) solid var(--pf-global--BackgroundColor--dark-400);
+  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--palette--black-500); /* 1px */
+  border-bottom-left-radius: var(--pf-global--BorderRadius--sm);
 }
 
 .draggable-ref__grip {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -245,14 +245,21 @@ html, body, #root {
   overflow: auto;
 }
 
-.resizable-ref { 
+.dashboard-card-resizable-wrapper { 
   display: flex;
   justify-content: space-between 
 }
 
+.resizable-ref {
+  cursor: col-resize;
+  position: relative;
+  border-right: 4px outset var(--pf-global--BackgroundColor--dark-400);
+  border-bottom-right-radius: 16px;
+}
+
 .draggable-ref {
-  border-radius: 'var(--pf-global--BorderRadius--sm)'; /* 3px */
-  border-width: 'var(--pf-global--BorderWidth--sm)'; /* 1px */
+  border-radius: var(--pf-global--BorderRadius--sm); /* 3px */
+  border-width: var(--pf-global--BorderWidth--sm); /* 1px */
   border-top-style: 'solid';
 }
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -241,31 +241,36 @@ html, body, #root {
 }
 
 .draggable-ref-wrapper__left {
-  opacity: 0.5;
   transition: transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.1s;
-  transform: translate(-50px, 0px); 
+  transform: translate(-50px, 0px);
+  opacity: 0.5;
 }
 
 .draggable-ref-wrapper__right {
-  opacity: 0.5;
   transition: transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.1s;
-  transform: translate(50px, 0px); 
+  transform: translate(50px, 0px);
+  opacity: 0.5;
 }
 
 .draggable-ref-wrapper__overlap {
-  opacity: 0.5;
-  transform: translate(0px, -15px); 
   transition: transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.1s;
+  transform: translate(0px, -15px);
+  opacity: 0.5;
+  box-shadow: 0 0.5rem 1rem 0 rgba(3, 3, 3, 0.25);
 }
 
 .draggable-ref-wrapper__reset {
-  opacity: 1;
-  transform: '';
   transition: transform 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0s, opacity 0.5s cubic-bezier(0.2, 1, 0.1, 1) 0.1s;
+  transform: '';
+  opacity: 1;
 }
 
 .draggable-ref-wrapper:active {
-  box-shadow: 0 0.5rem 1rem 0 rgba(3, 3, 3, 0.16);
+  box-shadow: 0 0.5rem 1rem 0 rgba(3, 3, 3, 0.25);
+}
+
+.draggable-ref-hover {
+  box-shadow: 0 0.5rem 1rem 0 rgba(3, 3, 3, 0.25);
 }
 
 .dashboard-card-resizable-wrapper { 
@@ -296,8 +301,6 @@ html, body, #root {
   cursor: grab;
   cursor: -moz-grab;
   cursor: -webkit-grab;
-  border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--palette--black-500); /* 1px */
-  border-bottom-left-radius: var(--pf-global--BorderRadius--sm);
 }
 
 .draggable-ref__grip:active {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -247,7 +247,6 @@ html, body, #root {
 
 .dashboard-card-resizable-wrapper { 
   display: flex;
-  justify-content: space-between 
 }
 
 .pf-c-card.pf-m-rounded.dashboard-card {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -262,7 +262,7 @@ html, body, #root {
 .resizable-ref {
   cursor: col-resize;
   position: relative;
-  border-right: var(--pf-global--BorderWidth--lg) solid var(--pf-global--palette--black-500); /* 3px */
+  border-right: 4px solid var(--pf-global--palette--black-500);
   border-top-right-radius: var(--pf-global--BorderRadius--sm); /* 3px */
   border-bottom-right-radius: var(--pf-global--BorderRadius--sm);
 }

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -250,37 +250,34 @@ html, body, #root {
   justify-content: space-between 
 }
 
+.pf-c-card.pf-m-rounded.dashboard-card {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 .resizable-ref {
   cursor: col-resize;
   position: relative;
-  border-right: var(--pf-global--BorderWidth--xl) outset var(--pf-global--BackgroundColor--dark-400);
-  border-bottom-right-radius: 3px;
-}
-
-#dashboard-grid {
-  border: 1px solid red;
-}
-
-.draggable-ref {
-  border-radius: var(--pf-global--BorderRadius--sm); /* 3px */
-}
-
-.draggable-ref__dragging {
-  border-bottom-left-radius: var(--pf-global--BorderRadius--sm);
-  border-bottom-right-radius: var(--pf-global--BorderRadius--sm);
-  border-left: var(--pf-global--BorderWidth--lg) solid var(--pf-global--palette--blue-300);
-  border-right: var(--pf-global--BorderWidth--lg) solid var(--pf-global--palette--blue-300);
-  border-bottom: var(--pf-global--BorderWidth--lg) solid var(--pf-global--palette--blue-300);
-}
-
-.draggable-ref__grip:hover {
-  border-top-left-radius: var(--pf-global--BorderRadius--sm);
-  border-top-right-radius: var(--pf-global--BorderRadius--sm);
-  background-color: var(--pf-global--palette--blue-300);
+  border-right: var(--pf-global--BorderWidth--xl) solid var(--pf-global--BackgroundColor--dark-400);
+  border-top-right-radius: var(--pf-global--BorderRadius--sm);;
+  border-bottom-right-radius: var(--pf-global--BorderRadius--sm);;
 }
 
 .draggable-ref__grip {
+  border-bottom: var(--pf-global--BorderWidth--lg) solid var(--pf-global--BackgroundColor--dark-400);
+}
+
+.draggable-ref__grip {
+  cursor: move;
   cursor: grab;
+  cursor: -moz-grab;
+  cursor: -webkit-grab;
+}
+
+.draggable-ref__grip:active {
+  cursor: grabbing;
+  cursor: -moz-grabbing;
+  cursor: -webkit-grabbing;
 }
 
 .xsm-icon {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -257,6 +257,10 @@ html, body, #root {
   border-bottom-right-radius: 3px;
 }
 
+#dashboard-grid {
+  border: 1px solid red;
+}
+
 .draggable-ref {
   border-radius: var(--pf-global--BorderRadius--sm); /* 3px */
 }

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -41,6 +41,16 @@ const MINUTE_MILLIS = 60 * SECOND_MILLIS;
 const HOUR_MILLIS = 60 * MINUTE_MILLIS;
 const DAY_MILLIS = 24 * HOUR_MILLIS;
 
+export function move(arr: [], from: number, to: number) {
+  arr.splice(to, 0, arr.splice(from, 1)[0]);
+  return arr;
+}
+
+export function swap(arr: [], from: number, to: number) {
+  arr[from] = arr.splice(to, 1, arr[from])[0];
+  return arr;
+}
+
 export const openTabForUrl = (url: string) => {
   const anchor = document.createElement('a') as HTMLAnchorElement;
   anchor.setAttribute('href', url);

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -41,12 +41,18 @@ const MINUTE_MILLIS = 60 * SECOND_MILLIS;
 const HOUR_MILLIS = 60 * MINUTE_MILLIS;
 const DAY_MILLIS = 24 * HOUR_MILLIS;
 
-export function move(arr: [], from: number, to: number) {
-  arr.splice(to, 0, arr.splice(from, 1)[0]);
+// [     0,    1,    2,    3     ] array
+//       0     1     2     3       indexes
+// {  0  |  1  |  2  |  3  |  4  } gap indices (drop zones)
+export function moveDashboardCard(arr: [], from: number, gapIndex: number) {
+  if (gapIndex > from) {
+    gapIndex--;
+  }
+  arr.splice(gapIndex, 0, arr.splice(from, 1)[0]);
   return arr;
 }
 
-export function swap(arr: [], from: number, to: number) {
+export function swapDashboardCard(arr: [], from: number, to: number) {
   arr[from] = arr.splice(to, 1, arr[from])[0];
   return arr;
 }

--- a/src/test/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/test/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -46,9 +46,15 @@ exports[`<Dashboard /> renders correctly 1`] = `
         >
           <div
             className="pf-l-grid pf-m-gutter"
+            id="dashboard-grid"
           >
             <div
               className="pf-l-grid__item"
+              style={
+                Object {
+                  "--pf-l-grid--item--Order": "0",
+                }
+              }
             >
               <div>
                 Add Card


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #730 

## Description of the change:
This change allows cards to be re-orderable with drag-and-drop swapping functionality. 

Again, no tests since beta dashboard functionality is likely to be changed in the future.

When create DashboardCards, you must pass in a `CardHeader` into the `cardHeader` prop.

## Motivation for the change:
See #730

## How to manually test:
1. Run normal smoketest and add some cards, and rearrange them by holding the top draggable bar and drag and dropping them around on top of each other to swap the cards places. You can also drag cards between other cards to rearrange them.
