### PR TITLE
fix(layout): fix content overflow

### DIFF
--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -738,7 +738,7 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
         <ToolbarGroup style={{ alignSelf: 'start' }} variant="button-group">
           <ToolbarItem variant="overflow-menu">
             <OverflowMenu
-              breakpoint="xl"
+              breakpoint="lg"
               breakpointReference={
                 props.toolbarBreakReference ||
                 (() => document.getElementById('active-recordings-toolbar') || document.body)

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -63,6 +63,14 @@ import {
   Drawer,
   DrawerContent,
   DrawerContentBody,
+  Dropdown,
+  KebabToggle,
+  OverflowMenu,
+  OverflowMenuContent,
+  OverflowMenuControl,
+  OverflowMenuDropdownItem,
+  OverflowMenuGroup,
+  OverflowMenuItem,
   Text,
   Timestamp,
   TimestampTooltipVariant,
@@ -93,6 +101,7 @@ const tableColumns: string[] = ['Name', 'Start Time', 'Duration', 'State', 'Labe
 
 export interface ActiveRecordingsTableProps {
   archiveEnabled: boolean;
+  toolbarBreakReference?: HTMLElement | (() => HTMLElement);
 }
 
 export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTableProps> = (props) => {
@@ -449,6 +458,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
         handleStopRecordings={handleStopRecordings}
         handleDeleteRecordings={handleDeleteRecordings}
         actionLoadings={actionLoadings}
+        toolbarBreakReference={props.toolbarBreakReference}
       />
     ),
     [
@@ -466,6 +476,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
       handleStopRecordings,
       handleDeleteRecordings,
       actionLoadings,
+      props.toolbarBreakReference,
     ]
   );
 
@@ -538,16 +549,20 @@ export interface ActiveRecordingsToolbarProps {
   handleStopRecordings: () => void;
   handleDeleteRecordings: () => void;
   actionLoadings: Record<ActiveActions, boolean>;
+  toolbarBreakReference?: HTMLElement | (() => HTMLElement);
 }
 
 const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const [warningModalOpen, setWarningModalOpen] = React.useState(false);
+  const [actionToggleOpen, setActionToggleOpen] = React.useState(false);
 
   const deletionDialogsEnabled = React.useMemo(
     () => context.settings.deletionDialogsEnabledFor(DeleteOrDisableWarningType.DeleteActiveRecordings),
     [context.settings]
   );
+
+  const handleActionToggle = React.useCallback(() => setActionToggleOpen((old) => !old), [setActionToggleOpen]);
 
   const handleWarningModalClose = React.useCallback(() => {
     setWarningModalOpen(false);
@@ -593,59 +608,93 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
 
   const buttons = React.useMemo(() => {
     let arr = [
-      <Button key="create" variant="primary" onClick={props.handleCreateRecording}>
-        Create
-      </Button>,
+      {
+        default: (
+          <Button variant="primary" onClick={props.handleCreateRecording}>
+            Create
+          </Button>
+        ),
+        collapsed: (
+          <OverflowMenuDropdownItem key={'Create'} isShared onClick={props.handleCreateRecording}>
+            Create
+          </OverflowMenuDropdownItem>
+        ),
+        key: 'Create',
+      },
     ];
     if (props.archiveEnabled) {
-      arr.push(
-        <Button
-          key="archive"
-          variant="secondary"
-          onClick={props.handleArchiveRecordings}
-          isDisabled={!props.checkedIndices.length || props.actionLoadings['ARCHIVE']}
-          {...actionLoadingProps['ARCHIVE']}
-        >
-          {props.actionLoadings['ARCHIVE'] ? 'Archiving' : 'Archive'}
-        </Button>
-      );
+      arr.push({
+        default: (
+          <Button
+            variant="secondary"
+            onClick={props.handleArchiveRecordings}
+            isDisabled={!props.checkedIndices.length || props.actionLoadings['ARCHIVE']}
+            {...actionLoadingProps['ARCHIVE']}
+          >
+            {props.actionLoadings['ARCHIVE'] ? 'Archiving' : 'Archive'}
+          </Button>
+        ),
+        collapsed: (
+          <OverflowMenuDropdownItem key={'Archive'} isShared onClick={props.handleArchiveRecordings}>
+            {props.actionLoadings['ARCHIVE'] ? 'Archiving' : 'Archive'}
+          </OverflowMenuDropdownItem>
+        ),
+        key: 'Archive',
+      });
     }
     arr = [
       ...arr,
-      <Button
-        key="edit labels"
-        variant="secondary"
-        onClick={props.handleEditLabels}
-        isDisabled={!props.checkedIndices.length}
-      >
-        Edit Labels
-      </Button>,
-      <Button
-        key="stop"
-        variant="tertiary"
-        onClick={props.handleStopRecordings}
-        isDisabled={isStopDisabled}
-        {...actionLoadingProps['STOP']}
-      >
-        {props.actionLoadings['STOP'] ? 'Stopping' : 'Stop'}
-      </Button>,
-      <Button
-        key="delete"
-        variant="danger"
-        onClick={handleDeleteButton}
-        isDisabled={!props.checkedIndices.length || props.actionLoadings['DELETE']}
-        {...actionLoadingProps['DELETE']}
-      >
-        {props.actionLoadings['DELETE'] ? 'Deleting' : 'Delete'}
-      </Button>,
+      {
+        default: (
+          <Button variant="secondary" onClick={props.handleEditLabels} isDisabled={!props.checkedIndices.length}>
+            Edit Labels
+          </Button>
+        ),
+        collapsed: (
+          <OverflowMenuDropdownItem key={'Edit Labels'} isShared onClick={props.handleEditLabels}>
+            Edit Labels
+          </OverflowMenuDropdownItem>
+        ),
+        key: 'Edit Labels',
+      },
+      {
+        default: (
+          <Button
+            variant="tertiary"
+            onClick={props.handleStopRecordings}
+            isDisabled={isStopDisabled}
+            {...actionLoadingProps['STOP']}
+          >
+            {props.actionLoadings['STOP'] ? 'Stopping' : 'Stop'}
+          </Button>
+        ),
+        collapsed: (
+          <OverflowMenuDropdownItem key={'Stop'} isShared onClick={props.handleStopRecordings}>
+            {props.actionLoadings['STOP'] ? 'Stopping' : 'Stop'}
+          </OverflowMenuDropdownItem>
+        ),
+        key: 'Stop',
+      },
+      {
+        default: (
+          <Button
+            variant="danger"
+            onClick={handleDeleteButton}
+            isDisabled={!props.checkedIndices.length || props.actionLoadings['DELETE']}
+            {...actionLoadingProps['DELETE']}
+          >
+            {props.actionLoadings['DELETE'] ? 'Deleting' : 'Delete'}
+          </Button>
+        ),
+        collapsed: (
+          <OverflowMenuDropdownItem key={'Delete'} isShared onClick={handleDeleteButton}>
+            {props.actionLoadings['DELETE'] ? 'Deleting' : 'Delete'}
+          </OverflowMenuDropdownItem>
+        ),
+        key: 'Delete',
+      },
     ];
-    return (
-      <>
-        {arr.map((btn, idx) => (
-          <ToolbarItem key={idx}>{btn}</ToolbarItem>
-        ))}
-      </>
-    );
+    return arr;
   }, [
     handleDeleteButton,
     isStopDisabled,
@@ -675,6 +724,7 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
       id="active-recordings-toolbar"
       aria-label="active-recording-toolbar"
       clearAllFilters={props.handleClearFilters}
+      isSticky
     >
       <ToolbarContent>
         <RecordingFilters
@@ -683,9 +733,38 @@ const ActiveRecordingsToolbar: React.FunctionComponent<ActiveRecordingsToolbarPr
           recordings={props.recordings}
           filters={props.targetRecordingFilters}
           updateFilters={props.updateFilters}
+          breakpoint={'xl'}
         />
         <ToolbarGroup style={{ alignSelf: 'start' }} variant="button-group">
-          {buttons}
+          <ToolbarItem variant="overflow-menu">
+            <OverflowMenu
+              breakpoint="xl"
+              breakpointReference={
+                props.toolbarBreakReference ||
+                (() => document.getElementById('active-recordings-toolbar') || document.body)
+              }
+            >
+              <OverflowMenuContent>
+                <OverflowMenuGroup groupType="button">
+                  {buttons.map((b) => (
+                    <OverflowMenuItem key={b.key}>{b.default}</OverflowMenuItem>
+                  ))}
+                </OverflowMenuGroup>
+              </OverflowMenuContent>
+              <OverflowMenuControl>
+                <Dropdown
+                  aria-label={'active-recording-actions'}
+                  isPlain
+                  isFlipEnabled
+                  onSelect={() => setActionToggleOpen(false)}
+                  menuAppendTo={document.body}
+                  isOpen={actionToggleOpen}
+                  toggle={<KebabToggle id="active-recording-actions-toggle-kebab" onToggle={handleActionToggle} />}
+                  dropdownItems={buttons.map((b) => b.collapsed)}
+                />
+              </OverflowMenuControl>
+            </OverflowMenu>
+          </ToolbarItem>
         </ToolbarGroup>
         {deleteActiveWarningModal}
       </ToolbarContent>

--- a/src/app/Recordings/Filters/DatetimeFilter.tsx
+++ b/src/app/Recordings/Filters/DatetimeFilter.tsx
@@ -164,7 +164,7 @@ export const DateTimeFilter: React.FunctionComponent<DateTimeFilterProps> = ({ o
 
   return (
     <Flex>
-      <Flex alignSelf={{ default: 'alignSelfFlexStart' }} flex={{ default: 'flex_1' }}>
+      <Flex alignSelf={{ default: 'alignSelfFlexStart' }}>
         <FlexItem spacer={{ default: 'spacerNone' }}>
           <Popover
             bodyContent={

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -136,6 +136,7 @@ export const RecordingActions: React.FunctionComponent<RecordingActionsProps> = 
   return (
     <Td isActionCell>
       <Dropdown
+        aria-label={`${props.recording.name}-actions`}
         menuAppendTo={document.body}
         position="right"
         direction="down"

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -86,6 +86,7 @@ export const categoryIsDate = (fieldKey: string) => /date/i.test(fieldKey);
 
 export interface RecordingFiltersProps {
   target: string;
+  breakpoint: 'md' | 'lg' | 'xl' | '2xl';
   isArchived: boolean;
   recordings: Recording[];
   filters: RecordingFiltersCategories;
@@ -97,6 +98,7 @@ export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
   isArchived,
   recordings,
   filters,
+  breakpoint = 'xl',
   updateFilters,
 }) => {
   const [formatter, _] = useDayjs();
@@ -236,7 +238,7 @@ export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
   );
 
   return (
-    <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
+    <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint={breakpoint}>
       <ToolbarGroup variant="filter-group">
         <ToolbarItem style={{ alignSelf: 'start' }} key={'category-select'}>
           {categoryDropdown}

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -61,7 +61,7 @@ export const Recordings: React.FunctionComponent<RecordingsProps> = (_) => {
 
   const cardBody = React.useMemo(() => {
     return archiveEnabled ? (
-      <Tabs id="recordings" activeKey={activeTab} onSelect={onTabSelect}>
+      <Tabs id="recordings" activeKey={activeTab} onSelect={onTabSelect} unmountOnExit>
         <Tab id="active-recordings" eventKey={0} title={<TabTitleText>Active Recordings</TabTitleText>}>
           <ActiveRecordingsTable archiveEnabled={true} />
         </Tab>

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -123,7 +123,6 @@ export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = (p
       <>
         <TableComposable
           isStickyHeader
-          scrolling=""
           aria-label={props.tableTitle}
           variant={props.isNestedTable ? 'compact' : undefined}
           style={{ zIndex: 99 }} // z-index of filters Select dropdown is 100

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -69,6 +69,8 @@ import {
   Td,
   Tbody,
   ActionsColumn,
+  OuterScrollContainer,
+  InnerScrollContainer,
 } from '@patternfly/react-table';
 import * as React from 'react';
 import { Link, useHistory, useRouteMatch } from 'react-router-dom';
@@ -467,6 +469,17 @@ export const Rules: React.FC<RulesProps> = (_) => {
     <>
       <BreadcrumbPage pageTitle="Automated Rules">
         <Card>
+          <CardTitle>About Automated Rules</CardTitle>
+          <CardBody>
+            Automated Rules define a dynamic set of Target JVMs to connect to and start{' '}
+            <Link to="/recordings">Active Recordings</Link> using a specific <Link to="/events">Event Template</Link>{' '}
+            when the Automated Rule is created and when any new matching Target JVMs appear. If your Target JVM
+            connections require JMX Credentials, you can configure these in <Link to="/security">Security</Link>.
+            Automated Rules can be configured to periodically copy the contents of the Active Recording to{' '}
+            <Link to="/archives">Archives</Link> to ensure you always have up-to-date information about your JVMs.
+          </CardBody>
+        </Card>
+        <Card>
           <CardBody>
             <Toolbar id="event-templates-toolbar">
               <ToolbarContent>
@@ -499,18 +512,7 @@ export const Rules: React.FC<RulesProps> = (_) => {
                 )}
               </ToolbarContent>
             </Toolbar>
-            {viewContent}
-          </CardBody>
-        </Card>
-        <Card>
-          <CardTitle>About Automated Rules</CardTitle>
-          <CardBody>
-            Automated Rules define a dynamic set of Target JVMs to connect to and start{' '}
-            <Link to="/recordings">Active Recordings</Link> using a specific <Link to="/events">Event Template</Link>{' '}
-            when the Automated Rule is created and when any new matching Target JVMs appear. If your Target JVM
-            connections require JMX Credentials, you can configure these in <Link to="/security">Security</Link>.
-            Automated Rules can be configured to periodically copy the contents of the Active Recording to{' '}
-            <Link to="/archives">Archives</Link> to ensure you always have up-to-date information about your JVMs.
+            <InnerScrollContainer>{viewContent}</InnerScrollContainer>
           </CardBody>
         </Card>
       </BreadcrumbPage>

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -69,7 +69,6 @@ import {
   Td,
   Tbody,
   ActionsColumn,
-  OuterScrollContainer,
   InnerScrollContainer,
 } from '@patternfly/react-table';
 import * as React from 'react';

--- a/src/app/TargetView/TargetView.tsx
+++ b/src/app/TargetView/TargetView.tsx
@@ -40,7 +40,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { Grid, GridItem } from '@patternfly/react-core';
+import { Grid, GridItem, gridSpans } from '@patternfly/react-core';
 import * as React from 'react';
 import { NoTargetSelected } from './NoTargetSelected';
 
@@ -69,11 +69,23 @@ export const TargetView: React.FunctionComponent<TargetViewProps> = (props) => {
     [props.compactSelect]
   );
 
+  const responsiveSpans = React.useMemo(
+    () =>
+      ({
+        sm: 12,
+        md: 12,
+        lg: compact ? 6 : 12,
+        xl: compact ? 6 : 12,
+        xl2: compact ? 6 : 12,
+      } as Record<'sm' | 'md' | 'lg' | 'xl' | 'xl2', gridSpans>),
+    [compact]
+  );
+
   return (
     <>
       <BreadcrumbPage pageTitle={props.pageTitle} breadcrumbs={props.breadcrumbs}>
         <Grid hasGutter>
-          <GridItem span={compact ? 6 : 12}>
+          <GridItem {...responsiveSpans}>
             <TargetSelect />
           </GridItem>
           <GridItem>{hasSelection ? props.children : <NoTargetSelected />}</GridItem>

--- a/src/test/Common.tsx
+++ b/src/test/Common.tsx
@@ -197,3 +197,12 @@ export const testTranslate = (key: string, ns = 'public'): string => {
   // if no translation is found, return the "test value" for debugging
   return t(key, 'i18next test value', { ns: ns });
 };
+
+// Default jsdom size 1024x728
+export const DEFAULT_DIMENSIONS = [1024, 728];
+
+export const resize = (width: number, height: number) => {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width });
+  Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: height });
+  window.dispatchEvent(new Event('resize'));
+};

--- a/src/test/Dashboard/__snapshots__/Dashboard.test.tsx.snap
+++ b/src/test/Dashboard/__snapshots__/Dashboard.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`<Dashboard /> renders correctly 1`] = `
         className="pf-l-grid pf-m-gutter"
       >
         <div
-          className="pf-l-grid__item pf-m-12-col"
+          className="pf-l-grid__item pf-m-12-col-on-sm pf-m-12-col-on-md pf-m-12-col-on-lg pf-m-12-col-on-xl pf-m-12-col-on-2xl"
         >
           <div>
             Target Select

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -53,7 +53,7 @@ import { act, cleanup, screen, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { of, Subject } from 'rxjs';
-import { renderWithServiceContextAndReduxStoreWithRouter } from '../Common';
+import { DEFAULT_DIMENSIONS, renderWithServiceContextAndReduxStoreWithRouter, resize } from '../Common';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };
@@ -109,8 +109,8 @@ jest.mock('@app/Recordings/RecordingFilters', () => {
 jest.spyOn(defaultServices.api, 'archiveRecording').mockReturnValue(of(true));
 jest.spyOn(defaultServices.api, 'deleteRecording').mockReturnValue(of(true));
 jest.spyOn(defaultServices.api, 'doGet').mockReturnValue(of([mockRecording]));
-jest.spyOn(defaultServices.api, 'downloadRecording').mockReturnValue();
-jest.spyOn(defaultServices.api, 'downloadReport').mockReturnValue();
+jest.spyOn(defaultServices.api, 'downloadRecording').mockReturnValue(void 0);
+jest.spyOn(defaultServices.api, 'downloadReport').mockReturnValue(void 0);
 jest.spyOn(defaultServices.api, 'grafanaDashboardUrl').mockReturnValue(of('/grafanaUrl'));
 jest.spyOn(defaultServices.api, 'grafanaDatasourceUrl').mockReturnValue(of('/datasource'));
 jest.spyOn(defaultServices.api, 'stopRecording').mockReturnValue(of(true));
@@ -118,7 +118,7 @@ jest.spyOn(defaultServices.api, 'uploadActiveRecordingToGrafana').mockReturnValu
 jest.spyOn(defaultServices.target, 'target').mockReturnValue(of(mockTarget));
 jest.spyOn(defaultServices.target, 'authFailure').mockReturnValue(of());
 
-jest.spyOn(defaultServices.reports, 'delete').mockReturnValue();
+jest.spyOn(defaultServices.reports, 'delete').mockReturnValue(void 0);
 
 jest
   .spyOn(defaultServices.settings, 'deletionDialogsEnabledFor')
@@ -178,7 +178,13 @@ jest.spyOn(window, 'open').mockReturnValue(null);
 describe('<ActiveRecordingsTable />', () => {
   let preloadedState: RootState;
 
-  beforeEach(() => {
+  beforeAll(async () => {
+    await act(async () => {
+      resize(2400, 1080);
+    });
+  });
+
+  beforeEach(async () => {
     mockRecording.metadata.labels = mockRecordingLabels;
     mockRecording.state = RecordingState.RUNNING;
     history.go(-history.length);
@@ -214,13 +220,20 @@ describe('<ActiveRecordingsTable />', () => {
     };
   });
 
+  afterAll(() => {
+    resize(DEFAULT_DIMENSIONS[0], DEFAULT_DIMENSIONS[1]);
+  });
+
   afterEach(cleanup);
 
   it('renders the recording table correctly', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} toolbarBreakReference={document.body} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     ['Create', 'Edit Labels', 'Stop', 'Delete'].map((text) => {
       const button = screen.getByText(text);
@@ -273,7 +286,7 @@ describe('<ActiveRecordingsTable />', () => {
       expect(label).toBeVisible();
     });
 
-    const actionIcon = screen.getByRole('button', { name: 'Actions' });
+    const actionIcon = within(screen.getByLabelText(`${mockRecording.name}-actions`)).getByLabelText('Actions');
     expect(actionIcon).toBeInTheDocument();
     expect(actionIcon).toBeVisible();
   });
@@ -314,10 +327,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('displays the toolbar buttons', async () => {
-    renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} toolbarBreakReference={document.body} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     expect(screen.getByText('Create')).toBeInTheDocument();
     expect(screen.getByText('Archive')).toBeInTheDocument();
@@ -327,10 +343,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('routes to the Create Flight Recording form when Create is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} toolbarBreakReference={document.body} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     await user.click(screen.getByText('Create'));
 
@@ -338,10 +357,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('archives the selected recording when Archive is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} toolbarBreakReference={document.body} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -355,10 +377,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('stops the selected recording when Stop is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} toolbarBreakReference={document.body} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -372,10 +397,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('opens the labels drawer when Edit Labels is clicked', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} toolbarBreakReference={document.body} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -385,10 +413,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('shows a popup when Delete is clicked and then deletes the recording after clicking confirmation Delete', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} toolbarBreakReference={document.body} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -412,10 +443,13 @@ describe('<ActiveRecordingsTable />', () => {
   });
 
   it('deletes the recording when Delete is clicked w/o popup warning', async () => {
-    const { user } = renderWithServiceContextAndReduxStoreWithRouter(<ActiveRecordingsTable archiveEnabled={true} />, {
-      preloadState: preloadedState,
-      history: history,
-    });
+    const { user } = renderWithServiceContextAndReduxStoreWithRouter(
+      <ActiveRecordingsTable archiveEnabled={true} toolbarBreakReference={document.body} />,
+      {
+        preloadState: preloadedState,
+        history: history,
+      }
+    );
 
     const checkboxes = screen.getAllByRole('checkbox');
     const selectAllCheck = checkboxes[0];
@@ -436,7 +470,7 @@ describe('<ActiveRecordingsTable />', () => {
     });
 
     await act(async () => {
-      await user.click(screen.getByLabelText('Actions'));
+      await user.click(within(screen.getByLabelText(`${mockRecording.name}-actions`)).getByLabelText('Actions'));
     });
     await user.click(screen.getByText('Download Recording'));
 
@@ -453,7 +487,7 @@ describe('<ActiveRecordingsTable />', () => {
     });
 
     await act(async () => {
-      await user.click(screen.getByLabelText('Actions'));
+      await user.click(within(screen.getByLabelText(`${mockRecording.name}-actions`)).getByLabelText('Actions'));
     });
     await user.click(screen.getByText('View Report ...'));
 
@@ -469,7 +503,7 @@ describe('<ActiveRecordingsTable />', () => {
     });
 
     await act(async () => {
-      await user.click(screen.getByLabelText('Actions'));
+      await user.click(within(screen.getByLabelText(`${mockRecording.name}-actions`)).getByLabelText('Actions'));
     });
     await user.click(screen.getByText('View in Grafana ...'));
 

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -53,7 +53,7 @@ import { screen, within, cleanup } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import { of, Subject } from 'rxjs';
-import { renderWithServiceContextAndReduxStoreWithRouter } from '../Common';
+import { DEFAULT_DIMENSIONS, renderWithServiceContextAndReduxStoreWithRouter, resize } from '../Common';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = { connectUrl: mockConnectUrl, alias: 'fooTarget' };
@@ -169,6 +169,13 @@ jest.spyOn(window, 'open').mockReturnValue(null);
 
 describe('<ArchivedRecordingsTable />', () => {
   let preloadedState: RootState;
+
+  beforeAll(async () => {
+    await tlr.act(async () => {
+      resize(2400, 1080);
+    });
+  });
+
   beforeEach(() => {
     history.go(-history.length);
     preloadedState = {
@@ -205,9 +212,18 @@ describe('<ArchivedRecordingsTable />', () => {
 
   afterEach(cleanup);
 
+  afterAll(() => {
+    resize(DEFAULT_DIMENSIONS[0], DEFAULT_DIMENSIONS[1]);
+  });
+
   it('renders the recording table correctly', async () => {
     renderWithServiceContextAndReduxStoreWithRouter(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+      <ArchivedRecordingsTable
+        target={of(mockTarget)}
+        isUploadsTable={false}
+        isNestedTable={false}
+        toolbarBreakReference={document.body}
+      />,
       {
         preloadState: preloadedState,
         history: history,
@@ -247,7 +263,7 @@ describe('<ArchivedRecordingsTable />', () => {
       expect(label).toBeVisible();
     });
 
-    const actionIcon = screen.getByRole('button', { name: 'Actions' });
+    const actionIcon = within(screen.getByLabelText(`${mockRecording.name}-actions`)).getByLabelText('Actions');
     expect(actionIcon).toBeInTheDocument();
     expect(actionIcon).toBeVisible();
 
@@ -293,7 +309,12 @@ describe('<ArchivedRecordingsTable />', () => {
 
   it('displays the toolbar buttons', async () => {
     renderWithServiceContextAndReduxStoreWithRouter(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+      <ArchivedRecordingsTable
+        target={of(mockTarget)}
+        isUploadsTable={false}
+        isNestedTable={false}
+        toolbarBreakReference={document.body}
+      />,
       {
         preloadState: preloadedState,
         history: history,
@@ -306,7 +327,12 @@ describe('<ArchivedRecordingsTable />', () => {
 
   it('opens the labels drawer when Edit Labels is clicked', async () => {
     const { user } = renderWithServiceContextAndReduxStoreWithRouter(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+      <ArchivedRecordingsTable
+        target={of(mockTarget)}
+        isUploadsTable={false}
+        isNestedTable={false}
+        toolbarBreakReference={document.body}
+      />,
       {
         preloadState: preloadedState,
         history: history,
@@ -322,7 +348,12 @@ describe('<ArchivedRecordingsTable />', () => {
 
   it('shows a popup when Delete is clicked and then deletes the recording after clicking confirmation Delete', async () => {
     const { user } = renderWithServiceContextAndReduxStoreWithRouter(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+      <ArchivedRecordingsTable
+        target={of(mockTarget)}
+        isUploadsTable={false}
+        isNestedTable={false}
+        toolbarBreakReference={document.body}
+      />,
       {
         preloadState: preloadedState,
         history: history,
@@ -351,7 +382,12 @@ describe('<ArchivedRecordingsTable />', () => {
 
   it('deletes the recording when Delete is clicked w/o popup warning', async () => {
     const { user } = renderWithServiceContextAndReduxStoreWithRouter(
-      <ArchivedRecordingsTable target={of(mockTarget)} isUploadsTable={false} isNestedTable={false} />,
+      <ArchivedRecordingsTable
+        target={of(mockTarget)}
+        isUploadsTable={false}
+        isNestedTable={false}
+        toolbarBreakReference={document.body}
+      />,
       {
         preloadState: preloadedState,
         history: history,
@@ -380,7 +416,7 @@ describe('<ArchivedRecordingsTable />', () => {
     );
 
     await tlr.act(async () => {
-      await user.click(screen.getByLabelText('Actions'));
+      await user.click(within(screen.getByLabelText(`${mockRecording.name}-actions`)).getByLabelText('Actions'));
     });
     await user.click(screen.getByText('Download Recording'));
 
@@ -400,7 +436,7 @@ describe('<ArchivedRecordingsTable />', () => {
     );
 
     await tlr.act(async () => {
-      await user.click(screen.getByLabelText('Actions'));
+      await user.click(within(screen.getByLabelText(`${mockRecording.name}-actions`)).getByLabelText('Actions'));
     });
     await user.click(screen.getByText('View Report ...'));
 
@@ -419,7 +455,7 @@ describe('<ArchivedRecordingsTable />', () => {
     );
 
     await tlr.act(async () => {
-      await user.click(screen.getByLabelText('Actions'));
+      await user.click(within(screen.getByLabelText(`${mockRecording.name}-actions`)).getByLabelText('Actions'));
     });
     await user.click(screen.getByText('View in Grafana ...'));
 
@@ -430,7 +466,12 @@ describe('<ArchivedRecordingsTable />', () => {
 
   it('renders correctly the Uploads table', async () => {
     const { user } = renderWithServiceContextAndReduxStoreWithRouter(
-      <ArchivedRecordingsTable target={of(mockUploadsTarget)} isUploadsTable={true} isNestedTable={false} />,
+      <ArchivedRecordingsTable
+        target={of(mockUploadsTarget)}
+        isUploadsTable={true}
+        isNestedTable={false}
+        toolbarBreakReference={document.body}
+      />,
       {
         preloadState: preloadedState,
         history: history,

--- a/src/test/Recordings/__snapshots__/Recordings.test.tsx.snap
+++ b/src/test/Recordings/__snapshots__/Recordings.test.tsx.snap
@@ -53,7 +53,6 @@ exports[`<Recordings /> renders correctly 1`] = `
             role="presentation"
           >
             <button
-              aria-controls="pf-tab-section-1-archived-recordings"
               aria-selected={false}
               className="pf-c-tabs__link"
               data-ouia-component-type="PF4/TabButton"
@@ -84,20 +83,6 @@ exports[`<Recordings /> renders correctly 1`] = `
       >
         <div>
           Active Recordings Table
-        </div>
-      </section>
-      <section
-        aria-labelledby="pf-tab-1-archived-recordings"
-        className="pf-c-tab-content"
-        data-ouia-component-type="PF4/TabContent"
-        data-ouia-safe={true}
-        hidden={true}
-        id="pf-tab-section-1-archived-recordings"
-        role="tabpanel"
-        tabIndex={0}
-      >
-        <div>
-          Archived Recordings Table
         </div>
       </section>
     </div>

--- a/src/test/Rules/__snapshots__/Rules.test.tsx.snap
+++ b/src/test/Rules/__snapshots__/Rules.test.tsx.snap
@@ -39,6 +39,59 @@ exports[`<Rules /> renders correctly 1`] = `
         id=""
       >
         <div
+          className="pf-c-card__title"
+        >
+          About Automated Rules
+        </div>
+        <div
+          className="pf-c-card__body"
+        >
+          Automated Rules define a dynamic set of Target JVMs to connect to and start
+           
+          <a
+            href="/recordings"
+            onClick={[Function]}
+          >
+            Active Recordings
+          </a>
+           using a specific 
+          <a
+            href="/events"
+            onClick={[Function]}
+          >
+            Event Template
+          </a>
+           
+          when the Automated Rule is created and when any new matching Target JVMs appear. If your Target JVM connections require JMX Credentials, you can configure these in 
+          <a
+            href="/security"
+            onClick={[Function]}
+          >
+            Security
+          </a>
+          . Automated Rules can be configured to periodically copy the contents of the Active Recording to
+           
+          <a
+            href="/archives"
+            onClick={[Function]}
+          >
+            Archives
+          </a>
+           to ensure you always have up-to-date information about your JVMs.
+        </div>
+      </article>
+    </div>
+    <div
+      className="pf-l-stack__item"
+    >
+      <article
+        className="pf-c-card"
+        data-ouia-component-id="OUIA-Generated-Card-2"
+        data-ouia-component-type="PF4/Card"
+        data-ouia-safe={true}
+        id=""
+      >
+        <div
           className="pf-c-card__body"
         >
           <div
@@ -128,93 +181,44 @@ exports[`<Rules /> renders correctly 1`] = `
             </div>
           </div>
           <div
-            className="pf-c-empty-state"
+            className="pf-c-scroll-inner-wrapper"
           >
             <div
-              className="pf-c-empty-state__content"
+              className="pf-c-empty-state"
             >
-              <svg
-                aria-hidden="true"
-                aria-labelledby={null}
-                className="pf-c-empty-state__icon"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style={
-                  Object {
-                    "verticalAlign": "-0.125em",
+              <div
+                className="pf-c-empty-state__content"
+              >
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  className="pf-c-empty-state__icon"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
                   }
-                }
-                viewBox="0 0 512 512"
-                width="1em"
-              >
-                <path
-                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                />
-              </svg>
-              <h4
-                className="pf-c-title pf-m-lg"
-                data-ouia-component-id="OUIA-Generated-Title-1"
-                data-ouia-component-type="PF4/Title"
-                data-ouia-safe={true}
-              >
-                No Automated Rules
-              </h4>
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                  />
+                </svg>
+                <h4
+                  className="pf-c-title pf-m-lg"
+                  data-ouia-component-id="OUIA-Generated-Title-1"
+                  data-ouia-component-type="PF4/Title"
+                  data-ouia-safe={true}
+                >
+                  No Automated Rules
+                </h4>
+              </div>
             </div>
           </div>
-        </div>
-      </article>
-    </div>
-    <div
-      className="pf-l-stack__item"
-    >
-      <article
-        className="pf-c-card"
-        data-ouia-component-id="OUIA-Generated-Card-2"
-        data-ouia-component-type="PF4/Card"
-        data-ouia-safe={true}
-        id=""
-      >
-        <div
-          className="pf-c-card__title"
-        >
-          About Automated Rules
-        </div>
-        <div
-          className="pf-c-card__body"
-        >
-          Automated Rules define a dynamic set of Target JVMs to connect to and start
-           
-          <a
-            href="/recordings"
-            onClick={[Function]}
-          >
-            Active Recordings
-          </a>
-           using a specific 
-          <a
-            href="/events"
-            onClick={[Function]}
-          >
-            Event Template
-          </a>
-           
-          when the Automated Rule is created and when any new matching Target JVMs appear. If your Target JVM connections require JMX Credentials, you can configure these in 
-          <a
-            href="/security"
-            onClick={[Function]}
-          >
-            Security
-          </a>
-          . Automated Rules can be configured to periodically copy the contents of the Active Recording to
-           
-          <a
-            href="/archives"
-            onClick={[Function]}
-          >
-            Archives
-          </a>
-           to ensure you always have up-to-date information about your JVMs.
         </div>
       </article>
     </div>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #828 

## Description of the change:

- [x] Enable horizontal scroll for rule table.
- [x] Collapse toolbar action buttons
  - [x] Active Recording Table
  - [x] Archive Recording Table. Note that PF advises against using overflow menu with only 2 buttons. So I add the breakpoint to lowest so that unless spaces are very limited, buttons are still shown.
  - [x]  Update tests. Got much complications with screen size testing.

## Motivation for the change:

The issue is quite severe for the Rule table as regular viewport also make it overflow. This PR addresses that and original issue with overflowing toolbar.

## How to manually test:
1. `Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2. Go to Automated Rule tab and create a rule if not any. See the table is not scrollable.
3. Go to Recording Tab. Reduce the screen viewport. See the buttons collapsing into a dropdowm


## Screenshots

**Collapsed toolbar:**

![Screenshot from 2023-02-02 16-02-45](https://user-images.githubusercontent.com/68053619/216448862-283eb55e-bf15-4fa3-82e7-552ccf4ea7bd.png)


**Collapsed Toolbar action buttons:**

![Screenshot from 2023-02-02 16-02-28](https://user-images.githubusercontent.com/68053619/216448868-1e1236a8-cdc8-4778-874c-1a706e8e0f32.png)

**Scrollable Automated table:**

![Screenshot from 2023-02-02 16-02-09](https://user-images.githubusercontent.com/68053619/216448870-f31f656a-2c00-4707-b721-0283d97c042e.png)
