### PR TITLE
chore(dev): `ESLINT_ENABLE` option and `yarn start:dev:lint` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:notests": "webpack --config webpack.prod.js",
     "clean": "rimraf dist",
     "start:dev": "webpack serve --hot --color --progress --config webpack.dev.js",
+    "start:dev:lint": "ESLINT_ENABLE=true webpack serve --hot --color --progress --config webpack.dev.js",
     "test": "jest --maxWorkers=50% --coverage=true",
     "test:ci": "jest --maxWorkers=50%",
     "eslint": "npm-run-all eslint:check",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -20,12 +20,6 @@ module.exports = merge(common('development'), {
   },
   plugins: [
     new DotenvPlugin(),
-    new ESLintPlugin({
-      cache: true,
-      cacheLocation: path.resolve(__dirname, '.eslintcache'),
-      extensions: ['js', 'jsx', 'ts', 'tsx'],
-      exclude: ['node_modules', 'dist'],
-    }),
   ],
   module: {
     rules: [
@@ -47,3 +41,13 @@ module.exports = merge(common('development'), {
     ]
   }
 });
+
+if (process.env.ESLINT_ENABLE === 'true') {
+  console.log('ESLint webpack-plugin enabled...');
+  module.exports.plugins.push(new ESLintPlugin({
+    cache: true,
+    cacheLocation: path.resolve(__dirname, '.eslintcache'),
+    extensions: ['js', 'jsx', 'ts', 'tsx'],
+    exclude: ['node_modules', 'dist'],
+  }));
+}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #854 

## Description of the change:
This change adds an env variable that can be passed in to enable eslint for development. There is also a new react script which does this for you `yarn start:dev:lint`

## Motivation for the change:
See #854 

## How to manually test:
1. Try both configurations. `yarn start:dev` and `yarn start:dev:lint` (or `ESLINT_ENABLE=true yarn start:dev`). One will use eslint, the other won't.