### PR TITLE
feat(dashboard): wrap cards in feature flag

### DIFF
--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -73,7 +73,7 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { useDispatch } from 'react-redux';
 import { Observable, of } from 'rxjs';
-import { getDashboardCards, getConfigByTitle, PropControl } from './Dashboard';
+import { getConfigByTitle, getDashboardCards, PropControl } from './Dashboard';
 
 interface AddCardProps {}
 

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -66,7 +66,7 @@ import {
   TEMPLATE_UNSUPPORTED_MESSAGE,
 } from '@app/Shared/Services/Report.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { automatedAnalysisConfigToRecordingAttributes } from '@app/Shared/Services/Settings.service';
+import { automatedAnalysisConfigToRecordingAttributes, FeatureLevel } from '@app/Shared/Services/Settings.service';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { calculateAnalysisTimer } from '@app/utils/utils';
@@ -803,6 +803,7 @@ export const AutomatedAnalysisCardSizes: DashboardCardSizes = {
 };
 
 export const AutomatedAnalysisCardDescriptor: DashboardCardDescriptor = {
+  featureLevel: FeatureLevel.PRODUCTION,
   title: 'Automated Analysis',
   cardSizes: AutomatedAnalysisCardSizes,
   description: `


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #840

## Description of the change:
Wrap dashboard cards in a `<FeatureFlag/>` so that they are only rendered if their configuration defines them part of the current feature level or higher. The dashboard layout is not actually modified in storage, the elements are only skipped when the component tree is being built, so if the user returns back to a lower feature level then the cards will reappear.

TODO later: add some visual indicator, like a badge in the card header matching the one in the application masthead, or a colour-coded border matching that badge, on each card so that it is obvious to the user that the cards they are using may not be production features. In this PR the user can only discover this by toggling the feature level and checking what disappears. This step entails more refactoring to extract the card itself to the higher component level and leave only the inner content as part of the card component, which is also useful for #739.