### PR TITLE
fix(agent): patch event should consider current target selection

### DIFF
--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -71,6 +71,7 @@ import {
   Td,
 } from '@patternfly/react-table';
 import * as React from 'react';
+import { combineLatest } from 'rxjs';
 import { AboutAgentCard } from './AboutAgentCard';
 
 export type LiveProbeActions = 'REMOVE';
@@ -200,7 +201,13 @@ export const AgentLiveProbes: React.FC<AgentLiveProbesProps> = (_) => {
 
   React.useEffect(() => {
     addSubscription(
-      context.notificationChannel.messages(NotificationCategory.ProbeTemplateApplied).subscribe((e) => {
+      combineLatest([
+        context.target.target(),
+        context.notificationChannel.messages(NotificationCategory.ProbeTemplateApplied),
+      ]).subscribe(([currentTarget, e]) => {
+        if (currentTarget.connectUrl != e.message.targetId) {
+          return;
+        }
         setProbes((old) => {
           const probes = e.message.events as EventProbe[];
           const probeIds = probes.map((p) => p.id);
@@ -211,7 +218,7 @@ export const AgentLiveProbes: React.FC<AgentLiveProbesProps> = (_) => {
         });
       })
     );
-  }, [addSubscription, context, context.notificationChannel, setProbes]);
+  }, [addSubscription, context, context.notificationChannel, context.target, setProbes]);
 
   React.useEffect(() => {
     addSubscription(


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #893 

## Description of the change:

Take into account the current global target selection when updating probe table.

## Motivation for the change:

See #893 
