### PR TITLE
feat(dashboard): full view dashboard card

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -9,9 +9,9 @@
   "CANCEL": "Cancel",
   "CARD_TYPE": "Card type",
   "CLEAR_FILTERS": "Clear all filters",
-  "CRITICAL": "CRITICAL",
   "CREATE": "Create",
   "CREATING": "Creating",
+  "CRITICAL": "CRITICAL",
   "CRYOSTAT_TRADEMARK": "Copyright The Cryostat Authors, The Universal Permissive License (UPL), Version 1.0",
   "DATE": "Date",
   "DESCRIPTION": "Description",
@@ -47,5 +47,6 @@
   "TEMPLATE": "Template",
   "TEMPLATE_HELPER_TEXT_INVALID": "Template must be selected",
   "TIME": "Time",
+  "VIEW": "View",
   "WARNING": "WARNING"
 }

--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -80,5 +80,5 @@ export const BreadcrumbPage: React.FC<BreadcrumbPageProps> = (props) => {
 export const isItemFilled = (item: React.ReactNode): boolean => {
   if (!item) return false;
   const toCheck = item['props'] ? item['props'] : item;
-  return toCheck['isFilled'] || toCheck['isFullHeight'];
+  return toCheck['isFilled'] || toCheck['isFullHeight'] || toCheck['data-full-height'];
 };

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -850,6 +850,9 @@ export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (prop
       cardSizes={AutomatedAnalysisCardSizes}
       id="automated-analysis-card"
       isCompact
+      isDraggable={props.isDraggable}
+      isResizable={props.isResizable}
+      isFullHeight={props.isFullHeight}
       isExpanded={isCardExpanded}
       cardHeader={header}
     >

--- a/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
@@ -162,11 +162,8 @@ export const JFRMetricsChartCard: React.FC<JFRMetricsChartCardProps> = (props) =
   }, [chartSrc, dashboardUrl]);
 
   const cardStyle = React.useMemo(() => {
-    if (controllerState !== ControllerState.READY) {
+    if (controllerState !== ControllerState.READY || props.isFullHeight) {
       return {};
-    }
-    if (props.isFullHeight) {
-      return { height: '100%' };
     }
     let height: string;
     switch (props.chartKind) {

--- a/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
@@ -165,17 +165,20 @@ export const JFRMetricsChartCard: React.FC<JFRMetricsChartCardProps> = (props) =
     if (controllerState !== ControllerState.READY) {
       return {};
     }
-    let height: number;
+    if (props.isFullHeight) {
+      return { height: '100%' };
+    }
+    let height: string;
     switch (props.chartKind) {
       case 'Core Count':
-        height = 250;
+        height = '250px';
         break;
       default:
-        height = 380;
+        height = `380px`;
         break;
     }
     return { height };
-  }, [controllerState, props.chartKind]);
+  }, [controllerState, props.chartKind, props.isFullHeight]);
 
   const resyncButton = React.useMemo(() => {
     return (
@@ -255,6 +258,9 @@ export const JFRMetricsChartCard: React.FC<JFRMetricsChartCardProps> = (props) =
       isCompact
       style={cardStyle}
       cardHeader={header}
+      isDraggable={props.isDraggable}
+      isResizable={props.isResizable}
+      isFullHeight={props.isFullHeight}
     >
       <CardBody>
         {controllerState === ControllerState.UNKNOWN ? (

--- a/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
@@ -130,6 +130,7 @@ const SimpleChart: React.FC<{
       legendPosition={'bottom'}
       themeColor={themeColor}
       width={width}
+      height={width / 2} // Aspect radio: 2:1
       padding={{
         left: 54,
         right: 30,
@@ -270,6 +271,7 @@ const chartKinds: MBeanMetricsChartKind[] = [
           labels={({ datum }) => (datum.x ? `${datum.x}: ${datum.y.toFixed(2)}%` : null)}
           themeColor={themeColor}
           width={width}
+          height={width / 2} // Aspect radio: 2:1
         />
       );
     },
@@ -422,11 +424,11 @@ export const MBeanMetricsChartCard: React.FC<MBeanMetricsChartCardProps> = (prop
 
   const visual = React.useMemo(
     () => (
-      <div ref={containerRef} style={{ height: 300 }} className="disabled-pointer">
+      <div ref={containerRef} style={{ height: props.isFullHeight ? '100%' : '300px' }} className="disabled-pointer">
         {chartKind.visual(props.themeColor, cardWidth, samples)}
       </div>
     ),
-    [containerRef, props.themeColor, chartKind, cardWidth, samples]
+    [containerRef, props.themeColor, props.isFullHeight, chartKind, cardWidth, samples]
   );
 
   return (
@@ -435,6 +437,9 @@ export const MBeanMetricsChartCard: React.FC<MBeanMetricsChartCardProps> = (prop
       dashboardId={props.dashboardId}
       cardSizes={MBeanMetricsChartCardSizes}
       isCompact
+      isDraggable={props.isDraggable}
+      isResizable={props.isResizable}
+      isFullHeight={props.isFullHeight}
       cardHeader={header}
     >
       <CardBody>{visual}</CardBody>

--- a/src/app/Dashboard/DashBoardSolo.tsx
+++ b/src/app/Dashboard/DashBoardSolo.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import { CardConfig } from '@app/Shared/Redux/Configurations/DashboardConfigSlicer';
+import { RootState } from '@app/Shared/Redux/ReduxStore';
+import { TargetView } from '@app/TargetView/TargetView';
+import { Bullseye, Button, EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { MonitoringIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+import { useSelector } from 'react-redux';
+import { useHistory, useLocation, withRouter } from 'react-router-dom';
+import { getConfigByName } from './Dashboard';
+
+export interface DashboardSoloProps {}
+
+const DashboardSolo: React.FC<DashboardSoloProps> = ({ ..._props }) => {
+  const { search } = useLocation();
+  const history = useHistory();
+
+  const cardConfigs: CardConfig[] = useSelector((state: RootState) => state.dashboardConfigs.list);
+
+  const cardConfig = React.useMemo(() => {
+    const cardId = new URLSearchParams(search).get('cardId');
+    return cardConfigs.find((config) => config.id === cardId);
+  }, [search, cardConfigs]);
+
+  const content = React.useMemo(() => {
+    if (!cardConfig) {
+      return (
+        <Bullseye>
+          <EmptyState variant="large">
+            <EmptyStateIcon variant="container" component={MonitoringIcon} />
+            <Title headingLevel="h3" size="lg">
+              Dashboard card not found
+            </Title>
+            <EmptyStateBody>
+              Provide a valid <code style={{ color: '#000' }}>cardId</code> query parameter and try again.
+            </EmptyStateBody>
+            <Button variant="primary" onClick={() => history.push('/')}>
+              Back to Dashboard
+            </Button>
+          </EmptyState>
+        </Bullseye>
+      );
+    } else {
+      const { id, name, span, props } = cardConfig;
+      return (
+        // Use default chart controller
+        <TargetView pageTitle={cardConfig.id} breadcrumbs={[{ path: '/', title: 'Dashboard' }]}>
+          <div data-full-height style={{ height: '100%' }}>
+            {React.createElement(getConfigByName(name).component, {
+              span: span,
+              ...props,
+              isDraggable: false,
+              isResizable: false,
+              isFullHeight: true,
+              dashboardId: id,
+            })}
+          </div>
+          <></>
+        </TargetView>
+      );
+    }
+  }, [cardConfig, history]);
+
+  return content;
+};
+
+export default withRouter(DashboardSolo);

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -52,6 +52,7 @@ import { TFunction } from 'i18next';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { Observable, of } from 'rxjs';
 import { AddCard } from './AddCard';
 import { AutomatedAnalysisCardDescriptor } from './AutomatedAnalysis/AutomatedAnalysisCard';
@@ -101,6 +102,9 @@ export interface DashboardProps {}
 export interface DashboardCardProps {
   span: number;
   dashboardId: number;
+  isDraggable?: boolean;
+  isResizable?: boolean;
+  isFullHeight?: boolean;
   actions?: JSX.Element[];
 }
 
@@ -286,6 +290,7 @@ export function getConfigByTitle(title: string, t: TFunction): DashboardCardDesc
 }
 
 export const Dashboard: React.FC<DashboardProps> = (_) => {
+  const history = useHistory();
   const serviceContext = React.useContext(ServiceContext);
   const dispatch = useDispatch<StateDispatch>();
   const cardConfigs: CardConfig[] = useSelector((state: RootState) => state.dashboardConfigs.list);
@@ -361,6 +366,7 @@ export const Dashboard: React.FC<DashboardProps> = (_) => {
                         key={`${cfg.name}-actions`}
                         onRemove={() => handleRemove(idx)}
                         onResetSize={() => handleResetSize(idx)}
+                        onView={() => history.push(`/d-solo?cardId=${cardConfigs[idx].id}`)}
                       />,
                     ],
                   })}

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -366,7 +366,7 @@ export const Dashboard: React.FC<DashboardProps> = (_) => {
                         key={`${cfg.name}-actions`}
                         onRemove={() => handleRemove(idx)}
                         onResetSize={() => handleResetSize(idx)}
-                        onView={() => history.push(`/d-solo?cardId=${cardConfigs[idx].id}`)}
+                        onView={() => history.push(`/d-solo?cardId=${cfg.id}`)}
                       />,
                     ],
                   })}

--- a/src/app/Dashboard/DashboardCard.tsx
+++ b/src/app/Dashboard/DashboardCard.tsx
@@ -49,6 +49,8 @@ export interface DashboardCardProps extends CardProps {
   dashboardId: number;
   cardSizes: DashboardCardSizes;
   cardHeader: React.ReactNode;
+  isDraggable?: boolean;
+  isResizable?: boolean;
   children?: React.ReactNode;
 }
 
@@ -56,7 +58,10 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
   children = null,
   cardHeader = null,
   dashboardId,
+  isDraggable = true,
+  isResizable = true,
   cardSizes,
+
   ...props
 }: DashboardCardProps) => {
   const cardRef = React.useRef<HTMLDivElement>(null);
@@ -73,25 +78,41 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
     }
   }, []);
 
-  return (
-    <DashboardCardContext.Provider value={cardRef}>
-      <DraggableRef dashboardId={dashboardId}>
-        <div className={'dashboard-card-resizable-wrapper'} ref={cardRef}>
-          <Card className="dashboard-card" isRounded {...props}>
-            <div
-              className={css(`${draggableRefKlazz}__grip`)}
-              onMouseEnter={onMouseEnter}
-              onMouseLeave={onMouseLeave}
-              draggable // draggable is required for drag events to fire
-            >
-              {cardHeader}
-            </div>
+  const resizeBar = React.useMemo(() => {
+    return isResizable ? <ResizableRef dashboardId={dashboardId} cardSizes={cardSizes} /> : null;
+  }, [isResizable, cardSizes, dashboardId]);
+
+  const content = React.useMemo(
+    () =>
+      isDraggable ? (
+        <DraggableRef dashboardId={dashboardId}>
+          <div className={'dashboard-card-resizable-wrapper'} ref={cardRef}>
+            <Card className="dashboard-card" isRounded {...props}>
+              <div
+                className={css(`${draggableRefKlazz}__grip`)}
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+                draggable // draggable is required for drag events to fire
+              >
+                {cardHeader}
+              </div>
+              {children}
+            </Card>
+            {resizeBar}
+          </div>
+        </DraggableRef>
+      ) : (
+        <>
+          <Card isRounded {...props}>
+            {cardHeader}
             {children}
           </Card>
-          <ResizableRef dashboardId={dashboardId} cardSizes={cardSizes} />
-        </div>
-      </DraggableRef>
-    </DashboardCardContext.Provider>
+          {resizeBar}
+        </>
+      ),
+    [cardRef, props, onMouseEnter, onMouseLeave, cardHeader, children, isDraggable, dashboardId, resizeBar]
   );
+
+  return <DashboardCardContext.Provider value={cardRef}>{content}</DashboardCardContext.Provider>;
 };
 DashboardCard.displayName = 'DashboardCard';

--- a/src/app/Dashboard/DashboardCardActionMenu.tsx
+++ b/src/app/Dashboard/DashboardCardActionMenu.tsx
@@ -41,10 +41,16 @@ import { useTranslation } from 'react-i18next';
 
 export interface DashboardCardActionProps {
   onRemove: () => void;
+  onView: () => void;
   onResetSize: () => void;
 }
 
-export const DashboardCardActionMenu: React.FunctionComponent<DashboardCardActionProps> = (props) => {
+export const DashboardCardActionMenu: React.FunctionComponent<DashboardCardActionProps> = ({
+  onRemove,
+  onResetSize,
+  onView,
+  ...props
+}) => {
   const [isOpen, setOpen] = React.useState(false);
 
   const [t] = useTranslation();
@@ -59,6 +65,7 @@ export const DashboardCardActionMenu: React.FunctionComponent<DashboardCardActio
   return (
     <>
       <Dropdown
+        {...props}
         isPlain
         isFlipEnabled
         menuAppendTo={'parent'}
@@ -67,10 +74,13 @@ export const DashboardCardActionMenu: React.FunctionComponent<DashboardCardActio
         toggle={<KebabToggle onToggle={setOpen} />}
         onSelect={onSelect}
         dropdownItems={[
-          <DropdownItem key="Remove" onClick={props.onRemove}>
+          <DropdownItem key="View" onClick={onView}>
+            {t('VIEW', { ns: 'common' })}
+          </DropdownItem>,
+          <DropdownItem key="Remove" onClick={onRemove}>
             {t('REMOVE', { ns: 'common' })}
           </DropdownItem>,
-          <DropdownItem key="Reset Size" onClick={props.onResetSize}>
+          <DropdownItem key="Reset Size" onClick={onResetSize}>
             {t('DashboardCardActionMenu.RESET_SIZE')}
           </DropdownItem>,
         ]}

--- a/src/app/Dashboard/Quickstart/QuickStartsCard.tsx
+++ b/src/app/Dashboard/Quickstart/QuickStartsCard.tsx
@@ -69,6 +69,9 @@ const QuickStartsCard: React.FunctionComponent<QuickStartsCardProps> = (props) =
     <DashboardCard
       dashboardId={props.dashboardId}
       cardSizes={QuickStartsCardSizes}
+      isDraggable={props.isDraggable}
+      isResizable={props.isResizable}
+      isFullHeight={props.isFullHeight}
       cardHeader={
         <CardHeader>
           <CardTitle component="h2">{t('QuickStartsCard.TITLE')}</CardTitle>

--- a/src/app/Shared/MatchExpressionEvaluator.tsx
+++ b/src/app/Shared/MatchExpressionEvaluator.tsx
@@ -60,7 +60,6 @@ import {
   InfoCircleIcon,
   WarningTriangleIcon,
 } from '@patternfly/react-icons';
-import _ from 'lodash';
 import * as React from 'react';
 
 export interface MatchExpressionEvaluatorProps {

--- a/src/app/Topology/Shared/utils.tsx
+++ b/src/app/Topology/Shared/utils.tsx
@@ -39,7 +39,6 @@ import { TopologyFilters } from '@app/Shared/Redux/Filters/TopologyFilterSlice';
 import { evaluateTargetWithExpr, hashCode } from '@app/utils/utils';
 import { Button } from '@patternfly/react-core';
 import { ContextMenuSeparator, GraphElement, NodeStatus } from '@patternfly/react-topology';
-import _ from 'lodash';
 import * as React from 'react';
 import { BehaviorSubject, debounceTime, Observable, Subscription } from 'rxjs';
 import { ContextMenuItem, MenuItemVariant, nodeActions } from '../Actions/NodeActions';

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -50,6 +50,7 @@ const About = lazy(() => import('@app/About/About'));
 const Archives = lazy(() => import('@app/Archives/Archives'));
 const CreateRecording = lazy(() => import('@app/CreateRecording/CreateRecording'));
 const Dashboard = lazy(() => import('@app/Dashboard/Dashboard'));
+const DashboardSolo = lazy(() => import('./Dashboard/DashBoardSolo'));
 const Events = lazy(() => import('@app/Events/Events'));
 const Login = lazy(() => import('@app/Login/Login'));
 const NotFound = lazy(() => import('@app/NotFound/NotFound'));
@@ -100,6 +101,14 @@ const routes: IAppRoute[] = [
     path: '/',
     title: 'Dashboard',
     navGroup: OVERVIEW,
+    children: [
+      {
+        component: DashboardSolo,
+        exact: true,
+        path: '/d-solo',
+        title: 'Dashboard',
+      },
+    ],
   },
   {
     component: QuickStarts,

--- a/src/test/Dashboard/Charts/jfr/__snapshots__/JFRMetricsChartCard.test.tsx.snap
+++ b/src/test/Dashboard/Charts/jfr/__snapshots__/JFRMetricsChartCard.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`<JFRMetricsChartCard /> renders correctly: with-content 1`] = `
       id="CPU Load-chart-card"
       style={
         Object {
-          "height": 380,
+          "height": "380px",
         }
       }
     >

--- a/src/test/Dashboard/Charts/mbean/__snapshots__/MBeanMetricsChartCard.test.tsx.snap
+++ b/src/test/Dashboard/Charts/mbean/__snapshots__/MBeanMetricsChartCard.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
           className="disabled-pointer"
           style={
             Object {
-              "height": 300,
+              "height": "300px",
             }
           }
         >
@@ -94,7 +94,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
             }
           >
             <svg
-              height={300}
+              height={0}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onTouchCancel={[Function]}
@@ -107,7 +107,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                   "width": "100%",
                 }
               }
-              viewBox="0 0 0 300"
+              viewBox="0 0 0 0"
               width={0}
             >
               <g
@@ -128,8 +128,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                   vectorEffect="non-scaling-stroke"
                   x1={54}
                   x2={-30}
-                  y1={240}
-                  y2={240}
+                  y1={-60}
+                  y2={-60}
                 />
                 <g
                   role="presentation"
@@ -150,15 +150,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={-30}
                     x2={-30}
-                    y1={240}
-                    y2={245}
+                    y1={-60}
+                    y2={-55}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-0-ChartLabel-4"
                     x={-30}
-                    y={266.97}
+                    y={-33.03}
                   >
                     <tspan
                       dx={0}
@@ -201,15 +201,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                   x1={54}
                   x2={54}
                   y1={10}
-                  y2={240}
+                  y2={-60}
                 />
                 <text
                   direction="inherit"
                   dx={0}
                   id="axis-axisLabel-0"
-                  transform="rotate(-90,14,125)"
+                  transform="rotate(-90,14,-25)"
                   x={14}
-                  y={122.97}
+                  y={-27.03}
                 >
                   <tspan
                     dx={0}
@@ -249,8 +249,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <line
                     role="presentation"
@@ -268,15 +268,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-0"
                     x={39}
-                    y={198.97}
+                    y={-41.03}
                   >
                     <tspan
                       dx={0}
@@ -317,8 +317,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <line
                     role="presentation"
@@ -336,15 +336,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-1"
                     x={39}
-                    y={152.97}
+                    y={-27.03}
                   >
                     <tspan
                       dx={0}
@@ -385,8 +385,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <line
                     role="presentation"
@@ -404,15 +404,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-2"
                     x={39}
-                    y={106.97}
+                    y={-13.030000000000001}
                   >
                     <tspan
                       dx={0}
@@ -453,8 +453,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <line
                     role="presentation"
@@ -472,15 +472,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-3"
                     x={39}
-                    y={60.969999999999985}
+                    y={0.9700000000000033}
                   >
                     <tspan
                       dx={0}
@@ -586,7 +586,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                   vectorEffect="non-scaling-stroke"
                   width={0}
                   x={0}
-                  y={272}
+                  y={112}
                 />
               </g>
             </svg>
@@ -603,7 +603,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
               }
             >
               <svg
-                height={300}
+                height={0}
                 style={
                   Object {
                     "height": "100%",
@@ -611,7 +611,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 1`] = `
                     "width": "100%",
                   }
                 }
-                viewBox="0 0 0 300"
+                viewBox="0 0 0 0"
                 width={0}
               />
             </div>
@@ -703,7 +703,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
           className="disabled-pointer"
           style={
             Object {
-              "height": 300,
+              "height": "300px",
             }
           }
         >
@@ -721,7 +721,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
             }
           >
             <svg
-              height={300}
+              height={0}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onTouchCancel={[Function]}
@@ -734,7 +734,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                   "width": "100%",
                 }
               }
-              viewBox="0 0 0 300"
+              viewBox="0 0 0 0"
               width={0}
             >
               <g
@@ -755,8 +755,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                   vectorEffect="non-scaling-stroke"
                   x1={54}
                   x2={-30}
-                  y1={240}
-                  y2={240}
+                  y1={-60}
+                  y2={-60}
                 />
                 <g
                   role="presentation"
@@ -777,15 +777,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={-30}
                     x2={-30}
-                    y1={240}
-                    y2={245}
+                    y1={-60}
+                    y2={-55}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-0-ChartLabel-4"
                     x={-30}
-                    y={266.97}
+                    y={-33.03}
                   >
                     <tspan
                       dx={0}
@@ -828,7 +828,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                   x1={54}
                   x2={54}
                   y1={10}
-                  y2={240}
+                  y2={-60}
                 />
                 <g
                   role="presentation"
@@ -848,8 +848,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <line
                     role="presentation"
@@ -867,15 +867,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-0"
                     x={39}
-                    y={198.97}
+                    y={-41.03}
                   >
                     <tspan
                       dx={0}
@@ -916,8 +916,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <line
                     role="presentation"
@@ -935,15 +935,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-1"
                     x={39}
-                    y={152.97}
+                    y={-27.03}
                   >
                     <tspan
                       dx={0}
@@ -984,8 +984,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <line
                     role="presentation"
@@ -1003,15 +1003,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-2"
                     x={39}
-                    y={106.97}
+                    y={-13.030000000000001}
                   >
                     <tspan
                       dx={0}
@@ -1052,8 +1052,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <line
                     role="presentation"
@@ -1071,15 +1071,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-3"
                     x={39}
-                    y={60.969999999999985}
+                    y={0.9700000000000033}
                   >
                     <tspan
                       dx={0}
@@ -1185,7 +1185,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                   vectorEffect="non-scaling-stroke"
                   width={0}
                   x={0}
-                  y={272}
+                  y={112}
                 />
               </g>
             </svg>
@@ -1202,7 +1202,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
               }
             >
               <svg
-                height={300}
+                height={0}
                 style={
                   Object {
                     "height": "100%",
@@ -1210,7 +1210,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 2`] = `
                     "width": "100%",
                   }
                 }
-                viewBox="0 0 0 300"
+                viewBox="0 0 0 0"
                 width={0}
               />
             </div>
@@ -1302,7 +1302,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
           className="disabled-pointer"
           style={
             Object {
-              "height": 300,
+              "height": "300px",
             }
           }
         >
@@ -1320,7 +1320,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
             }
           >
             <svg
-              height={300}
+              height={0}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onTouchCancel={[Function]}
@@ -1333,7 +1333,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                   "width": "100%",
                 }
               }
-              viewBox="0 0 0 300"
+              viewBox="0 0 0 0"
               width={0}
             >
               <g
@@ -1354,8 +1354,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                   vectorEffect="non-scaling-stroke"
                   x1={54}
                   x2={-30}
-                  y1={240}
-                  y2={240}
+                  y1={-60}
+                  y2={-60}
                 />
                 <g
                   role="presentation"
@@ -1376,15 +1376,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={-30}
                     x2={-30}
-                    y1={240}
-                    y2={245}
+                    y1={-60}
+                    y2={-55}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-0-ChartLabel-4"
                     x={-30}
-                    y={266.97}
+                    y={-33.03}
                   >
                     <tspan
                       dx={0}
@@ -1427,15 +1427,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                   x1={54}
                   x2={54}
                   y1={10}
-                  y2={240}
+                  y2={-60}
                 />
                 <text
                   direction="inherit"
                   dx={0}
                   id="axis-axisLabel-0"
-                  transform="rotate(-90,14,125)"
+                  transform="rotate(-90,14,-25)"
                   x={14}
-                  y={122.97}
+                  y={-27.03}
                 >
                   <tspan
                     dx={0}
@@ -1475,8 +1475,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <line
                     role="presentation"
@@ -1494,15 +1494,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-0"
                     x={39}
-                    y={198.97}
+                    y={-41.03}
                   >
                     <tspan
                       dx={0}
@@ -1543,8 +1543,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <line
                     role="presentation"
@@ -1562,15 +1562,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-1"
                     x={39}
-                    y={152.97}
+                    y={-27.03}
                   >
                     <tspan
                       dx={0}
@@ -1611,8 +1611,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <line
                     role="presentation"
@@ -1630,15 +1630,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-2"
                     x={39}
-                    y={106.97}
+                    y={-13.030000000000001}
                   >
                     <tspan
                       dx={0}
@@ -1679,8 +1679,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <line
                     role="presentation"
@@ -1698,15 +1698,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-3"
                     x={39}
-                    y={60.969999999999985}
+                    y={0.9700000000000033}
                   >
                     <tspan
                       dx={0}
@@ -1812,7 +1812,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                   vectorEffect="non-scaling-stroke"
                   width={0}
                   x={0}
-                  y={272}
+                  y={112}
                 />
               </g>
             </svg>
@@ -1829,7 +1829,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
               }
             >
               <svg
-                height={300}
+                height={0}
                 style={
                   Object {
                     "height": "100%",
@@ -1837,7 +1837,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 3`] = `
                     "width": "100%",
                   }
                 }
-                viewBox="0 0 0 300"
+                viewBox="0 0 0 0"
                 width={0}
               />
             </div>
@@ -1929,7 +1929,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
           className="disabled-pointer"
           style={
             Object {
-              "height": 300,
+              "height": "300px",
             }
           }
         >
@@ -1947,7 +1947,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
             }
           >
             <svg
-              height={300}
+              height={0}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onTouchCancel={[Function]}
@@ -1960,7 +1960,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                   "width": "100%",
                 }
               }
-              viewBox="0 0 0 300"
+              viewBox="0 0 0 0"
               width={0}
             >
               <g
@@ -1981,8 +1981,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                   vectorEffect="non-scaling-stroke"
                   x1={54}
                   x2={-30}
-                  y1={240}
-                  y2={240}
+                  y1={-60}
+                  y2={-60}
                 />
                 <g
                   role="presentation"
@@ -2003,15 +2003,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={-30}
                     x2={-30}
-                    y1={240}
-                    y2={245}
+                    y1={-60}
+                    y2={-55}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-0-ChartLabel-4"
                     x={-30}
-                    y={266.97}
+                    y={-33.03}
                   >
                     <tspan
                       dx={0}
@@ -2054,15 +2054,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                   x1={54}
                   x2={54}
                   y1={10}
-                  y2={240}
+                  y2={-60}
                 />
                 <text
                   direction="inherit"
                   dx={0}
                   id="axis-axisLabel-0"
-                  transform="rotate(-90,14,125)"
+                  transform="rotate(-90,14,-25)"
                   x={14}
-                  y={122.97}
+                  y={-27.03}
                 >
                   <tspan
                     dx={0}
@@ -2102,8 +2102,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <line
                     role="presentation"
@@ -2121,15 +2121,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-0"
                     x={39}
-                    y={198.97}
+                    y={-41.03}
                   >
                     <tspan
                       dx={0}
@@ -2170,8 +2170,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <line
                     role="presentation"
@@ -2189,15 +2189,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-1"
                     x={39}
-                    y={152.97}
+                    y={-27.03}
                   >
                     <tspan
                       dx={0}
@@ -2238,8 +2238,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <line
                     role="presentation"
@@ -2257,15 +2257,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-2"
                     x={39}
-                    y={106.97}
+                    y={-13.030000000000001}
                   >
                     <tspan
                       dx={0}
@@ -2306,8 +2306,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <line
                     role="presentation"
@@ -2325,15 +2325,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-3"
                     x={39}
-                    y={60.969999999999985}
+                    y={0.9700000000000033}
                   >
                     <tspan
                       dx={0}
@@ -2439,7 +2439,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                   vectorEffect="non-scaling-stroke"
                   width={0}
                   x={0}
-                  y={272}
+                  y={112}
                 />
               </g>
             </svg>
@@ -2456,7 +2456,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
               }
             >
               <svg
-                height={300}
+                height={0}
                 style={
                   Object {
                     "height": "100%",
@@ -2464,7 +2464,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 4`] = `
                     "width": "100%",
                   }
                 }
-                viewBox="0 0 0 300"
+                viewBox="0 0 0 0"
                 width={0}
               />
             </div>
@@ -2556,7 +2556,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
           className="disabled-pointer"
           style={
             Object {
-              "height": 300,
+              "height": "300px",
             }
           }
         >
@@ -2574,7 +2574,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
             }
           >
             <svg
-              height={300}
+              height={0}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onTouchCancel={[Function]}
@@ -2587,7 +2587,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                   "width": "100%",
                 }
               }
-              viewBox="0 0 0 300"
+              viewBox="0 0 0 0"
               width={0}
             >
               <g
@@ -2608,8 +2608,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                   vectorEffect="non-scaling-stroke"
                   x1={54}
                   x2={-30}
-                  y1={240}
-                  y2={240}
+                  y1={-60}
+                  y2={-60}
                 />
                 <g
                   role="presentation"
@@ -2630,15 +2630,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={-30}
                     x2={-30}
-                    y1={240}
-                    y2={245}
+                    y1={-60}
+                    y2={-55}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-0-ChartLabel-4"
                     x={-30}
-                    y={266.97}
+                    y={-33.03}
                   >
                     <tspan
                       dx={0}
@@ -2681,15 +2681,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                   x1={54}
                   x2={54}
                   y1={10}
-                  y2={240}
+                  y2={-60}
                 />
                 <text
                   direction="inherit"
                   dx={0}
                   id="axis-axisLabel-0"
-                  transform="rotate(-90,14,125)"
+                  transform="rotate(-90,14,-25)"
                   x={14}
-                  y={122.97}
+                  y={-27.03}
                 >
                   <tspan
                     dx={0}
@@ -2729,8 +2729,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <line
                     role="presentation"
@@ -2748,15 +2748,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-0"
                     x={39}
-                    y={198.97}
+                    y={-41.03}
                   >
                     <tspan
                       dx={0}
@@ -2797,8 +2797,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <line
                     role="presentation"
@@ -2816,15 +2816,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-1"
                     x={39}
-                    y={152.97}
+                    y={-27.03}
                   >
                     <tspan
                       dx={0}
@@ -2865,8 +2865,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <line
                     role="presentation"
@@ -2884,15 +2884,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-2"
                     x={39}
-                    y={106.97}
+                    y={-13.030000000000001}
                   >
                     <tspan
                       dx={0}
@@ -2933,8 +2933,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <line
                     role="presentation"
@@ -2952,15 +2952,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-3"
                     x={39}
-                    y={60.969999999999985}
+                    y={0.9700000000000033}
                   >
                     <tspan
                       dx={0}
@@ -3066,7 +3066,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                   vectorEffect="non-scaling-stroke"
                   width={0}
                   x={0}
-                  y={272}
+                  y={112}
                 />
               </g>
             </svg>
@@ -3083,7 +3083,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
               }
             >
               <svg
-                height={300}
+                height={0}
                 style={
                   Object {
                     "height": "100%",
@@ -3091,7 +3091,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 5`] = `
                     "width": "100%",
                   }
                 }
-                viewBox="0 0 0 300"
+                viewBox="0 0 0 0"
                 width={0}
               />
             </div>
@@ -3183,7 +3183,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 6`] = `
           className="disabled-pointer"
           style={
             Object {
-              "height": 300,
+              "height": "300px",
             }
           }
         >
@@ -3200,7 +3200,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 6`] = `
             }
           >
             <svg
-              height={230}
+              height={0}
               role="img"
               style={
                 Object {
@@ -3209,7 +3209,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 6`] = `
                   "width": "100%",
                 }
               }
-              viewBox="0 0 0 230"
+              viewBox="0 0 0 0"
               width={0}
             >
               <g>
@@ -3231,7 +3231,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 6`] = `
                       "strokeWidth": 1,
                     }
                   }
-                  transform="translate(0, 115)"
+                  transform="translate(0, 0)"
                 />
                 <path
                   d="M0,0Z"
@@ -3251,14 +3251,14 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 6`] = `
                       "strokeWidth": 1,
                     }
                   }
-                  transform="translate(0, 115)"
+                  transform="translate(0, 0)"
                 />
               </g>
               <text
                 direction="inherit"
                 dx={0}
                 x={0}
-                y={123.52}
+                y={8.52}
               >
                 <tspan
                   dx={0}
@@ -3293,7 +3293,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 6`] = `
               }
             >
               <svg
-                height={230}
+                height={0}
                 style={
                   Object {
                     "height": "100%",
@@ -3301,7 +3301,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 6`] = `
                     "width": "100%",
                   }
                 }
-                viewBox="0 0 0 230"
+                viewBox="0 0 0 0"
                 width={0}
               />
             </div>
@@ -3393,7 +3393,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
           className="disabled-pointer"
           style={
             Object {
-              "height": 300,
+              "height": "300px",
             }
           }
         >
@@ -3411,7 +3411,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
             }
           >
             <svg
-              height={300}
+              height={0}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onTouchCancel={[Function]}
@@ -3424,7 +3424,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                   "width": "100%",
                 }
               }
-              viewBox="0 0 0 300"
+              viewBox="0 0 0 0"
               width={0}
             >
               <g
@@ -3445,8 +3445,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                   vectorEffect="non-scaling-stroke"
                   x1={54}
                   x2={-30}
-                  y1={240}
-                  y2={240}
+                  y1={-60}
+                  y2={-60}
                 />
                 <g
                   role="presentation"
@@ -3467,15 +3467,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={-30}
                     x2={-30}
-                    y1={240}
-                    y2={245}
+                    y1={-60}
+                    y2={-55}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-0-ChartLabel-4"
                     x={-30}
-                    y={266.97}
+                    y={-33.03}
                   >
                     <tspan
                       dx={0}
@@ -3518,15 +3518,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                   x1={54}
                   x2={54}
                   y1={10}
-                  y2={240}
+                  y2={-60}
                 />
                 <text
                   direction="inherit"
                   dx={0}
                   id="axis-axisLabel-0"
-                  transform="rotate(-90,14,125)"
+                  transform="rotate(-90,14,-25)"
                   x={14}
-                  y={122.97}
+                  y={-27.03}
                 >
                   <tspan
                     dx={0}
@@ -3566,8 +3566,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <line
                     role="presentation"
@@ -3585,15 +3585,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-0"
                     x={39}
-                    y={198.97}
+                    y={-41.03}
                   >
                     <tspan
                       dx={0}
@@ -3634,8 +3634,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <line
                     role="presentation"
@@ -3653,15 +3653,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-1"
                     x={39}
-                    y={152.97}
+                    y={-27.03}
                   >
                     <tspan
                       dx={0}
@@ -3702,8 +3702,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <line
                     role="presentation"
@@ -3721,15 +3721,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-2"
                     x={39}
-                    y={106.97}
+                    y={-13.030000000000001}
                   >
                     <tspan
                       dx={0}
@@ -3770,8 +3770,8 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <line
                     role="presentation"
@@ -3789,15 +3789,15 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-3"
                     x={39}
-                    y={60.969999999999985}
+                    y={0.9700000000000033}
                   >
                     <tspan
                       dx={0}
@@ -3903,7 +3903,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                   vectorEffect="non-scaling-stroke"
                   width={0}
                   x={0}
-                  y={272}
+                  y={112}
                 />
               </g>
             </svg>
@@ -3920,7 +3920,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
               }
             >
               <svg
-                height={300}
+                height={0}
                 style={
                   Object {
                     "height": "100%",
@@ -3928,7 +3928,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 7`] = `
                     "width": "100%",
                   }
                 }
-                viewBox="0 0 0 300"
+                viewBox="0 0 0 0"
                 width={0}
               />
             </div>
@@ -4020,7 +4020,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 8`] = `
           className="disabled-pointer"
           style={
             Object {
-              "height": 300,
+              "height": "300px",
             }
           }
         >
@@ -4037,7 +4037,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 8`] = `
             }
           >
             <svg
-              height={230}
+              height={0}
               role="img"
               style={
                 Object {
@@ -4046,7 +4046,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 8`] = `
                   "width": "100%",
                 }
               }
-              viewBox="0 0 0 230"
+              viewBox="0 0 0 0"
               width={0}
             >
               <g>
@@ -4068,7 +4068,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 8`] = `
                       "strokeWidth": 1,
                     }
                   }
-                  transform="translate(0, 115)"
+                  transform="translate(0, 0)"
                 />
                 <path
                   d="M0,0Z"
@@ -4088,14 +4088,14 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 8`] = `
                       "strokeWidth": 1,
                     }
                   }
-                  transform="translate(0, 115)"
+                  transform="translate(0, 0)"
                 />
               </g>
               <text
                 direction="inherit"
                 dx={0}
                 x={0}
-                y={123.52}
+                y={8.52}
               >
                 <tspan
                   dx={0}
@@ -4130,7 +4130,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 8`] = `
               }
             >
               <svg
-                height={230}
+                height={0}
                 style={
                   Object {
                     "height": "100%",
@@ -4138,7 +4138,7 @@ exports[`<MBeanMetricsChartCard /> renders correctly: with-content 8`] = `
                     "width": "100%",
                   }
                 }
-                viewBox="0 0 0 230"
+                viewBox="0 0 0 0"
                 width={0}
               />
             </div>
@@ -4231,7 +4231,7 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
           className="disabled-pointer"
           style={
             Object {
-              "height": 300,
+              "height": "300px",
             }
           }
         >
@@ -4249,7 +4249,7 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
             }
           >
             <svg
-              height={300}
+              height={0}
               onMouseLeave={[Function]}
               onMouseMove={[Function]}
               onTouchCancel={[Function]}
@@ -4262,7 +4262,7 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                   "width": "100%",
                 }
               }
-              viewBox="0 0 0 300"
+              viewBox="0 0 0 0"
               width={0}
             >
               <g
@@ -4283,8 +4283,8 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                   vectorEffect="non-scaling-stroke"
                   x1={54}
                   x2={-30}
-                  y1={240}
-                  y2={240}
+                  y1={-60}
+                  y2={-60}
                 />
                 <g
                   role="presentation"
@@ -4305,15 +4305,15 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                     vectorEffect="non-scaling-stroke"
                     x1={-30}
                     x2={-30}
-                    y1={240}
-                    y2={245}
+                    y1={-60}
+                    y2={-55}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-0-ChartLabel-4"
                     x={-30}
-                    y={266.97}
+                    y={-33.03}
                   >
                     <tspan
                       dx={0}
@@ -4356,15 +4356,15 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                   x1={54}
                   x2={54}
                   y1={10}
-                  y2={240}
+                  y2={-60}
                 />
                 <text
                   direction="inherit"
                   dx={0}
                   id="axis-axisLabel-0"
-                  transform="rotate(-90,14,125)"
+                  transform="rotate(-90,14,-25)"
                   x={14}
-                  y={122.97}
+                  y={-27.03}
                 >
                   <tspan
                     dx={0}
@@ -4404,8 +4404,8 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <line
                     role="presentation"
@@ -4423,15 +4423,15 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={194}
-                    y2={194}
+                    y1={-46}
+                    y2={-46}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-0"
                     x={39}
-                    y={198.97}
+                    y={-41.03}
                   >
                     <tspan
                       dx={0}
@@ -4472,8 +4472,8 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <line
                     role="presentation"
@@ -4491,15 +4491,15 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={148}
-                    y2={148}
+                    y1={-32}
+                    y2={-32}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-1"
                     x={39}
-                    y={152.97}
+                    y={-27.03}
                   >
                     <tspan
                       dx={0}
@@ -4540,8 +4540,8 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <line
                     role="presentation"
@@ -4559,15 +4559,15 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={102}
-                    y2={102}
+                    y1={-18}
+                    y2={-18}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-2"
                     x={39}
-                    y={106.97}
+                    y={-13.030000000000001}
                   >
                     <tspan
                       dx={0}
@@ -4608,8 +4608,8 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={-30}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <line
                     role="presentation"
@@ -4627,15 +4627,15 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                     vectorEffect="non-scaling-stroke"
                     x1={54}
                     x2={49}
-                    y1={55.999999999999986}
-                    y2={55.999999999999986}
+                    y1={-3.9999999999999964}
+                    y2={-3.9999999999999964}
                   />
                   <text
                     direction="inherit"
                     dx={0}
                     id="chart-axis-1-ChartLabel-3"
                     x={39}
-                    y={60.969999999999985}
+                    y={0.9700000000000033}
                   >
                     <tspan
                       dx={0}
@@ -4741,7 +4741,7 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                   vectorEffect="non-scaling-stroke"
                   width={0}
                   x={0}
-                  y={272}
+                  y={112}
                 />
               </g>
             </svg>
@@ -4758,7 +4758,7 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
               }
             >
               <svg
-                height={300}
+                height={0}
                 style={
                   Object {
                     "height": "100%",
@@ -4766,7 +4766,7 @@ exports[`<MBeanMetricsChartCard /> renders loading state correctly: loading-view
                     "width": "100%",
                   }
                 }
-                viewBox="0 0 0 300"
+                viewBox="0 0 0 0"
                 width={0}
               />
             </div>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #739 

## Description of the change:

Added a subroute to view the card in "full-screen" mode. This approach is similar to Grafana Dashboard. The route requires a query paramter `cardId` to find the card configuration. If none or invalid, an empty state will be shown.

## Motivation for the change:

See #739 

## How to test

1. Create any dashboard card.
2. Click on top-right kebab icon to show action.
3. Click `View` to see full mode.
4. Notice the breadcrumb has the card Id (same as query param) and allows going back to main dashboard. 
