### PR TITLE
feat(topology): group node actions

### DIFF
--- a/src/app/Dashboard/JvmDetails/JvmDetailsCard.tsx
+++ b/src/app/Dashboard/JvmDetails/JvmDetailsCard.tsx
@@ -39,6 +39,7 @@
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
 import { Target } from '@app/Shared/Services/Target.service';
+import { NodeAction } from '@app/Topology/Actions/NodeActions';
 import EntityDetails from '@app/Topology/Shared/Entity/EntityDetails';
 import { NodeType } from '@app/Topology/typings';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
@@ -47,7 +48,6 @@ import * as React from 'react';
 import { DashboardCardDescriptor, DashboardCardProps, DashboardCardSizes } from '../Dashboard';
 import { DashboardCard } from '../DashboardCard';
 import '@app/Topology/styles/base.css';
-import { NodeAction } from '@app/Topology/Actions/NodeActions';
 
 export interface JvmDetailsCardProps extends DashboardCardProps {}
 

--- a/src/app/Topology/Actions/NodeActions.tsx
+++ b/src/app/Topology/Actions/NodeActions.tsx
@@ -36,58 +36,94 @@
  * SOFTWARE.
  */
 
-import { NotificationsContext } from '@app/Notifications/Notifications';
+import { Notifications, NotificationsContext } from '@app/Notifications/Notifications';
+import { ActiveRecording } from '@app/Shared/Services/Api.service';
+import { NotificationCategory, NotificationMessage } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { DropdownItem, DropdownItemProps } from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownItemProps, DropdownProps, DropdownToggle } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
 import { ContextMenuItem as PFContextMenuItem, GraphElement } from '@patternfly/react-topology';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
-import { ListElement } from '../Shared/utils';
-import { NodeType, TargetNode } from '../typings';
+import { Observable, Subject, switchMap, map, merge, filter, debounceTime } from 'rxjs';
+import { getConnectUrlFromEvent } from '../Shared/Entity/utils';
+import { getAllLeaves, ListElement } from '../Shared/utils';
+import { EnvironmentNode, NodeType, TargetNode } from '../typings';
 import { ActionUtils } from './utils';
 
-export type NodeActionFunction = (
-  element: GraphElement | ListElement,
-  actionUtils: ActionUtils,
-  track: ReturnType<typeof useSubscriptions>
-) => void;
+export type NodeActionFunction = (element: GraphElement | ListElement, actionUtils: ActionUtils) => void;
 
 export type MenuItemVariant = 'dropdownItem' | 'contextMenuItem';
 
+export type MenuItemComponent = React.FC<DropdownItemProps> | React.FC<React.ComponentProps<typeof PFContextMenuItem>>;
+
 export interface ContextMenuItemProps
-  extends Omit<React.ComponentProps<typeof PFContextMenuItem> & React.ComponentProps<typeof DropdownItem>, 'onClick'> {
+  extends Omit<
+    React.ComponentProps<typeof PFContextMenuItem> & React.ComponentProps<typeof DropdownItem>,
+    'onClick' | 'isDisabled'
+  > {
   onClick?: NodeActionFunction;
   element: GraphElement | ListElement;
   variant: MenuItemVariant;
+  isDisabled?: (element: GraphElement | ListElement, actionUtils: ActionUtils) => Observable<boolean>;
 }
 
-export const ContextMenuItem: React.FC<ContextMenuItemProps> = ({ children, element, onClick, variant, ...props }) => {
+export const ContextMenuItem: React.FC<ContextMenuItemProps> = ({
+  children,
+  element,
+  onClick,
+  variant,
+  isDisabled,
+  ...props
+}) => {
   const history = useHistory();
+  const addSubscription = useSubscriptions();
   const services = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
-  const addSubscription = useSubscriptions();
+  const elementSubjRef = React.useRef(new Subject<GraphElement | ListElement>());
+  const elementSubj = elementSubjRef.current;
 
-  const handleOnclick = React.useCallback(() => {
-    onClick && onClick(element, { history, services, notifications }, addSubscription);
-  }, [onClick, history, services, notifications, addSubscription, element]);
+  const [disabled, setDisabled] = React.useState(false);
 
-  let Comp: React.FC<DropdownItemProps> | React.ComponentProps<typeof PFContextMenuItem>;
+  const handleOnclick = React.useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      onClick && onClick(element, { history, services, notifications });
+    },
+    [onClick, history, services, notifications, element]
+  );
+
+  React.useEffect(() => {
+    if (isDisabled) {
+      addSubscription(
+        elementSubj
+          .pipe(switchMap((element) => isDisabled(element, { services, notifications, history })))
+          .subscribe(setDisabled)
+      );
+    }
+  }, [addSubscription, elementSubj, isDisabled, services, notifications, history]);
+
+  React.useEffect(() => {
+    elementSubj.next(element);
+  }, [elementSubj, element]);
+
+  let Component: MenuItemComponent;
   switch (variant) {
     case 'contextMenuItem':
-      Comp = PFContextMenuItem;
+      Component = PFContextMenuItem;
       break;
     case 'dropdownItem':
-      Comp = DropdownItem;
+      Component = DropdownItem;
       break;
     default:
-      throw new Error('unknown variant');
+      throw new Error(`Unknown variant: ${variant}`);
   }
 
   return (
-    <Comp onClick={handleOnclick} {...props}>
+    <Component {...props} onClick={handleOnclick} isDisabled={disabled}>
       {children}
-    </Comp>
+    </Component>
   );
 };
 
@@ -97,21 +133,57 @@ export type NodeActionKey =
   | 'CREATE_RECORDINGS'
   | 'CREATE_RULES'
   | 'DELETE_TARGET'
+  | 'GROUP_START_RECORDING'
+  | 'GROUP_STOP_RECORDING'
+  | 'GROUP_DELETE_RECORDING'
+  | 'GROUP_ARCHIVE_RECORDING'
   | '';
 
+export const QUICK_RECORDING_NAME = 'cryostat_topology_action';
+
+export const QUICK_RECORDING_LABEL_KEY = 'cryostat.io.topology-group';
+
+const isQuickRecording = (recording: ActiveRecording) => {
+  return recording.name === QUICK_RECORDING_NAME;
+};
+
+const isQuickRecordingExist = (group: EnvironmentNode, { services }: ActionUtils) => {
+  const svcUrls = new Set(getAllLeaves(group).map((tn) => tn.target.connectUrl));
+  const filterFn = (e: NotificationMessage) => {
+    const targetId = getConnectUrlFromEvent(e);
+    const recording = e.message.recording;
+    return targetId !== undefined && svcUrls.has(targetId) && isQuickRecording(recording);
+  };
+
+  return merge(
+    services.api.groupHasRecording(group, QUICK_RECORDING_NAME),
+    services.notificationChannel.messages(NotificationCategory.ActiveRecordingCreated).pipe(
+      filter(filterFn),
+      map((_) => true)
+    ),
+    services.notificationChannel.messages(NotificationCategory.ActiveRecordingDeleted).pipe(
+      filter(filterFn),
+      debounceTime(500),
+      map((_) => services.api.groupHasRecording(group, QUICK_RECORDING_NAME))
+    )
+  );
+};
+
 export interface NodeAction {
-  key: NodeActionKey;
-  action?: NodeActionFunction;
-  title?: React.ReactNode;
-  isSeparator?: boolean;
-  includeList?: NodeType[]; // Empty means all
-  blockList?: NodeType[]; // Empty means none
+  readonly key: NodeActionKey;
+  readonly isGroup?: boolean;
+  readonly action?: NodeActionFunction;
+  readonly title?: React.ReactNode;
+  readonly isSeparator?: boolean;
+  readonly isDisabled?: (element: GraphElement | ListElement, actionUtils: ActionUtils) => Observable<boolean>;
+  readonly includeList?: NodeType[]; // Empty means all
+  readonly blockList?: NodeType[]; // Empty means none
 }
 
 export const nodeActions: NodeAction[] = [
   {
     key: 'VIEW_DASHBOARD',
-    action: (element, { history, services }, _) => {
+    action: (element, { history, services }) => {
       const targetNode: TargetNode = element.getData();
 
       services.target.setTarget(targetNode.target);
@@ -121,7 +193,7 @@ export const nodeActions: NodeAction[] = [
   },
   {
     key: 'VIEW_RECORDINGS',
-    action: (element, { history, services }, _) => {
+    action: (element, { history, services }) => {
       const targetNode: TargetNode = element.getData();
 
       services.target.setTarget(targetNode.target);
@@ -132,7 +204,7 @@ export const nodeActions: NodeAction[] = [
   { key: '', isSeparator: true },
   {
     key: 'CREATE_RECORDINGS',
-    action: (element, { history, services }, _) => {
+    action: (element, { history, services }) => {
       const targetNode: TargetNode = element.getData();
 
       services.target.setTarget(targetNode.target);
@@ -142,7 +214,7 @@ export const nodeActions: NodeAction[] = [
   },
   {
     key: 'CREATE_RULES',
-    action: (element, { history, services }, _) => {
+    action: (element, { history, services }) => {
       const targetNode: TargetNode = element.getData();
 
       services.target.setTarget(targetNode.target);
@@ -153,11 +225,265 @@ export const nodeActions: NodeAction[] = [
   { key: '', isSeparator: true },
   {
     key: 'DELETE_TARGET',
-    action: (element, { services }, track) => {
+    action: (element, { services }) => {
       const targetNode: TargetNode = element.getData();
-      track(services.api.deleteTarget(targetNode.target).subscribe(() => undefined));
+      services.api.deleteTarget(targetNode.target).subscribe(() => undefined);
     },
     title: 'Delete Target',
     includeList: [NodeType.CUSTOM_TARGET],
   },
+  {
+    key: 'GROUP_START_RECORDING',
+    title: 'Start recording',
+    isGroup: true,
+    action: (element, { services, notifications }) => {
+      const group: EnvironmentNode = element.getData();
+      services.api
+        .graphql<any>(
+          `
+          query StartRecordingForGroup($filter: EnvironmentNodeFilterInput, $recordingName: String!, $labels: String) {
+            environmentNodes(filter: $filter) {
+              name
+              descendantTargets {
+                name
+                doStartRecording(recording: {
+                  name: $recordingName,
+                  template: "Continuous",
+                  templateType: "TARGET",
+                  duration: 0,
+                  restart: true,
+                  metadata: {
+                    labels: $labels
+                  },
+                  }) {
+                      name
+                      state
+                }
+              }
+            }
+          }
+            `,
+          {
+            filter: { id: group.id },
+            recordingName: QUICK_RECORDING_NAME,
+            labels: services.api.stringifyRecordingLabels([
+              {
+                key: QUICK_RECORDING_LABEL_KEY,
+                value: group.name.replace(/[\s+-]/g, '_'),
+              },
+            ]),
+          },
+          false,
+          true
+        )
+        .subscribe((body) => {
+          notifyGroupActionErrors('GROUP_START_RECORDING', group, body, notifications);
+        });
+    },
+  },
+  {
+    key: 'GROUP_ARCHIVE_RECORDING',
+    title: 'Archive recording',
+    isGroup: true,
+    action: (element, { services, notifications }) => {
+      const group: EnvironmentNode = element.getData();
+      services.api
+        .graphql<any>(
+          `
+          query DeleteRecordingForGroup ($groupFilter: EnvironmentNodeFilterInput, $recordingFilter: ActiveRecordingFilterInput){
+            environmentNodes(filter: $groupFilter) {
+              name
+              descendantTargets {
+                name
+                recordings {
+                    active(filter: $recordingFilter) {
+                        data {
+                          doArchive {
+                            name
+                          }
+                        }
+                    }
+                }
+              }
+            }
+        }
+            `,
+          {
+            groupFilter: { id: group.id },
+            recordingFilter: { name: QUICK_RECORDING_NAME },
+          },
+          false,
+          true
+        )
+        .subscribe((body) => {
+          notifyGroupActionErrors('GROUP_ARCHIVE_RECORDING', group, body, notifications);
+        });
+    },
+    isDisabled: (element, utils) => {
+      return isQuickRecordingExist(element.getData(), utils).pipe(map((exist) => !exist));
+    },
+  },
+  {
+    key: 'GROUP_STOP_RECORDING',
+    title: 'Stop recording',
+    isGroup: true,
+    action: (element, { services, notifications }) => {
+      const group: EnvironmentNode = element.getData();
+      services.api
+        .graphql<any>(
+          `
+          query StopRecordingForGroup ($groupFilter: EnvironmentNodeFilterInput, $recordingFilter: ActiveRecordingFilterInput){
+            environmentNodes(filter: $groupFilter) {
+              name
+              descendantTargets {
+                name
+                recordings {
+                    active(filter: $recordingFilter) {
+                        data {
+                            doStop {
+                              name
+                              state
+                            }
+                        }
+                    }
+                }
+              }
+            }
+        }
+            `,
+          {
+            groupFilter: { id: group.id },
+            recordingFilter: { name: QUICK_RECORDING_NAME },
+          },
+          false,
+          true
+        )
+        .subscribe((body) => {
+          notifyGroupActionErrors('GROUP_STOP_RECORDING', group, body, notifications);
+        });
+    },
+    isDisabled: (element, utils) => {
+      return isQuickRecordingExist(element.getData(), utils).pipe(map((exist) => !exist));
+    },
+  },
+  { key: '', isSeparator: true, isGroup: true },
+  {
+    key: 'GROUP_DELETE_RECORDING',
+    title: 'Delete recording',
+    isGroup: true,
+    action: (element, { services, notifications }) => {
+      const group: EnvironmentNode = element.getData();
+      services.api
+        .graphql<any>(
+          `
+          query DeleteRecordingForGroup ($groupFilter: EnvironmentNodeFilterInput, $recordingFilter: ActiveRecordingFilterInput){
+            environmentNodes(filter: $groupFilter) {
+              name
+              descendantTargets {
+                name
+                recordings {
+                    active(filter: $recordingFilter) {
+                        data {
+                            doDelete {
+                              name
+                              state
+                            }
+                        }
+                    }
+                }
+              }
+            }
+        }
+            `,
+          {
+            groupFilter: { id: group.id },
+            recordingFilter: { name: QUICK_RECORDING_NAME },
+          },
+          false,
+          true
+        )
+        .subscribe((body) => {
+          notifyGroupActionErrors('GROUP_DELETE_RECORDING', group, body, notifications);
+        });
+    },
+    isDisabled: (element, utils) => {
+      return isQuickRecordingExist(element.getData(), utils).pipe(map((exist) => !exist));
+    },
+  },
 ];
+
+type GroupActionResponse = {
+  errors?: {
+    message: string;
+    path: (string | number)[];
+  }[];
+  data: {
+    environmentNodes: {
+      descendantTargets: { name: string }[]; // graphql query specifies name
+    }[];
+  };
+};
+
+export const notifyGroupActionErrors = (
+  type: Extract<
+    'GROUP_START_RECORDING' | 'GROUP_ARCHIVE_RECORDING' | 'GROUP_STOP_RECORDING' | 'GROUP_DELETE_RECORDING',
+    NodeActionKey
+  >,
+  group: EnvironmentNode,
+  { errors, data }: GroupActionResponse,
+  notifications: Notifications
+): void => {
+  if (errors) {
+    const actionVerb = type
+      .split('_')
+      .slice(1)
+      .map((str) => str.toLowerCase())
+      .join(' ');
+    const groupDisplay = `${group.nodeType} ${group.name}`;
+    errors.forEach((err) => {
+      // Location of failed target node
+      const searchIndex = Number(err.path[err.path.indexOf('descendantTargets') + 1]);
+      if (searchIndex == undefined) {
+        notifications.danger(`Could not ${actionVerb} for a Target in ${groupDisplay}`, err.message);
+      }
+
+      // Get the name of failed target node
+      const name: string | undefined = data.environmentNodes[0]?.descendantTargets[searchIndex]?.name;
+
+      if (name) {
+        notifications.danger(`Could not ${actionVerb} for Target ${name} in ${groupDisplay}`, err.message);
+      } else {
+        notifications.danger(`Could not ${actionVerb} for a Target in ${groupDisplay}`, err.message);
+      }
+    });
+  }
+};
+
+export interface ActionDropdownProps extends Omit<DropdownProps, 'isOpen' | 'onSelect' | 'toggle'> {
+  actions: JSX.Element[];
+}
+
+export const ActionDropdown: React.FC<ActionDropdownProps> = ({
+  className,
+  actions,
+  position,
+  menuAppendTo,
+  ...props
+}) => {
+  const [actionOpen, setActionOpen] = React.useState(false);
+  const handleClose = React.useCallback(() => setActionOpen(false), [setActionOpen]);
+  return (
+    <Dropdown
+      {...props}
+      className={css(className)}
+      aria-label={'entity-action-menu'}
+      position={position || 'right'}
+      menuAppendTo={menuAppendTo || (() => document.getElementById('topology-card') || document.body)}
+      onSelect={handleClose}
+      isOpen={actionOpen}
+      onClick={(e) => e.stopPropagation()}
+      toggle={<DropdownToggle onToggle={setActionOpen}>Actions</DropdownToggle>}
+      dropdownItems={actions}
+    />
+  );
+};

--- a/src/app/Topology/GraphView/CustomGroup.tsx
+++ b/src/app/Topology/GraphView/CustomGroup.tsx
@@ -37,7 +37,14 @@
  */
 import openjdkSvg from '@app/assets/openjdk.svg';
 import { RootState } from '@app/Shared/Redux/ReduxStore';
-import { DefaultGroup, Node, observer, WithDragNodeProps, WithSelectionProps } from '@patternfly/react-topology';
+import {
+  DefaultGroup,
+  Node,
+  observer,
+  WithContextMenuProps,
+  WithDragNodeProps,
+  WithSelectionProps,
+} from '@patternfly/react-topology';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { EnvironmentNode, NodeType } from '../typings';
@@ -64,7 +71,7 @@ export const renderIcon = (width: number, height: number): React.ReactNode => {
   );
 };
 
-export interface CustomGroupProps extends Partial<WithSelectionProps & WithDragNodeProps> {
+export interface CustomGroupProps extends Partial<WithSelectionProps & WithDragNodeProps & WithContextMenuProps> {
   element: Node;
   collapsedWidth?: number;
   collapsedHeight?: number;
@@ -75,6 +82,8 @@ const CustomGroup: React.FC<CustomGroupProps> = ({
   onSelect,
   selected,
   dragNodeRef,
+  contextMenuOpen,
+  onContextMenu,
   collapsedHeight = DEFAULT_NODE_COLLAPSED_DIAMETER,
   collapsedWidth = DEFAULT_NODE_COLLAPSED_DIAMETER,
   ...props
@@ -114,6 +123,8 @@ const CustomGroup: React.FC<CustomGroupProps> = ({
           collapsedWidth: collapsedWidth,
           badge: showBadge ? data.nodeType : undefined,
           showLabel: true,
+          contextMenuOpen: contextMenuOpen,
+          onContextMenu: onContextMenu,
         } as React.ComponentProps<typeof DefaultGroup>,
         element.isCollapsed() ? collapsedContent : null
       )}

--- a/src/app/Topology/GraphView/UtilsFactory.tsx
+++ b/src/app/Topology/GraphView/UtilsFactory.tsx
@@ -265,8 +265,10 @@ export const layoutFactory: LayoutFactory = (type: string, graph: Graph): Layout
 export const componentFactory: ComponentFactory = (kind: ModelKind, type: string) => {
   switch (type) {
     case 'group':
-      return withDragNode(nodeDragSourceSpec('group', false, false))(
-        withSelection({ multiSelect: false, controlled: true })(CustomGroup)
+      return withContextMenu(actionFactory)(
+        withDragNode(nodeDragSourceSpec('group', false, false))(
+          withSelection({ multiSelect: false, controlled: true })(CustomGroup)
+        )
       );
     default:
       switch (kind) {

--- a/src/app/Topology/ListView/UtilsFactory.tsx
+++ b/src/app/Topology/ListView/UtilsFactory.tsx
@@ -36,10 +36,12 @@
  * SOFTWARE.
  */
 import { TopologyFilters } from '@app/Shared/Redux/Filters/TopologyFilterSlice';
-import { Badge, Label, LabelGroup, TreeViewDataItem } from '@patternfly/react-core';
+import { Badge, Flex, FlexItem, Label, LabelGroup, TreeViewDataItem } from '@patternfly/react-core';
 import * as React from 'react';
+import { ActionDropdown } from '../Actions/NodeActions';
 import EntityDetails from '../Shared/Entity/EntityDetails';
 import {
+  actionFactory,
   COLLAPSE_EXEMPTS,
   getAllLeaves,
   getUniqueGroupId,
@@ -105,12 +107,20 @@ const _transformDataGroupedByTopLevel = (
       return {
         ...base,
         title: (
-          <>
-            <span className="topology-listview__realm-title">
-              {realm.nodeType}: {realm.name}
-            </span>
-            <Badge>{base.children.length}</Badge>
-          </>
+          <Flex>
+            <FlexItem flex={{ default: 'flex_1' }}>
+              <span className="topology-listview__realm-title">
+                {realm.nodeType}: {realm.name}
+              </span>
+              <Badge>{base.children.length}</Badge>
+            </FlexItem>
+            <FlexItem>
+              <ActionDropdown
+                className="entity-overview__action-menu"
+                actions={actionFactory({ getData: () => realm }, 'dropdownItem')}
+              />
+            </FlexItem>
+          </Flex>
         ),
       };
     })
@@ -181,12 +191,20 @@ const _buildFullData = (
     {
       id: getUniqueGroupId(node),
       title: (
-        <>
-          <span className="topology-listview__realm-title">
-            {node.nodeType}: {node.name}
-          </span>
-          <Badge>{children.length}</Badge>
-        </>
+        <Flex>
+          <FlexItem flex={{ default: 'flex_1' }}>
+            <span className="topology-listview__realm-title">
+              {node.nodeType}: {node.name}
+            </span>
+            <Badge>{children.length}</Badge>
+          </FlexItem>
+          <FlexItem>
+            <ActionDropdown
+              className="entity-overview__action-menu"
+              actions={actionFactory({ getData: () => node }, 'dropdownItem')}
+            />
+          </FlexItem>
+        </Flex>
       ),
       name: (
         <LabelGroup categoryName="Labels">

--- a/src/app/Topology/Shared/Entity/utils.ts
+++ b/src/app/Topology/Shared/Entity/utils.ts
@@ -289,7 +289,6 @@ export const getResourceListPatchFn = (
         return apiService.isTargetMatched(credential.matchExpression, target).pipe(
           map((ok) => {
             if (ok) {
-              // return apiService.isTargetMatched(credential.matchExpression, )
               let newArr = arr.filter((r) => r.id !== credential.id);
               if (!removed) {
                 newArr = newArr.concat([credential]);
@@ -331,6 +330,6 @@ export const getLinkPropsForTargetResource = (
   }
 };
 
-export const extraTargetConnectUrlFromEvent = (event: NotificationMessage): string | undefined => {
+export const getConnectUrlFromEvent = (event: NotificationMessage): string | undefined => {
   return event.message.target || event.message.targetId;
 };

--- a/src/app/Topology/Shared/utils.tsx
+++ b/src/app/Topology/Shared/utils.tsx
@@ -36,7 +36,7 @@
  * SOFTWARE.
  */
 import { TopologyFilters } from '@app/Shared/Redux/Filters/TopologyFilterSlice';
-import { evaluateTargetWithExpr, hashCode } from '@app/utils/utils';
+import { evaluateTargetWithExpr } from '@app/utils/utils';
 import { Button } from '@patternfly/react-core';
 import { ContextMenuSeparator, GraphElement, NodeStatus } from '@patternfly/react-topology';
 import * as React from 'react';
@@ -88,11 +88,11 @@ export interface TransformConfig {
 }
 
 export const getUniqueGroupId = (group: EnvironmentNode) => {
-  return `${group.name}-${hashCode(JSON.stringify(group.labels))}-${hashCode(JSON.stringify(group.children))}`;
+  return `${group.id}`;
 };
 
 export const getUniqueTargetId = (target: TargetNode) => {
-  return target.name;
+  return `${target.id}`;
 };
 
 export type StatusExtra = { title?: string; description?: string; callForAction?: React.ReactNode[] };
@@ -125,9 +125,11 @@ export const actionFactory = (
   actionFilter = (_: NodeAction) => true
 ) => {
   const data: TargetNode = element.getData();
+  const isGroup = !isTargetNode(data);
   let filtered = nodeActions.filter((action) => {
     return (
       actionFilter(action) &&
+      (action.isGroup || false) === isGroup &&
       (!action.includeList || action.includeList.includes(data.nodeType)) &&
       (!action.blockList || !action.blockList.includes(data.nodeType))
     );
@@ -142,12 +144,12 @@ export const actionFactory = (
   }
   filtered = stop >= 0 ? filtered.slice(0, stop + 1) : [];
 
-  return filtered.map(({ isSeparator, title, action }, index) => {
+  return filtered.map(({ isSeparator, key, title, isDisabled, action }, index) => {
     if (isSeparator) {
       return <ContextMenuSeparator key={`separator-${index}`} />;
     }
     return (
-      <ContextMenuItem key={`${title}-${index}`} element={element} onClick={action} variant={variant}>
+      <ContextMenuItem key={key} element={element} onClick={action} variant={variant} isDisabled={isDisabled}>
         {title}
       </ContextMenuItem>
     );

--- a/src/app/Topology/Topology.tsx
+++ b/src/app/Topology/Topology.tsx
@@ -103,7 +103,6 @@ export const Topology: React.FC<TopologyProps> = ({ ..._props }) => {
           },
           error: (err) => {
             setError(err);
-            console.log(err);
           },
         })
       );

--- a/src/app/Topology/styles/base.css
+++ b/src/app/Topology/styles/base.css
@@ -118,6 +118,10 @@ Below CSS rules only apply to Topology components
   border-radius: 500px;
 }
 
+.empty-text {
+  color: var(--pf-global--palette--black-400);
+}
+
 .entity-overview__wrapper {
   padding: 1.6em;
   padding-right: 0.6em;
@@ -139,10 +143,6 @@ Below CSS rules only apply to Topology components
 
 .entity-overview__displayed-annotations {
   margin-bottom: 0.5em;
-}
-
-.empty-text {
-  color: var(--pf-global--palette--black-400)
 }
 
 .entity-overview__entity-title-wrapper {
@@ -174,6 +174,10 @@ Below CSS rules only apply to Topology components
 
 .entity-overview__header {
   margin: 0em 0em 1em 1em;
+}
+
+.entity-overview__action-menu {
+  background-color: #fff;
 }
 
 .topology-listview__realm-title {
@@ -215,7 +219,7 @@ Below CSS rules only apply to Topology components
   box-sizing: border-box;
   text-align: center;
   padding: 0.2em 0 0.2em 0;
-  background-color: var(--pf-global--palette--blue-400) ;
+  background-color: var(--pf-global--palette--blue-400);
   color: #fff;
   font-size: 0.9em;
   margin-bottom: -1em;

--- a/src/app/Topology/typings.ts
+++ b/src/app/Topology/typings.ts
@@ -66,20 +66,22 @@ export interface NodeLabels {
 }
 
 interface _AbstractNode {
-  name: string;
-  nodeType: NodeType;
-  labels: NodeLabels;
+  readonly id: number;
+  readonly name: string;
+  readonly nodeType: NodeType;
+  readonly labels: NodeLabels;
 }
 
 export interface EnvironmentNode extends _AbstractNode {
-  children: (EnvironmentNode | TargetNode)[];
+  readonly children: (EnvironmentNode | TargetNode)[];
 }
 
 export interface TargetNode extends _AbstractNode {
-  target: Target;
+  readonly target: Target;
 }
 
 export const DEFAULT_EMPTY_UNIVERSE: EnvironmentNode = {
+  id: 0,
   name: 'Universe',
   nodeType: NodeType.UNIVERSE,
   labels: {},


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #901 
Depends on https://github.com/cryostatio/cryostat/issues/1403
Depends on https://github.com/cryostatio/cryostat/issues/1410
Depends on https://github.com/cryostatio/cryostat/pull/1411
Depends on https://github.com/cryostatio/cryostat/pull/1417

## Description of the change:

- [x] Add an action menu for group nodes. Currently, only support starting recordings for all targets under that group (all leaves).
- [x] Clean up comments.
- [x] Remove subscription tracker for callback. Action menu is closed when selecting, thus unmounting the items => unsubscribe to the observable. However, there is no `setState` available in callback so its safe not to tracked.  

Note: Fail operations on an individual target (e.g. missing credentials) are silent (even notifications are not shown). Any idea to check errors?

## Motivation for the change:

See #901 

## How to manually test:
1. `Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2.  Go to Topology View
