### PR TITLE
fix(topology): add missing callbacks to empty state actions

### DIFF
--- a/src/app/Topology/Shared/TopologyEmptyState.tsx
+++ b/src/app/Topology/Shared/TopologyEmptyState.tsx
@@ -35,6 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { topologyDeleteAllFiltersIntent } from '@app/Shared/Redux/ReduxStore';
 import {
   Bullseye,
   Button,
@@ -47,13 +48,16 @@ import {
 } from '@patternfly/react-core';
 import { TopologyIcon } from '@patternfly/react-icons';
 import * as React from 'react';
+import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { DiscoveryTreeContext, getAllLeaves } from './utils';
+import { DiscoveryTreeContext, getAllLeaves, SearchExprServiceContext } from './utils';
 
 export interface TopologyEmptyStateProps {}
 
 export const TopologyEmptyState: React.FC<TopologyEmptyStateProps> = ({ ...props }) => {
   const discoveryTree = React.useContext(DiscoveryTreeContext);
+  const dispatch = useDispatch();
+  const searchExprService = React.useContext(SearchExprServiceContext);
 
   const isTruelyEmpty = React.useMemo(() => {
     return !getAllLeaves(discoveryTree).length;
@@ -72,12 +76,16 @@ export const TopologyEmptyState: React.FC<TopologyEmptyStateProps> = ({ ...props
       <>
         <EmptyStateBody>Adjust your filters/searches and try again.</EmptyStateBody>
         <EmptyStateSecondaryActions>
-          <Button variant={'link'}>Clear Filters</Button>
-          <Button variant={'link'}>Clear Search</Button>
+          <Button variant={'link'} onClick={() => dispatch(topologyDeleteAllFiltersIntent())}>
+            Clear Filters
+          </Button>
+          <Button variant={'link'} onClick={() => searchExprService.setSearchExpression('')}>
+            Clear Searches
+          </Button>
         </EmptyStateSecondaryActions>
       </>
     );
-  }, [isTruelyEmpty]);
+  }, [isTruelyEmpty, searchExprService, dispatch]);
 
   return (
     <Bullseye {...props}>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to: #891 

## Description of the change:

Added missing callback to empty state

## Motivation for the change:

Empty state actions should perform work as expected.

## How to manually test:

1. Go to Topology -> Select listview -> type any words in search bar -> clear searches
2. Go to Topology -> Select graphview -> choose a bad filter (a target + a group not containing the target) -> clear filters.
