### PR TITLE
feat(topology): expanded row for resource details

### DIFF
--- a/src/app/Topology/Actions/CreateTarget.tsx
+++ b/src/app/Topology/Actions/CreateTarget.tsx
@@ -47,6 +47,7 @@ import { Target } from '@app/Shared/Services/Target.service';
 import '@app/Topology/styles/base.css';
 import { getFromLocalStorage } from '@app/utils/LocalStorage';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { portalRoot } from '@app/utils/utils';
 import {
   Accordion,
   AccordionContent,
@@ -495,6 +496,7 @@ export const SampleNodeDonut: React.FC<SampleNodeDonutProps> = ({
       <Flex className={css(className)} direction={{ default: 'column' }}>
         <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
           <Tooltip
+            appendTo={portalRoot}
             content={
               _actionEnabled
                 ? `Click to test${validation.option !== ValidatedOptions.default ? ' again' : ''}.`
@@ -519,7 +521,7 @@ export const SampleNodeDonut: React.FC<SampleNodeDonutProps> = ({
         </FlexItem>
         <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
           <div className={css('sample-node-donut__node-label')}>
-            <Tooltip content={'Custom Target'}>
+            <Tooltip content={'Custom Target'} appendTo={portalRoot}>
               <span className="sample-node-donut__node-label-badge">{'CT'}</span>
             </Tooltip>
             {_transformedTarget.alias || '<Name>'}

--- a/src/app/Topology/GraphView/CustomNode.tsx
+++ b/src/app/Topology/GraphView/CustomNode.tsx
@@ -60,6 +60,7 @@ import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { getStatusTargetNode, isTargetMatched, nodeTypeToAbbr, useSearchExpression } from '../Shared/utils';
 import { TargetNode } from '../typings';
+import { getNodeDecorators } from './NodeDecorator';
 import { RESOURCE_NAME_TRUNCATE_LENGTH } from './UtilsFactory';
 
 export const NODE_ICON_PADDING = 5;
@@ -112,17 +113,20 @@ const CustomNode: React.FC<CustomNodeProps> = ({
   const labelIcon = React.useMemo(() => <img src={cryostatSvg} />, []);
 
   const data: TargetNode = element.getData();
-  const [nodeStatus, extra] = getStatusTargetNode(data);
+  const [nodeStatus] = getStatusTargetNode(data);
 
   const classNames = React.useMemo(() => {
     const additional = expression === '' || isTargetMatched(data, expression) ? '' : 'search-inactive';
     return css('topology__target-node', additional);
   }, [data, expression]);
 
+  const nodeDecorators = React.useMemo(() => (showStatus ? getNodeDecorators(element) : null), [element, showStatus]);
+
   return (
     <Layer id={contextMenuOpen ? TOP_LAYER : DEFAULT_LAYER}>
       <g className={classNames} id={'target-node-visual-group'} ref={hoverRef as React.LegacyRef<SVGGElement>}>
         <DefaultNode
+          {...props}
           element={element}
           onSelect={onSelect}
           selected={selected}
@@ -134,14 +138,12 @@ const CustomNode: React.FC<CustomNodeProps> = ({
           badgeColor={NODE_BADGE_COLOR}
           badgeClassName={'topology__node-badge'}
           nodeStatus={showStatus ? nodeStatus : undefined}
-          showStatusDecorator={showStatus}
           showStatusBackground={!hover && detailsLevel === ScaleDetailsLevel.low}
-          statusDecoratorTooltip={showStatus ? extra?.title : undefined}
           truncateLength={RESOURCE_NAME_TRUNCATE_LENGTH}
           labelIcon={showIcon ? labelIcon : undefined}
           secondaryLabel={showConnectUrl ? data.target.connectUrl : undefined}
           showLabel
-          {...props}
+          attachments={nodeDecorators}
         >
           <g id={'target-node-visual-inner-icon'}>{renderIcon(data, element, !showIcon)}</g>
         </DefaultNode>

--- a/src/app/Topology/GraphView/NodeDecorator.tsx
+++ b/src/app/Topology/GraphView/NodeDecorator.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import { ActiveRecording, isHttpError, RecordingState } from '@app/Shared/Services/Api.service';
+import { Tooltip } from '@patternfly/react-core';
+import { ExclamationCircleIcon, InProgressIcon, RunningIcon, WarningTriangleIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
+import {
+  Decorator,
+  DEFAULT_DECORATOR_RADIUS,
+  getDefaultShapeDecoratorCenter,
+  Node,
+  TopologyQuadrant,
+} from '@patternfly/react-topology';
+import * as React from 'react';
+import { useResources } from '../Shared/Entity/utils';
+import { getStatusTargetNode } from '../Shared/utils';
+import { TargetNode } from '../typings';
+
+export const getNodeDecorators = (element: Node) => {
+  return (
+    <>
+      <ActiveRecordingDecorator element={element} quadrant={TopologyQuadrant.upperRight} />,
+      <StatusDecorator element={element} quadrant={TopologyQuadrant.lowerLeft} />
+    </>
+  );
+};
+
+interface DecoratorProps {
+  element: Node;
+  quadrant: TopologyQuadrant;
+}
+
+export const ActiveRecordingDecorator: React.FC<DecoratorProps> = ({ element, quadrant, ...props }) => {
+  const data: TargetNode = element.getData();
+  const { x, y } = getDefaultShapeDecoratorCenter(quadrant, element);
+  const { resources: recordings, error, loading } = useResources<ActiveRecording>(data, 'activeRecordings');
+
+  const runningRecs = React.useMemo(
+    () => recordings.filter((rec) => rec.state === RecordingState.RUNNING),
+    [recordings]
+  );
+
+  const iconConfig = React.useMemo(() => {
+    const base = 'topology__node-decorator-icon';
+    if (loading) {
+      return {
+        icon: <InProgressIcon className={css(base, 'progress')} />,
+        tooltip: 'Retrieving active recordings.',
+      };
+    }
+    return runningRecs.length && !error
+      ? {
+          icon: <RunningIcon className={css(base, 'success')} />,
+          tooltip: `${runningRecs.length} running active recording${runningRecs.length > 2 ? 's' : ''}.`,
+        }
+      : undefined;
+  }, [error, loading, runningRecs]);
+
+  return iconConfig ? (
+    <Tooltip {...props} content={iconConfig.tooltip}>
+      <Decorator x={x} y={y} radius={DEFAULT_DECORATOR_RADIUS} showBackground icon={iconConfig.icon} />
+    </Tooltip>
+  ) : null;
+};
+
+export const StatusDecorator: React.FC<DecoratorProps> = ({ element, quadrant, ...props }) => {
+  const data: TargetNode = element.getData();
+  const [nodeStatus, extra] = getStatusTargetNode(data);
+  const { x, y } = getDefaultShapeDecoratorCenter(quadrant, element);
+  return nodeStatus ? (
+    <Tooltip {...props} content={extra?.title}>
+      <Decorator
+        x={x}
+        y={y}
+        radius={DEFAULT_DECORATOR_RADIUS}
+        showBackground
+        icon={<WarningTriangleIcon className={css('topology__node-decorator-icon', 'warning')} />}
+      />
+    </Tooltip>
+  ) : null;
+};

--- a/src/app/Topology/GraphView/NodeDecorator.tsx
+++ b/src/app/Topology/GraphView/NodeDecorator.tsx
@@ -36,6 +36,7 @@
  * SOFTWARE.
  */
 import { ActiveRecording, RecordingState } from '@app/Shared/Services/Api.service';
+import { portalRoot } from '@app/utils/utils';
 import { Tooltip } from '@patternfly/react-core';
 import { InProgressIcon, RunningIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
@@ -92,7 +93,7 @@ export const ActiveRecordingDecorator: React.FC<DecoratorProps> = ({ element, qu
   }, [error, loading, runningRecs]);
 
   return iconConfig ? (
-    <Tooltip {...props} content={iconConfig.tooltip}>
+    <Tooltip {...props} content={iconConfig.tooltip} appendTo={portalRoot}>
       <Decorator x={x} y={y} radius={DEFAULT_DECORATOR_RADIUS} showBackground icon={iconConfig.icon} />
     </Tooltip>
   ) : null;
@@ -103,7 +104,7 @@ export const StatusDecorator: React.FC<DecoratorProps> = ({ element, quadrant, .
   const [nodeStatus, extra] = getStatusTargetNode(data);
   const { x, y } = getDefaultShapeDecoratorCenter(quadrant, element);
   return nodeStatus ? (
-    <Tooltip {...props} content={extra?.title}>
+    <Tooltip {...props} content={extra?.title} appendTo={portalRoot}>
       <Decorator
         x={x}
         y={y}

--- a/src/app/Topology/GraphView/NodeDecorator.tsx
+++ b/src/app/Topology/GraphView/NodeDecorator.tsx
@@ -35,9 +35,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { ActiveRecording, isHttpError, RecordingState } from '@app/Shared/Services/Api.service';
+import { ActiveRecording, RecordingState } from '@app/Shared/Services/Api.service';
 import { Tooltip } from '@patternfly/react-core';
-import { ExclamationCircleIcon, InProgressIcon, RunningIcon, WarningTriangleIcon } from '@patternfly/react-icons';
+import { InProgressIcon, RunningIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import {
   Decorator,

--- a/src/app/Topology/Shared/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Shared/Entity/EntityDetails.tsx
@@ -43,7 +43,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { ActionDropdown, NodeAction } from '@app/Topology/Actions/NodeActions';
 import useDayjs from '@app/utils/useDayjs';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { hashCode, splitWordsOnUppercase } from '@app/utils/utils';
+import { hashCode, portalRoot, splitWordsOnUppercase } from '@app/utils/utils';
 import {
   Alert,
   AlertActionCloseButton,
@@ -498,7 +498,7 @@ export const TargetResourceItem: React.FC<{
               <LinearDotSpinner />
             </Bullseye>
           ) : error ? (
-            <Tooltip content={error.message}>
+            <Tooltip content={error.message} appendTo={portalRoot}>
               <WarningTriangleIcon color="var(--pf-global--warning-color--100)" />
             </Tooltip>
           ) : (
@@ -528,7 +528,7 @@ export const GroupResources: React.FC<{ envNode: EnvironmentNode }> = ({ envNode
           <CardBody>
             <Flex>
               <FlexItem flex={{ default: 'flex_1' }}>
-                <Tooltip content={isTarget ? child.target.connectUrl : child.name}>
+                <Tooltip content={isTarget ? child.target.connectUrl : child.name} appendTo={portalRoot}>
                   <div>
                     <Badge>{nodeTypeToAbbr(child.nodeType)}</Badge>
                     <span style={{ marginLeft: '0.5em' }}>{isTarget ? child.target.alias : child.name}</span>
@@ -537,7 +537,7 @@ export const GroupResources: React.FC<{ envNode: EnvironmentNode }> = ({ envNode
               </FlexItem>
               {status === NodeStatus.warning ? (
                 <FlexItem>
-                  <Tooltip content={extra?.title}>
+                  <Tooltip content={extra?.title} appendTo={portalRoot}>
                     <WarningTriangleIcon color="var(--pf-global--warning-color--100)" />
                   </Tooltip>
                 </FlexItem>

--- a/src/app/Topology/Shared/Entity/EntityTitle.tsx
+++ b/src/app/Topology/Shared/Entity/EntityTitle.tsx
@@ -35,6 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { portalRoot } from '@app/utils/utils';
 import { Tooltip } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import * as React from 'react';
@@ -47,7 +48,7 @@ export const EntityTitle: React.FC<{
   return (
     <div className={css('entity-overview__entity-title-wrapper')} {...props}>
       {badge ? (
-        <Tooltip content={badgeTooltipContent}>
+        <Tooltip content={badgeTooltipContent} appendTo={portalRoot}>
           <span className="entity-overview__entity-title-badge">{badge}</span>
         </Tooltip>
       ) : (

--- a/src/app/Topology/Shared/Entity/utils.tsx
+++ b/src/app/Topology/Shared/Entity/utils.tsx
@@ -299,10 +299,6 @@ export const getResourceListPatchFn = (
         const recording: Recording = eventData.message.recording;
         let newArr = arr.filter((r) => r.name !== recording.name);
         if (!removed) {
-          // Stop event emits a recording with RUNNING state
-          if (eventData.meta.category === NotificationCategory.ActiveRecordingStopped) {
-            (recording as ActiveRecording).state = RecordingState.STOPPED;
-          }
           newArr = newArr.concat([recording]);
         }
         return of(newArr);

--- a/src/app/Topology/Shared/HintBanner.tsx
+++ b/src/app/Topology/Shared/HintBanner.tsx
@@ -35,6 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { portalRoot } from '@app/utils/utils';
 import { Tooltip } from '@patternfly/react-core';
 import { CloseIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
@@ -52,7 +53,7 @@ export const HintBanner: React.FC<HintBannerProps> = ({ className, style, childr
   return show ? (
     <div className={css('topology__hint-banner', className)} style={style} {...props}>
       {children}
-      <Tooltip content={'Do not show again.'}>
+      <Tooltip content={'Do not show again.'} appendTo={portalRoot}>
         <CloseIcon className="close-icon" onClick={onClose} />
       </Tooltip>
     </div>

--- a/src/app/Topology/Toolbar/QuickSearchButton.tsx
+++ b/src/app/Topology/Toolbar/QuickSearchButton.tsx
@@ -35,13 +35,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { portalRoot } from '@app/utils/utils';
 import { Button, Tooltip } from '@patternfly/react-core';
 import * as React from 'react';
 import QuickSearchIcon from '../Shared/QuickSearchIcon';
 
 export const QuickSearchButton: React.FC<{ onClick: () => void }> = ({ onClick, ...props }) => {
   return (
-    <Tooltip {...props} position="right" content={'Add to view'}>
+    <Tooltip {...props} position="right" content={'Add to view'} appendTo={portalRoot}>
       <Button variant="plain" onClick={onClick} className={'topology__quick-search-button'}>
         <QuickSearchIcon className="top" />
       </Button>

--- a/src/app/Topology/Toolbar/TopologyToolbar.tsx
+++ b/src/app/Topology/Toolbar/TopologyToolbar.tsx
@@ -36,6 +36,7 @@
  * SOFTWARE.
  */
 import { topologyConfigSetViewModeIntent, topologyDeleteAllFiltersIntent } from '@app/Shared/Redux/ReduxStore';
+import { portalRoot } from '@app/utils/utils';
 import { Button, Popover, Toolbar, ToolbarContent, ToolbarItem, Tooltip } from '@patternfly/react-core';
 import { TopologyIcon, ListIcon, MouseIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 import { Visualization } from '@patternfly/react-topology';
@@ -86,7 +87,13 @@ export const TopologyToolbar: React.FC<TopologyToolbarProps> = ({ variant, visua
 
   const actionIcon = React.useMemo(
     () => (
-      <Tooltip entryDelay={0} content={isGraphView ? 'Graph View' : 'List View'} aria="none" aria-live="polite">
+      <Tooltip
+        entryDelay={0}
+        content={isGraphView ? 'Graph View' : 'List View'}
+        aria="none"
+        aria-live="polite"
+        appendTo={portalRoot}
+      >
         <Button className="topology__view-switcher" aria-label="Clipboard" variant="plain" onClick={toggleView}>
           {isGraphView ? <TopologyIcon /> : <ListIcon />}
         </Button>

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -523,3 +523,15 @@ input[type=number].datetime-picker__number-input {
 .overflow-auto {
   overflow: auto;
 }
+
+svg.topology__node-decorator-icon.warning {
+  fill: var(--pf-global--warning-color--100);
+}
+
+svg.topology__node-decorator-icon.success {
+  fill: var(--pf-global--success-color--100);
+}
+
+svg.topology__node-decorator-icon.progress {
+  fill: var(--pf-global--info-color--100);
+}

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -35,10 +35,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import '@app/Topology/styles/base.css';
-import '@app/app.css';
+
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/quickstarts/dist/quickstarts.css';
+import '@app/app.css';
+import '@app/Topology/styles/base.css';
 import '@i18n/config';
 import { AppLayout } from '@app/AppLayout/AppLayout';
 import { NotificationsContext, NotificationsInstance } from '@app/Notifications/Notifications';


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #891 
Depends on https://github.com/cryostatio/cryostat/issues/1428

## Description of the change:

Each resource row can have an expanded section that show detail view. For now, only `ActiveRecording` row is supported. Others will show an empty text.

## Motivation for the change:

See https://github.com/cryostatio/cryostat-web/pull/906#issuecomment-1472888342

## Screenshots

![Screenshot from 2023-03-22 21-38-37](https://user-images.githubusercontent.com/68053619/227076824-150e3fcc-ade8-4e3b-bcb9-9b9ebc447caf.png)



