### PR TITLE
fix(webpack): revert code splitting routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "cryostat-web",
-  "version": "0.0.1",
+  "version": "2.3.0",
   "description": "Web-Client for Cryostat",
-  "main": "server.js",
   "repository": "https://github.com/cryostatio/cryostat-web.git",
   "license": "UPL",
   "private": true,
@@ -44,7 +43,6 @@
     "@types/react-test-renderer": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.53.0",
     "@typescript-eslint/parser": "^5.53.0",
-    "@vue/preload-webpack-plugin": "^2.0.0",
     "css-loader": "^6.7.3",
     "css-minimizer-webpack-plugin": "^4.2.2",
     "dotenv-webpack": "^8.0.1",

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -510,11 +510,6 @@ input[type=number].datetime-picker__number-input {
   width: 2em;
 }
 
-/* TODO: Remove when css orders are fixed */
-.pf-c-skip-to-content {
-  position: absolute !important;
-}
-
 .add-credential-modal {
   width: 80% !important;
   height: 80%;

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -36,32 +36,31 @@
  * SOFTWARE.
  */
 
-import React, { lazy, Suspense } from 'react';
+import * as React from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
-import { LoadingView } from './LoadingView/LoadingView';
+import About from './About/About';
+import Archives from './Archives/Archives';
+import CreateRecording from './CreateRecording/CreateRecording';
+import Dashboard from './Dashboard/Dashboard';
+import DashboardSolo from './Dashboard/DashboardSolo';
+import Events from './Events/Events';
+import Login from './Login/Login';
+import NotFound from './NotFound/NotFound';
+import QuickStarts from './QuickStarts/QuickStarts';
+import Recordings from './Recordings/Recordings';
+import CreateRule from './Rules/CreateRule';
+import Rules from './Rules/Rules';
+import SecurityPanel from './SecurityPanel/SecurityPanel';
+import Settings from './Settings/Settings';
 import { SessionState } from './Shared/Services/Login.service';
 import { ServiceContext } from './Shared/Services/Services';
 import { FeatureLevel } from './Shared/Services/Settings.service';
+import CreateTarget from './Topology/Actions/CreateTarget';
+import Topology from './Topology/Topology';
 import { useDocumentTitle } from './utils/useDocumentTitle';
 import { useSubscriptions } from './utils/useSubscriptions';
 import { accessibleRouteChangeHandler } from './utils/utils';
-const About = lazy(() => import('@app/About/About'));
-const Archives = lazy(() => import('@app/Archives/Archives'));
-const CreateRecording = lazy(() => import('@app/CreateRecording/CreateRecording'));
-const Dashboard = lazy(() => import('@app/Dashboard/Dashboard'));
-const DashboardSolo = lazy(() => import('./Dashboard/DashboardSolo'));
-const Events = lazy(() => import('@app/Events/Events'));
-const Login = lazy(() => import('@app/Login/Login'));
-const NotFound = lazy(() => import('@app/NotFound/NotFound'));
-const Recordings = lazy(() => import('@app/Recordings/Recordings'));
-const CreateRule = lazy(() => import('@app/Rules/CreateRule'));
-const QuickStarts = lazy(() => import('@app/QuickStarts/QuickStarts'));
-const Rules = lazy(() => import('@app/Rules/Rules'));
-const Settings = lazy(() => import('@app/Settings/Settings'));
-const SecurityPanel = lazy(() => import('@app/SecurityPanel/SecurityPanel'));
-const Topology = lazy(() => import('@app/Topology/Topology'));
-const CreateTarget = lazy(() => import('@app/Topology/Actions/CreateTarget'));
 
 let routeFocusTimer: number;
 const OVERVIEW = 'Overview';
@@ -282,24 +281,22 @@ const AppRoutes: React.FunctionComponent<AppRoutesProps> = (_) => {
 
   return (
     <LastLocationProvider>
-      <Suspense fallback={<LoadingView />}>
-        <Switch>
-          {flatten(routes)
-            .filter((r) => (loggedIn ? r.component !== Login : r.anonymous))
-            .filter((r) => r.featureLevel === undefined || r.featureLevel >= activeLevel)
-            .map(({ path, exact, component, title, isAsync }, idx) => (
-              <RouteWithTitleUpdates
-                path={path}
-                exact={exact}
-                component={component}
-                key={idx}
-                title={title}
-                isAsync={isAsync}
-              />
-            ))}
-          <PageNotFound title="404 Page Not Found" />
-        </Switch>
-      </Suspense>
+      <Switch>
+        {flatten(routes)
+          .filter((r) => (loggedIn ? r.component !== Login : r.anonymous))
+          .filter((r) => r.featureLevel === undefined || r.featureLevel >= activeLevel)
+          .map(({ path, exact, component, title, isAsync }, idx) => (
+            <RouteWithTitleUpdates
+              path={path}
+              exact={exact}
+              component={component}
+              key={idx}
+              title={title}
+              isAsync={isAsync}
+            />
+          ))}
+        <PageNotFound title="404 Page Not Found" />
+      </Switch>
     </LastLocationProvider>
   );
 };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
-const PreloadWebpackPlugin = require('@vue/preload-webpack-plugin');
 
 const BG_IMAGES_DIRNAME = 'bgimages';
 const ASSET_PATH = process.env.ASSET_PATH || '/';
@@ -16,12 +15,6 @@ module.exports = (env) => {
       new HtmlWebpackPlugin({
         template: path.resolve(__dirname, 'src', 'index.html'),
         favicon: './src/app/assets/favicon.ico',
-      }),
-      new PreloadWebpackPlugin({
-        rel: 'prefetch',
-        include: [/\.js$/], // lazy-load chunks to prefetch
-        // exlude initial chunk, npm chunks
-        fileBlacklist: [/^(app|npm)(\.[\w-]+)+\.bundle\.js$/]
       })
     ],
     // https://medium.com/hackernoon/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758

--- a/yarn.lock
+++ b/yarn.lock
@@ -2374,16 +2374,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/preload-webpack-plugin@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@vue/preload-webpack-plugin@npm:2.0.0"
-  peerDependencies:
-    html-webpack-plugin: ^5.0.0 || ^4.5.1
-    webpack: ^5.20.0 || ^4.1.0
-  checksum: 8c8247c2a7dafa14c66adb92e14d44305970cb8642392b5f5b174282c1a5f146d85457575af02e86787aa58d9eee5ee3994aac6b275b9539f7310d3763c262fe
-  languageName: node
-  linkType: hard
-
 "@webassemblyjs/ast@npm:1.11.1":
   version: 1.11.1
   resolution: "@webassemblyjs/ast@npm:1.11.1"
@@ -3941,7 +3931,6 @@ __metadata:
     "@types/react-test-renderer": ^18.0.0
     "@typescript-eslint/eslint-plugin": ^5.53.0
     "@typescript-eslint/parser": ^5.53.0
-    "@vue/preload-webpack-plugin": ^2.0.0
     css-loader: ^6.7.3
     css-minimizer-webpack-plugin: ^4.2.2
     dayjs: ^1.11.7


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #863 

## Description of the change:

Revert any route code-splitting. This way all modules are combined into a single chunks and css order is correct.

## Motivation for the change:

Code-splitting causes css splitting also causes incorrect css order.

## Others

```
$ ls -lst dist/
total 24888
  ... Some other npm chunks
4364 -rw-r--r--. 1 thvo thvo 4464935 Mar 28 16:31 app.42655dbd468f507b.bundle.js # Single main chunk here
  16 -rw-r--r--. 1 thvo thvo   15294 Mar 28 16:31 app.ca8cbbf143633cc9.bundle.css # Single main css chunk here
7044 -rw-r--r--. 1 thvo thvo 7212327 Mar 28 16:31 npm.patternfly.b80ecc5a3ab05a91.bundle.js
   4 -rw-r--r--. 1 thvo thvo    1994 Mar 28 16:31 runtime.1faec187d6b6f3ff.bundle.js
  12 -rw-r--r--. 1 thvo thvo    8800 Mar 28 16:31 index.html # No prefetch
  48 -rw-r--r--. 1 thvo thvo   46149 Feb 27 16:04 npm.delaunator.c3fe326120717ae0.bundle.js
  20 -rw-r--r--. 1 thvo thvo   17379 Feb 27 16:04 npm.delaunay-find.38efd7a4daa9cf41.bundle.js
 168 -rw-r--r--. 1 thvo thvo  169462 Feb 27 16:04 npm.dompurify.9c9d18bb7cd01f80.bundle.js
  ... Some other npm chunks
  16 -rw-r--r--. 1 thvo thvo   15406 Feb  7 17:15 favicon.ico
   0 drwxr-xr-x. 1 thvo thvo     340 Feb  7 17:15 images
   0 drwxr-xr-x. 1 thvo thvo    3298 Feb  7 17:15 fonts
```