### PR TITLE
fix(topology): mini quicksearch should check active feature level

### DIFF
--- a/src/app/Topology/Actions/QuickSearchPanel.tsx
+++ b/src/app/Topology/Actions/QuickSearchPanel.tsx
@@ -157,30 +157,31 @@ export const QuickSearchPanel: React.FC<QuickSearchPanelProps> = ({ ...props }) 
     [setSearchText]
   );
 
-  const filteredItems = React.useMemo(() => {
-    if (searchText === '') {
-      return quickSearches;
+  const filteredQuicksearches = React.useMemo(() => {
+    let items = quickSearches.filter((qs) => activeLevel <= qs.featureLevel);
+    if (searchText && searchText !== '') {
+      const regex = new RegExp(searchText, 'i');
+      items = items.filter(({ name, descriptionFull = '', descriptionShort = '', labels = [] }) => {
+        let matchResult = regex.test(name) || regex.test(descriptionFull) || regex.test(descriptionShort);
+
+        matchResult = matchResult || labels.reduce((acc, curr) => acc || regex.test(curr.content), false);
+
+        return matchResult;
+      });
     }
 
-    const regex = new RegExp(searchText, 'i');
-    return quickSearches.filter(({ name, descriptionFull = '', descriptionShort = '', labels = [] }) => {
-      let matchResult = regex.test(name) || regex.test(descriptionFull) || regex.test(descriptionShort);
-
-      matchResult = matchResult || labels.reduce((acc, curr) => acc || regex.test(curr.content), false);
-
-      return matchResult;
-    });
-  }, [searchText]);
+    return items;
+  }, [searchText, activeLevel]);
 
   const matchedItem = React.useMemo(() => {
-    return filteredItems.find((qs) => qs.id === activeTab);
-  }, [filteredItems, activeTab]);
+    return filteredQuicksearches.find((qs) => qs.id === activeTab);
+  }, [filteredQuicksearches, activeTab]);
 
   React.useEffect(() => {
-    if (!matchedItem && filteredItems.length) {
-      setActiveTab(filteredItems[0].id);
+    if (!matchedItem && filteredQuicksearches.length) {
+      setActiveTab(filteredQuicksearches[0].id);
     }
-  }, [filteredItems, matchedItem]);
+  }, [filteredQuicksearches, matchedItem]);
 
   return (
     <Stack hasGutter>
@@ -192,7 +193,7 @@ export const QuickSearchPanel: React.FC<QuickSearchPanelProps> = ({ ...props }) 
           onClear={() => handleSearch('')}
         />
       </StackItem>
-      {filteredItems.length ? (
+      {filteredQuicksearches.length ? (
         <StackItem>
           <Sidebar {...props} tabIndex={0} style={{ height: 'max-content' }} hasGutter>
             <SidebarPanel variant="sticky">
@@ -207,17 +208,15 @@ export const QuickSearchPanel: React.FC<QuickSearchPanelProps> = ({ ...props }) 
                 onSelect={handleTabChange}
                 role={'region'}
               >
-                {filteredItems
-                  .filter((qs) => activeLevel <= qs.featureLevel)
-                  .map((qs, index) => (
-                    <Tab
-                      className={css('topology__quicksearch__tab')}
-                      eventKey={qs.id}
-                      key={index}
-                      isDisabled={qs.disabled}
-                      title={<QuickSearchTabTitle item={qs} />}
-                    />
-                  ))}
+                {filteredQuicksearches.map((qs, index) => (
+                  <Tab
+                    className={css('topology__quicksearch__tab')}
+                    eventKey={qs.id}
+                    key={index}
+                    isDisabled={qs.disabled}
+                    title={<QuickSearchTabTitle item={qs} />}
+                  />
+                ))}
               </Tabs>
             </SidebarPanel>
             <SidebarContent>
@@ -292,7 +291,7 @@ export const QuickSearchContextMenu: React.FC<QuickSearchContextMenuProps> = ({ 
               isFocused
               ref={hoverRef}
               itemId={'Add to View'}
-              flyoutMenu={<QuickSearchFlyoutMenu quicksearches={quickSearches} isShow={hover} />}
+              flyoutMenu={<QuickSearchFlyoutMenu isShow={hover} />}
             >
               Add to View
             </MenuItem>
@@ -305,19 +304,24 @@ export const QuickSearchContextMenu: React.FC<QuickSearchContextMenuProps> = ({ 
 
 export interface QuickSearchFlyoutMenuProps {
   isShow?: boolean;
-  quicksearches: QuickSearchItem[];
 }
 
-export const QuickSearchFlyoutMenu: React.FC<QuickSearchFlyoutMenuProps> = ({ isShow, quicksearches, ...props }) => {
+export const QuickSearchFlyoutMenu: React.FC<QuickSearchFlyoutMenuProps> = ({ isShow, ...props }) => {
   const history = useHistory();
   const services = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const addSubscription = useSubscriptions();
+  const activeLevel = useFeatureLevel();
 
   const [hover, hoverRef] = useHover(0, 0);
 
+  const filteredQuicksearches = React.useMemo(
+    () => quickSearches.filter((qs) => activeLevel <= qs.featureLevel),
+    [activeLevel]
+  );
+
   const items = React.useMemo(() => {
-    return quicksearches.map(({ id, icon, name, createAction = () => undefined }) => (
+    return filteredQuicksearches.map(({ id, icon, name, createAction = () => undefined }) => (
       <MenuItem
         key={id}
         itemId={id}
@@ -331,7 +335,7 @@ export const QuickSearchFlyoutMenu: React.FC<QuickSearchFlyoutMenuProps> = ({ is
         {name}
       </MenuItem>
     ));
-  }, [quicksearches, history, services, notifications, addSubscription]);
+  }, [filteredQuicksearches, history, services, notifications, addSubscription]);
 
   return isShow || hover ? (
     <Menu

--- a/src/app/Topology/Actions/QuickSearchPanel.tsx
+++ b/src/app/Topology/Actions/QuickSearchPanel.tsx
@@ -80,11 +80,10 @@ export const QuickSearchTabContent: React.FC<{ item?: QuickSearchItem }> = ({ it
   const history = useHistory();
   const services = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
-  const addSubscription = useSubscriptions();
 
   const handleActionClick = React.useCallback(() => {
-    item?.createAction && item.createAction({ history, services, notifications }, addSubscription);
-  }, [item, history, services, notifications, addSubscription]);
+    item?.createAction && item.createAction({ history, services, notifications });
+  }, [item, history, services, notifications]);
 
   return item ? (
     <Stack {...props} hasGutter>
@@ -310,7 +309,6 @@ export const QuickSearchFlyoutMenu: React.FC<QuickSearchFlyoutMenuProps> = ({ is
   const history = useHistory();
   const services = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
-  const addSubscription = useSubscriptions();
   const activeLevel = useFeatureLevel();
 
   const [hover, hoverRef] = useHover(0, 0);
@@ -330,12 +328,12 @@ export const QuickSearchFlyoutMenu: React.FC<QuickSearchFlyoutMenuProps> = ({ is
             <Bullseye>{icon}</Bullseye>
           </div>
         }
-        onClick={() => createAction({ history, services, notifications }, addSubscription)}
+        onClick={() => createAction({ history, services, notifications })}
       >
         {name}
       </MenuItem>
     ));
-  }, [filteredQuicksearches, history, services, notifications, addSubscription]);
+  }, [filteredQuicksearches, history, services, notifications]);
 
   return isShow || hover ? (
     <Menu

--- a/src/app/Topology/Actions/utils.ts
+++ b/src/app/Topology/Actions/utils.ts
@@ -63,5 +63,5 @@ export interface QuickSearchItem {
   featureLevel: FeatureLevel;
   disabled?: boolean;
   actionText?: React.ReactNode;
-  createAction?: (utils: ActionUtils, track: (sub: Subscription) => void) => void;
+  createAction?: (utils: ActionUtils) => void;
 }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #891 

## Description of the change:

Mini quick search (opened by right click on topology view) needs to check for active feature level.

## Motivation for the change:

Right now, it does not check so all quick searches are allowed.

## Screenshots

Considering BETA level, the dev sample is DEVELOPMENT level.

### Before

![Screenshot from 2023-03-30 03-14-36](https://user-images.githubusercontent.com/68053619/228758530-690e82dc-0644-44c3-8e0c-c08ad37c5041.png)

### After

![Screenshot from 2023-03-30 03-14-56](https://user-images.githubusercontent.com/68053619/228758545-9f3896d3-ed8c-4a38-ad92-d601bb17aee6.png)
