### PR TITLE
feat(router): routable views

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -42,7 +42,7 @@ import { useJoyride } from '@app/Joyride/JoyrideProvider';
 import { NotificationCenter } from '@app/Notifications/NotificationCenter';
 import { Notification, NotificationsContext } from '@app/Notifications/Notifications';
 import { IAppRoute, navGroups, routes } from '@app/routes';
-import { selectTab, ThemeSetting } from '@app/Settings/SettingsUtils';
+import { selectTab, SettingTab, tabAsParam, ThemeSetting } from '@app/Settings/SettingsUtils';
 import { DynamicFeatureFlag, FeatureFlag } from '@app/Shared/FeatureFlag/FeatureFlag';
 import { SessionState } from '@app/Shared/Services/Login.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
@@ -301,9 +301,10 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
 
   const handleLanguagePref = React.useCallback(() => {
     if (routerHistory.location.pathname === '/settings') {
-      selectTab('SETTINGS.CATEGORIES.GENERAL');
+      selectTab(SettingTab.GENERAL);
     } else {
-      routerHistory.push('/settings', { preSelectedTab: 'SETTINGS.CATEGORIES.GENERAL' });
+      const query = new URLSearchParams({ tab: tabAsParam(SettingTab.GENERAL) });
+      routerHistory.push(`/settings?${query}`);
     }
   }, [routerHistory]);
 

--- a/src/app/Archives/Archives.tsx
+++ b/src/app/Archives/Archives.tsx
@@ -76,7 +76,7 @@ export const Archives: React.FC<ArchivesProps> = ({ ...props }) => {
   const addSubscription = useSubscriptions();
 
   const activeTab = React.useMemo(() => {
-    return getActiveTab(search, Object.values(ArchiveTab), ArchiveTab.ALL_TARGETS);
+    return getActiveTab(search, 'tab', Object.values(ArchiveTab), ArchiveTab.ALL_TARGETS);
   }, [search]);
 
   const [archiveEnabled, setArchiveEnabled] = React.useState(false);
@@ -86,8 +86,9 @@ export const Archives: React.FC<ArchivesProps> = ({ ...props }) => {
   }, [context.api, addSubscription, setArchiveEnabled]);
 
   const onTabSelect = React.useCallback(
-    (_: React.MouseEvent, key: string | number) => switchTab(history, pathname, `${key}`),
-    [history, pathname]
+    (_: React.MouseEvent, key: string | number) =>
+      switchTab(history, pathname, search, { tabKey: 'tab', tabValue: `${key}` }),
+    [history, pathname, search]
   );
 
   const uploadTargetAsObs = React.useMemo(() => of(uploadAsTarget), []);
@@ -113,7 +114,7 @@ export const Archives: React.FC<ArchivesProps> = ({ ...props }) => {
         </Title>
       </EmptyState>
     );
-  }, [archiveEnabled, activeTab, uploadTargetAsObs]);
+  }, [archiveEnabled, activeTab, uploadTargetAsObs, onTabSelect]);
 
   return (
     <BreadcrumbPage {...props} pageTitle="Archives">

--- a/src/app/Archives/Archives.tsx
+++ b/src/app/Archives/Archives.tsx
@@ -41,11 +41,11 @@ import { UPLOADS_SUBDIRECTORY } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { Target } from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { getActiveTab, switchTab } from '@app/utils/utils';
 import { Card, CardBody, EmptyState, EmptyStateIcon, Tab, Tabs, TabTitleText, Title } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { StaticContext } from 'react-router';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import { of } from 'rxjs';
 import { AllArchivedRecordingsTable } from './AllArchivedRecordingsTable';
 import { AllTargetsArchivedRecordingsTable } from './AllTargetsArchivedRecordingsTable';
@@ -61,37 +61,47 @@ export const uploadAsTarget: Target = {
   alias: '',
 };
 
-export type SupportedTab = 'all-archives' | 'all-targets' | 'uploads';
-
-export interface ArchivesProps {
-  tab?: SupportedTab;
+enum ArchiveTab {
+  ALL_ARCHIVES = 'all-archives',
+  ALL_TARGETS = 'all-targets',
+  UPLOADS = 'uploads',
 }
 
-export const Archives: React.FC<RouteComponentProps<Record<string, never>, StaticContext, ArchivesProps>> = ({
-  location,
-  ..._props
-}) => {
+export interface ArchivesProps {}
+
+export const Archives: React.FC<ArchivesProps> = ({ ...props }) => {
+  const { search, pathname } = useLocation();
+  const history = useHistory();
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
-  const [activeTab, setActiveTab] = React.useState(location?.state?.tab || 'all-archives');
+
+  const activeTab = React.useMemo(() => {
+    return getActiveTab(search, Object.values(ArchiveTab), ArchiveTab.ALL_TARGETS);
+  }, [search]);
+
   const [archiveEnabled, setArchiveEnabled] = React.useState(false);
 
   React.useEffect(() => {
     addSubscription(context.api.isArchiveEnabled().subscribe(setArchiveEnabled));
   }, [context.api, addSubscription, setArchiveEnabled]);
 
+  const onTabSelect = React.useCallback(
+    (_: React.MouseEvent, key: string | number) => switchTab(history, pathname, `${key}`),
+    [history, pathname]
+  );
+
   const uploadTargetAsObs = React.useMemo(() => of(uploadAsTarget), []);
 
   const cardBody = React.useMemo(() => {
     return archiveEnabled ? (
-      <Tabs id="archives" activeKey={activeTab} onSelect={(evt, key) => setActiveTab(`${key}` as SupportedTab)}>
-        <Tab id="all-targets" eventKey={'all-archives'} title={<TabTitleText>All Targets</TabTitleText>}>
+      <Tabs id="archives" activeKey={activeTab} onSelect={onTabSelect} unmountOnExit>
+        <Tab id="all-targets" eventKey={ArchiveTab.ALL_TARGETS} title={<TabTitleText>All Targets</TabTitleText>}>
           <AllTargetsArchivedRecordingsTable />
         </Tab>
-        <Tab id="all-archives" eventKey={'all-targets'} title={<TabTitleText>All Archives</TabTitleText>}>
+        <Tab id="all-archives" eventKey={ArchiveTab.ALL_ARCHIVES} title={<TabTitleText>All Archives</TabTitleText>}>
           <AllArchivedRecordingsTable />
         </Tab>
-        <Tab id="uploads" eventKey={'uploads'} title={<TabTitleText>Uploads</TabTitleText>}>
+        <Tab id="uploads" eventKey={ArchiveTab.UPLOADS} title={<TabTitleText>Uploads</TabTitleText>}>
           <ArchivedRecordingsTable target={uploadTargetAsObs} isUploadsTable={true} isNestedTable={false} />
         </Tab>
       </Tabs>
@@ -106,7 +116,7 @@ export const Archives: React.FC<RouteComponentProps<Record<string, never>, Stati
   }, [archiveEnabled, activeTab, uploadTargetAsObs]);
 
   return (
-    <BreadcrumbPage pageTitle="Archives">
+    <BreadcrumbPage {...props} pageTitle="Archives">
       <Card>
         <CardBody>{cardBody}</CardBody>
       </Card>
@@ -114,4 +124,4 @@ export const Archives: React.FC<RouteComponentProps<Record<string, never>, Stati
   );
 };
 
-export default withRouter(Archives);
+export default Archives;

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -59,7 +59,7 @@ export const Recordings: React.FC<RecordingsProps> = ({ ...props }) => {
   const addSubscription = useSubscriptions();
 
   const activeTab = React.useMemo(() => {
-    return getActiveTab(search, Object.values(RecordingTab), RecordingTab.ACTIVE_RECORDING);
+    return getActiveTab(search, 'tab', Object.values(RecordingTab), RecordingTab.ACTIVE_RECORDING);
   }, [search]);
 
   const [archiveEnabled, setArchiveEnabled] = React.useState(false);
@@ -69,8 +69,9 @@ export const Recordings: React.FC<RecordingsProps> = ({ ...props }) => {
   }, [context.api, addSubscription, setArchiveEnabled]);
 
   const onTabSelect = React.useCallback(
-    (_: React.MouseEvent, key: string | number) => switchTab(history, pathname, `${key}`),
-    [history, pathname]
+    (_: React.MouseEvent, key: string | number) =>
+      switchTab(history, pathname, search, { tabKey: 'tab', tabValue: `${key}` }),
+    [history, pathname, search]
   );
 
   const targetAsObs = React.useMemo(() => context.target.target(), [context.target]);

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -38,35 +38,41 @@
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { switchTab } from '@app/utils/utils';
 import { Card, CardBody, CardTitle, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import * as React from 'react';
-import { StaticContext } from 'react-router';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router';
 import { ActiveRecordingsTable } from './ActiveRecordingsTable';
 import { ArchivedRecordingsTable } from './ArchivedRecordingsTable';
 
-export type SupportedTab = 'active' | 'archived';
-
-export interface RecordingsProps {
-  tab?: SupportedTab;
+enum RecordingTab {
+  ACTIVE_RECORDING = 'active-recording',
+  ARCHIVED_RECORDING = 'archived-recording',
 }
 
-export const Recordings: React.FC<RouteComponentProps<Record<string, never>, StaticContext, RecordingsProps>> = ({
-  location,
-  ..._props
-}) => {
+export interface RecordingsProps {}
+
+export const Recordings: React.FC<RecordingsProps> = ({ ...props }) => {
+  const { search, pathname } = useLocation();
+  const history = useHistory();
   const context = React.useContext(ServiceContext);
-  const [activeTab, setActiveTab] = React.useState(location?.state?.tab || 'active');
-  const [archiveEnabled, setArchiveEnabled] = React.useState(false);
   const addSubscription = useSubscriptions();
+
+  const activeTab = React.useMemo(() => {
+    const queries = new URLSearchParams(search);
+    const tab = queries.get('tab');
+    return tab && Object.values(RecordingTab).includes(tab as RecordingTab) ? tab : RecordingTab.ACTIVE_RECORDING;
+  }, [search]);
+
+  const [archiveEnabled, setArchiveEnabled] = React.useState(false);
 
   React.useEffect(() => {
     addSubscription(context.api.isArchiveEnabled().subscribe(setArchiveEnabled));
   }, [context.api, addSubscription, setArchiveEnabled]);
 
   const onTabSelect = React.useCallback(
-    (_, key: string | number) => setActiveTab(`${key}` as SupportedTab),
-    [setActiveTab]
+    (_: React.MouseEvent, key: string | number) => switchTab(history, pathname, `${key}`),
+    [history, pathname]
   );
 
   const targetAsObs = React.useMemo(() => context.target.target(), [context.target]);
@@ -76,15 +82,15 @@ export const Recordings: React.FC<RouteComponentProps<Record<string, never>, Sta
       <Tabs id="recordings" activeKey={activeTab} onSelect={onTabSelect} unmountOnExit>
         <Tab
           id="active-recordings"
-          eventKey={'active'}
+          eventKey={RecordingTab.ACTIVE_RECORDING}
           title={<TabTitleText>Active Recordings</TabTitleText>}
-          data-quickstart-id="active-recordings-tab"
+          data-quickstart-id="active-recordings-tab"       
         >
           <ActiveRecordingsTable archiveEnabled={true} />
         </Tab>
         <Tab
           id="archived-recordings"
-          eventKey={'archived'}
+          eventKey={RecordingTab.ARCHIVED_RECORDING}
           title={<TabTitleText>Archived Recordings</TabTitleText>}
           data-quickstart-id="archived-recordings-tab"
         >
@@ -100,7 +106,7 @@ export const Recordings: React.FC<RouteComponentProps<Record<string, never>, Sta
   }, [archiveEnabled, activeTab, onTabSelect, targetAsObs]);
 
   return (
-    <TargetView pageTitle="Recordings">
+    <TargetView {...props} pageTitle="Recordings">
       <Card>
         <CardBody>{cardBody}</CardBody>
       </Card>
@@ -108,4 +114,4 @@ export const Recordings: React.FC<RouteComponentProps<Record<string, never>, Sta
   );
 };
 
-export default withRouter(Recordings);
+export default Recordings;

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -38,7 +38,7 @@
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { switchTab } from '@app/utils/utils';
+import { getActiveTab, switchTab } from '@app/utils/utils';
 import { Card, CardBody, CardTitle, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import * as React from 'react';
 import { useHistory, useLocation } from 'react-router';
@@ -59,9 +59,7 @@ export const Recordings: React.FC<RecordingsProps> = ({ ...props }) => {
   const addSubscription = useSubscriptions();
 
   const activeTab = React.useMemo(() => {
-    const queries = new URLSearchParams(search);
-    const tab = queries.get('tab');
-    return tab && Object.values(RecordingTab).includes(tab as RecordingTab) ? tab : RecordingTab.ACTIVE_RECORDING;
+    return getActiveTab(search, Object.values(RecordingTab), RecordingTab.ACTIVE_RECORDING);
   }, [search]);
 
   const [archiveEnabled, setArchiveEnabled] = React.useState(false);

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -83,7 +83,7 @@ export const Recordings: React.FC<RecordingsProps> = ({ ...props }) => {
           id="active-recordings"
           eventKey={RecordingTab.ACTIVE_RECORDING}
           title={<TabTitleText>Active Recordings</TabTitleText>}
-          data-quickstart-id="active-recordings-tab"       
+          data-quickstart-id="active-recordings-tab"
         >
           <ActiveRecordingsTable archiveEnabled={true} />
         </Tab>

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -45,6 +45,7 @@ import {
   EmptyStateBody,
   Button,
   EmptyStateSecondaryActions,
+  Bullseye,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import {
@@ -121,18 +122,18 @@ export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = ({
     view = <LoadingView />;
   } else if (isEmpty) {
     view = (
-      <>
+      <Bullseye>
         <EmptyState>
           <EmptyStateIcon icon={SearchIcon} />
           <Title headingLevel="h4" size="lg">
             No {tableTitle}
           </Title>
         </EmptyState>
-      </>
+      </Bullseye>
     );
   } else if (isEmptyFilterResult) {
     view = (
-      <>
+      <Bullseye>
         <EmptyState>
           <EmptyStateIcon icon={SearchIcon} />
           <Title headingLevel="h4" size="lg">
@@ -147,7 +148,7 @@ export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = ({
             </Button>
           </EmptyStateSecondaryActions>
         </EmptyState>
-      </>
+      </Bullseye>
     );
   } else {
     view = (
@@ -185,9 +186,9 @@ export const RecordingsTable: React.FunctionComponent<RecordingsTableProps> = ({
 
   return (
     <>
-      <OuterScrollContainer className="recording-table-container">
+      <OuterScrollContainer className="recording-table-outer-container">
         {isError ? null : toolbar}
-        <InnerScrollContainer>{view}</InnerScrollContainer>
+        <InnerScrollContainer className="recording-table--inner-container">{view}</InnerScrollContainer>
         {tableFooter}
       </OuterScrollContainer>
     </>

--- a/src/app/Settings/AutoRefresh.tsx
+++ b/src/app/Settings/AutoRefresh.tsx
@@ -41,7 +41,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { Checkbox } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { UserSetting } from './SettingsUtils';
+import { SettingTab, UserSetting } from './SettingsUtils';
 
 const defaultPreferences = {
   autoRefreshEnabled: true,
@@ -109,5 +109,5 @@ export const AutoRefresh: UserSetting = {
   titleKey: 'SETTINGS.AUTO_REFRESH.TITLE',
   descConstruct: 'SETTINGS.AUTO_REFRESH.DESCRIPTION',
   content: Component,
-  category: 'SETTINGS.CATEGORIES.CONNECTIVITY',
+  category: SettingTab.CONNECTIVITY,
 };

--- a/src/app/Settings/AutomatedAnalysisConfig.tsx
+++ b/src/app/Settings/AutomatedAnalysisConfig.tsx
@@ -42,7 +42,7 @@ import { TargetSelect } from '@app/TargetSelect/TargetSelect';
 import { Stack, StackItem } from '@patternfly/react-core';
 import * as React from 'react';
 import { of } from 'rxjs';
-import { UserSetting } from './SettingsUtils';
+import { SettingTab, UserSetting } from './SettingsUtils';
 
 const Component = () => {
   const [target, setTarget] = React.useState(NO_TARGET);
@@ -62,5 +62,5 @@ export const AutomatedAnalysisConfig: UserSetting = {
   titleKey: 'SETTINGS.AUTOMATED_ANALYSIS_CONFIG.TITLE',
   descConstruct: 'SETTINGS.AUTOMATED_ANALYSIS_CONFIG.DESCRIPTION',
   content: Component,
-  category: 'SETTINGS.CATEGORIES.DASHBOARD',
+  category: SettingTab.DASHBOARD,
 };

--- a/src/app/Settings/ChartCardsConfig.tsx
+++ b/src/app/Settings/ChartCardsConfig.tsx
@@ -40,7 +40,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { FormGroup, HelperText, HelperTextItem, NumberInput, Stack, StackItem } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { UserSetting } from './SettingsUtils';
+import { SettingTab, UserSetting } from './SettingsUtils';
 
 const min = 1;
 
@@ -99,5 +99,5 @@ export const ChartCardsConfig: UserSetting = {
   titleKey: 'SETTINGS.CHARTS_CONFIG.TITLE',
   descConstruct: 'SETTINGS.CHARTS_CONFIG.DESCRIPTION',
   content: Component,
-  category: 'SETTINGS.CATEGORIES.DASHBOARD',
+  category: SettingTab.DASHBOARD,
 };

--- a/src/app/Settings/CredentialsStorage.tsx
+++ b/src/app/Settings/CredentialsStorage.tsx
@@ -41,7 +41,7 @@ import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { UserSetting } from './SettingsUtils';
+import { SettingTab, UserSetting } from './SettingsUtils';
 
 export interface Location {
   key: string;
@@ -130,5 +130,5 @@ export const CredentialsStorage: UserSetting = {
     parts: [<Link key={0} to="/security" />],
   },
   content: Component,
-  category: 'SETTINGS.CATEGORIES.ADVANCED',
+  category: SettingTab.ADVANCED,
 };

--- a/src/app/Settings/DatetimeControl.tsx
+++ b/src/app/Settings/DatetimeControl.tsx
@@ -42,7 +42,7 @@ import { locales, Timezone } from '@i18n/datetime';
 import { FormGroup, HelperText, HelperTextItem, Select, SelectOption, Stack, StackItem } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { UserSetting } from './SettingsUtils';
+import { SettingTab, UserSetting } from './SettingsUtils';
 
 const Component = () => {
   const [t] = useTranslation();
@@ -156,5 +156,5 @@ export const DatetimeControl: UserSetting = {
   titleKey: 'SETTINGS.DATETIME_CONTROL.TITLE',
   descConstruct: 'SETTINGS.DATETIME_CONTROL.DESCRIPTION',
   content: Component,
-  category: 'SETTINGS.CATEGORIES.GENERAL',
+  category: SettingTab.GENERAL,
 };

--- a/src/app/Settings/DeletionDialogControl.tsx
+++ b/src/app/Settings/DeletionDialogControl.tsx
@@ -49,7 +49,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { UserSetting } from './SettingsUtils';
+import { SettingTab, UserSetting } from './SettingsUtils';
 
 const Component = () => {
   const [t] = useTranslation();
@@ -129,5 +129,5 @@ export const DeletionDialogControl: UserSetting = {
   titleKey: 'SETTINGS.DELETION_DIALOG_CONTROL.TITLE',
   descConstruct: 'SETTINGS.DELETION_DIALOG_CONTROL.DESCRIPTION',
   content: Component,
-  category: 'SETTINGS.CATEGORIES.NOTIFICATION_MESSAGE',
+  category: SettingTab.NOTIFICATION_MESSAGE,
 };

--- a/src/app/Settings/FeatureLevels.tsx
+++ b/src/app/Settings/FeatureLevels.tsx
@@ -42,7 +42,7 @@ import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Select, SelectOption } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { UserSetting } from './SettingsUtils';
+import { SettingTab, UserSetting } from './SettingsUtils';
 
 const Component = () => {
   const [t] = useTranslation();
@@ -112,5 +112,5 @@ export const FeatureLevels: UserSetting = {
   titleKey: 'SETTINGS.FEATURE_LEVEL.TITLE',
   descConstruct: 'SETTINGS.FEATURE_LEVEL.DESCRIPTION',
   content: Component,
-  category: 'SETTINGS.CATEGORIES.ADVANCED',
+  category: SettingTab.ADVANCED,
 };

--- a/src/app/Settings/Language.tsx
+++ b/src/app/Settings/Language.tsx
@@ -41,7 +41,7 @@ import { localeReadable } from '@i18n/i18nextUtil';
 import { Select, SelectOption } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { UserSetting } from './SettingsUtils';
+import { SettingTab, UserSetting } from './SettingsUtils';
 
 const Component = () => {
   const [t, i18n] = useTranslation();
@@ -86,7 +86,7 @@ export const Language: UserSetting = {
   titleKey: 'SETTINGS.LANGUAGE.TITLE',
   descConstruct: 'SETTINGS.LANGUAGE.DESCRIPTION',
   content: Component,
-  category: 'SETTINGS.CATEGORIES.GENERAL',
+  category: SettingTab.GENERAL,
   orderInGroup: 1,
   featureLevel: FeatureLevel.BETA,
 };

--- a/src/app/Settings/NotificationControl.tsx
+++ b/src/app/Settings/NotificationControl.tsx
@@ -50,7 +50,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { UserSetting } from './SettingsUtils';
+import { SettingTab, UserSetting } from './SettingsUtils';
 
 const min = 0;
 const max = 10;
@@ -179,6 +179,6 @@ export const NotificationControl: UserSetting = {
   titleKey: 'SETTINGS.NOTIFICATION_CONTROL.TITLE',
   descConstruct: 'SETTINGS.NOTIFICATION_CONTROL.DESCRIPTION',
   content: Component,
-  category: 'SETTINGS.CATEGORIES.NOTIFICATION_MESSAGE',
+  category: SettingTab.NOTIFICATION_MESSAGE,
   orderInGroup: 1,
 };

--- a/src/app/Settings/SettingsUtils.ts
+++ b/src/app/Settings/SettingsUtils.ts
@@ -46,16 +46,22 @@ export interface _TransformedUserSetting extends Omit<UserSetting, 'content'> {
   featureLevel: FeatureLevel;
 }
 
-export const _SettingCategoryKeys = [
-  'SETTINGS.CATEGORIES.GENERAL',
-  'SETTINGS.CATEGORIES.CONNECTIVITY',
-  'SETTINGS.CATEGORIES.NOTIFICATION_MESSAGE',
-  'SETTINGS.CATEGORIES.DASHBOARD',
-  'SETTINGS.CATEGORIES.ADVANCED',
-] as const;
+export enum SettingTab {
+  GENERAL = 'SETTINGS.CATEGORIES.GENERAL',
+  CONNECTIVITY = 'SETTINGS.CATEGORIES.CONNECTIVITY',
+  NOTIFICATION_MESSAGE = 'SETTINGS.CATEGORIES.NOTIFICATION_MESSAGE',
+  DASHBOARD = 'SETTINGS.CATEGORIES.DASHBOARD',
+  ADVANCED = 'SETTINGS.CATEGORIES.ADVANCED',
+}
 
-// Use translation keys for internal categorization
-export type SettingCategory = (typeof _SettingCategoryKeys)[number];
+export const tabAsParam = (key: SettingTab) => {
+  const parts = key.split('.');
+  return parts[parts.length - 1].toLowerCase().replace(/[_]/g, '-');
+};
+
+export const paramAsTab = (param: string) => {
+  return `SETTINGS.CATEGORIES.${param.toUpperCase().replace(/[-]/g, '_')}`;
+};
 
 export interface UserSetting {
   titleKey: string;
@@ -69,12 +75,12 @@ export interface UserSetting {
         parts: React.ReactNode[];
       };
   content: React.FunctionComponent;
-  category: SettingCategory;
+  category: SettingTab;
   orderInGroup?: number; // default -1
   featureLevel?: FeatureLevel; // default PRODUCTION
 }
 
-export const selectTab = (tabKey: SettingCategory) => {
+export const selectTab = (tabKey: SettingTab) => {
   const tab = document.getElementById(`pf-tab-${tabKey}-${hashCode(tabKey)}`);
   tab && tab.click();
 };

--- a/src/app/Settings/Theme.tsx
+++ b/src/app/Settings/Theme.tsx
@@ -40,7 +40,7 @@ import { useTheme } from '@app/utils/useTheme';
 import { Select, SelectOption } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { ThemeSetting, UserSetting } from './SettingsUtils';
+import { SettingTab, ThemeSetting, UserSetting } from './SettingsUtils';
 
 const Component = () => {
   const { t } = useTranslation();
@@ -85,6 +85,6 @@ export const Theme: UserSetting = {
   titleKey: 'SETTINGS.THEME.TITLE',
   descConstruct: 'SETTINGS.THEME.DESCRIPTION',
   content: Component,
-  category: 'SETTINGS.CATEGORIES.GENERAL',
+  category: SettingTab.GENERAL,
   orderInGroup: 2,
 };

--- a/src/app/Settings/WebSocketDebounce.tsx
+++ b/src/app/Settings/WebSocketDebounce.tsx
@@ -39,7 +39,7 @@
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { NumberInput } from '@patternfly/react-core';
 import * as React from 'react';
-import { UserSetting } from './SettingsUtils';
+import { SettingTab, UserSetting } from './SettingsUtils';
 
 const defaultPreferences = {
   webSocketDebounceMs: 100,
@@ -119,5 +119,5 @@ export const WebSocketDebounce: UserSetting = {
   titleKey: 'SETTINGS.WEBSOCKET_CONNECTION_DEBOUNCE.TITLE',
   descConstruct: 'SETTINGS.WEBSOCKET_CONNECTION_DEBOUNCE.DESCRIPTION',
   content: Component,
-  category: 'SETTINGS.CATEGORIES.CONNECTIVITY',
+  category: SettingTab.CONNECTIVITY,
 };

--- a/src/app/Topology/Shared/Entity/utils.tsx
+++ b/src/app/Topology/Shared/Entity/utils.tsx
@@ -366,17 +366,17 @@ export const getLinkPropsForTargetResource = (
 ): React.ComponentProps<Link> => {
   switch (resourceType) {
     case 'activeRecordings':
-      return { to: { pathname: '/recordings', state: { tab: 'active' } } };
+      return { to: { pathname: '/recordings', search: '?tab=active-recording' } };
     case 'archivedRecordings':
-      return { to: { pathname: '/recordings', state: { tab: 'archived' } } };
+      return { to: { pathname: '/recordings', search: '?tab=archived-recording' } };
     case 'archivedUploadRecordings':
-      return { to: { pathname: '/archives', state: { tab: 'uploads' } } };
+      return { to: { pathname: '/archives', search: '?tab=uploads' } };
     case 'eventTemplates':
-      return { to: { pathname: '/events', state: { eventTab: 'templates' } } };
+      return { to: { pathname: '/events', search: '?eventTab=event-template' } };
     case 'eventTypes':
-      return { to: { pathname: '/events', state: { eventTab: 'types' } } };
+      return { to: { pathname: '/events', search: '?eventTab=event-type' } };
     case 'agentProbes':
-      return { to: { pathname: '/events', state: { agentTab: 'probes' } } };
+      return { to: { pathname: '/events', search: '?agentTab=agent-probe' } };
     case 'automatedRules':
       return { to: { pathname: '/rules' } };
     case 'credentials':

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -98,8 +98,12 @@ html, body, #root {
   --pf-c-chip__text--MaxWidth: 100ch;
 }
 
-.recording-table-container {
-  height: 32rem;
+.recording-table-outer-container {
+  height: 67.3vh;
+}
+
+.recording-table--inner-container {
+  height: 100%;
 }
 
 #dashboard-layout-dropdown-toggle {

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -224,13 +224,24 @@ export const sortResources = <R>(
   return [...(direction === SortByDirection.asc ? sorted : sorted.reverse())];
 };
 
-export const switchTab = (history: ReturnType<typeof useHistory>, pathname: string, tab: string) => {
-  const query = new URLSearchParams({ tab: tab });
+export interface TabConfig {
+  tabKey: string;
+  tabValue: string;
+}
+
+export const switchTab = (
+  history: ReturnType<typeof useHistory>,
+  pathname: string,
+  search: string,
+  { tabKey, tabValue }: TabConfig
+) => {
+  const query = new URLSearchParams(search);
+  query.set(tabKey, tabValue);
   history.push(`${pathname}?${query.toString()}`);
 };
 
-export const getActiveTab = <T>(search: string, supportedTabs: T[], defaultTab: T) => {
+export const getActiveTab = <T>(search: string, key: string, supportedTabs: T[], defaultTab: T) => {
   const query = new URLSearchParams(search);
-  const tab = query.get('tab') || defaultTab;
+  const tab = query.get(key) || defaultTab;
   return supportedTabs.includes(tab as T) ? (tab as T) : defaultTab;
 };

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -229,3 +229,8 @@ export const switchTab = (history: ReturnType<typeof useHistory>, pathname: stri
   history.push(`${pathname}?${query.toString()}`);
 };
 
+export const getActiveTab = <T>(search: string, supportedTabs: T[], defaultTab: T) => {
+  const query = new URLSearchParams(search);
+  const tab = query.get('tab') || defaultTab;
+  return supportedTabs.includes(tab as T) ? (tab as T) : defaultTab;
+};

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -38,6 +38,7 @@
 
 import { ISortBy, SortByDirection } from '@patternfly/react-table';
 import _ from 'lodash';
+import { useHistory } from 'react-router-dom';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 const SECOND_MILLIS = 1000;
@@ -199,11 +200,12 @@ export const getValue = (object: any, keyPath: string[]) => {
   return keyPath.reduce((acc, key) => acc[key], object);
 };
 
+/* eslint-enable @typescript-eslint/no-explicit-any */
 export const sortResources = <R>(
   { index, direction }: ISortBy,
   resources: R[],
   mapper: (index?: number) => string[] | undefined,
-  getTransform: (index?: number) => ((value: any, resource: any) => any) | undefined
+  getTransform: (index?: number) => ((value: any, resource: R) => any) | undefined
 ): R[] => {
   const keyPaths = mapper(index);
   if (!keyPaths || !keyPaths.length) {
@@ -221,4 +223,9 @@ export const sortResources = <R>(
   });
   return [...(direction === SortByDirection.asc ? sorted : sorted.reverse())];
 };
-/* eslint-enable @typescript-eslint/no-explicit-any */
+
+export const switchTab = (history: ReturnType<typeof useHistory>, pathname: string, tab: string) => {
+  const query = new URLSearchParams({ tab: tab });
+  history.push(`${pathname}?${query.toString()}`);
+};
+

--- a/src/test/Archives/Archives.test.tsx
+++ b/src/test/Archives/Archives.test.tsx
@@ -40,12 +40,12 @@ import { NotificationsContext, NotificationsInstance } from '@app/Notifications/
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { cleanup, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
+import { Router } from 'react-router-dom';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';
 import { renderWithServiceContextAndRouter } from '../Common';
-import { Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
 
 jest.mock('@app/Recordings/ArchivedRecordingsTable', () => {
   return {

--- a/src/test/Archives/Archives.test.tsx
+++ b/src/test/Archives/Archives.test.tsx
@@ -43,7 +43,9 @@ import '@testing-library/jest-dom';
 import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';
-import { renderWithServiceContext } from '../Common';
+import { renderWithServiceContextAndRouter } from '../Common';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 jest.mock('@app/Recordings/ArchivedRecordingsTable', () => {
   return {
@@ -76,24 +78,26 @@ jest
   .mockReturnValueOnce(of(false)) // Test archives disabled case
   .mockReturnValue(of(true));
 
+const history = createMemoryHistory({ initialEntries: ['/archives'] });
+
 describe('<Archives />', () => {
   afterEach(cleanup);
 
   it('has the correct page title', async () => {
-    renderWithServiceContext(<Archives />);
+    renderWithServiceContextAndRouter(<Archives />, { history: history });
 
     expect(screen.getByText('Archives')).toBeInTheDocument();
   });
 
   it('handles the case where archiving is enabled', async () => {
-    renderWithServiceContext(<Archives />);
+    renderWithServiceContextAndRouter(<Archives />, { history: history });
 
     expect(screen.getByText('All Targets')).toBeInTheDocument();
     expect(screen.getByText('Uploads')).toBeInTheDocument();
   });
 
   it('handles the case where archiving is disabled', async () => {
-    renderWithServiceContext(<Archives />);
+    renderWithServiceContextAndRouter(<Archives />, { history: history });
 
     expect(screen.queryByText('All Targets')).not.toBeInTheDocument();
     expect(screen.queryByText('Uploads')).not.toBeInTheDocument();
@@ -101,7 +105,7 @@ describe('<Archives />', () => {
   });
 
   it('handles changing tabs', async () => {
-    const { user } = renderWithServiceContext(<Archives />);
+    const { user } = renderWithServiceContextAndRouter(<Archives />, { history: history });
 
     // Assert that the All Targets tab is currently selected (default behaviour)
     let tabsList = screen.getAllByRole('tab');
@@ -143,7 +147,9 @@ describe('<Archives />', () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
           <NotificationsContext.Provider value={NotificationsInstance}>
-            <Archives />
+            <Router history={history}>
+              <Archives />
+            </Router>
           </NotificationsContext.Provider>
         </ServiceContext.Provider>
       );

--- a/src/test/Archives/__snapshots__/Archives.test.tsx.snap
+++ b/src/test/Archives/__snapshots__/Archives.test.tsx.snap
@@ -58,16 +58,15 @@ exports[`<Archives /> renders correctly 1`] = `
                 role="tablist"
               >
                 <li
-                  className="pf-c-tabs__item pf-m-current"
+                  className="pf-c-tabs__item"
                   role="presentation"
                 >
                   <button
-                    aria-controls="pf-tab-section-all-archives-all-targets"
-                    aria-selected={true}
+                    aria-selected={false}
                     className="pf-c-tabs__link"
                     data-ouia-component-type="PF4/TabButton"
                     data-ouia-safe={true}
-                    id="pf-tab-all-archives-all-targets"
+                    id="pf-tab-all-targets-all-targets"
                     onClick={[Function]}
                     role="tab"
                     type="button"
@@ -84,12 +83,11 @@ exports[`<Archives /> renders correctly 1`] = `
                   role="presentation"
                 >
                   <button
-                    aria-controls="pf-tab-section-all-targets-all-archives"
                     aria-selected={false}
                     className="pf-c-tabs__link"
                     data-ouia-component-type="PF4/TabButton"
                     data-ouia-safe={true}
-                    id="pf-tab-all-targets-all-archives"
+                    id="pf-tab-all-archives-all-archives"
                     onClick={[Function]}
                     role="tab"
                     type="button"
@@ -102,12 +100,12 @@ exports[`<Archives /> renders correctly 1`] = `
                   </button>
                 </li>
                 <li
-                  className="pf-c-tabs__item"
+                  className="pf-c-tabs__item pf-m-current"
                   role="presentation"
                 >
                   <button
                     aria-controls="pf-tab-section-uploads-uploads"
-                    aria-selected={false}
+                    aria-selected={true}
                     className="pf-c-tabs__link"
                     data-ouia-component-type="PF4/TabButton"
                     data-ouia-safe={true}
@@ -126,39 +124,11 @@ exports[`<Archives /> renders correctly 1`] = `
               </ul>
             </div>
             <section
-              aria-labelledby="pf-tab-all-archives-all-targets"
-              className="pf-c-tab-content"
-              data-ouia-component-type="PF4/TabContent"
-              data-ouia-safe={true}
-              hidden={false}
-              id="pf-tab-section-all-archives-all-targets"
-              role="tabpanel"
-              tabIndex={0}
-            >
-              <div>
-                All Targets Table
-              </div>
-            </section>
-            <section
-              aria-labelledby="pf-tab-all-targets-all-archives"
-              className="pf-c-tab-content"
-              data-ouia-component-type="PF4/TabContent"
-              data-ouia-safe={true}
-              hidden={true}
-              id="pf-tab-section-all-targets-all-archives"
-              role="tabpanel"
-              tabIndex={0}
-            >
-              <div>
-                All Archives Table
-              </div>
-            </section>
-            <section
               aria-labelledby="pf-tab-uploads-uploads"
               className="pf-c-tab-content"
               data-ouia-component-type="PF4/TabContent"
               data-ouia-safe={true}
-              hidden={true}
+              hidden={false}
               id="pf-tab-section-uploads-uploads"
               role="tabpanel"
               tabIndex={0}

--- a/src/test/Recordings/Recordings.test.tsx
+++ b/src/test/Recordings/Recordings.test.tsx
@@ -44,7 +44,9 @@ import '@testing-library/jest-dom';
 import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';
-import { renderWithServiceContext } from '../Common';
+import { renderWithServiceContextAndRouter } from '../Common';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 jest.mock('@app/Recordings/ActiveRecordingsTable', () => {
   return {
@@ -93,31 +95,33 @@ jest
   .mockReturnValueOnce(of(false)) // handles the case where archiving is disabled
   .mockReturnValue(of(true)); // others
 
+const history = createMemoryHistory({ initialEntries: ['/recordings'] });
+
 describe('<Recordings />', () => {
   afterEach(cleanup);
 
   it('has the correct title in the TargetView', async () => {
-    renderWithServiceContext(<Recordings />);
+    renderWithServiceContextAndRouter(<Recordings />, { history });
 
     expect(screen.getByText('Recordings')).toBeInTheDocument();
   });
 
   it('handles the case where archiving is enabled', async () => {
-    renderWithServiceContext(<Recordings />);
+    renderWithServiceContextAndRouter(<Recordings />, { history });
 
     expect(screen.getByText('Active Recordings')).toBeInTheDocument();
     expect(screen.getByText('Archived Recordings')).toBeInTheDocument();
   });
 
   it('handles the case where archiving is disabled', async () => {
-    renderWithServiceContext(<Recordings />);
+    renderWithServiceContextAndRouter(<Recordings />, { history });
 
     expect(screen.getByText('Active Recordings')).toBeInTheDocument();
     expect(screen.queryByText('Archived Recordings')).not.toBeInTheDocument();
   });
 
   it('handles updating the activeTab state', async () => {
-    const { user } = renderWithServiceContext(<Recordings />);
+    const { user } = renderWithServiceContextAndRouter(<Recordings />, { history });
 
     // Assert that the active recordings tab is currently selected (default behaviour)
     let tabsList = screen.getAllByRole('tab');
@@ -150,9 +154,11 @@ describe('<Recordings />', () => {
     await act(async () => {
       tree = renderer.create(
         <ServiceContext.Provider value={defaultServices}>
-          <NotificationsContext.Provider value={NotificationsInstance}>
-            <Recordings />
-          </NotificationsContext.Provider>
+          <Router history={history}>
+            <NotificationsContext.Provider value={NotificationsInstance}>
+              <Recordings />
+            </NotificationsContext.Provider>
+          </Router>
         </ServiceContext.Provider>
       );
     });

--- a/src/test/Recordings/Recordings.test.tsx
+++ b/src/test/Recordings/Recordings.test.tsx
@@ -41,12 +41,12 @@ import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { Target } from '@app/Shared/Services/Target.service';
 import { cleanup, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { createMemoryHistory } from 'history';
 import * as React from 'react';
+import { Router } from 'react-router-dom';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';
 import { renderWithServiceContextAndRouter } from '../Common';
-import { Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
 
 jest.mock('@app/Recordings/ActiveRecordingsTable', () => {
   return {

--- a/src/test/Recordings/__snapshots__/Recordings.test.tsx.snap
+++ b/src/test/Recordings/__snapshots__/Recordings.test.tsx.snap
@@ -27,17 +27,16 @@ exports[`<Recordings /> renders correctly 1`] = `
           role="tablist"
         >
           <li
-            className="pf-c-tabs__item pf-m-current"
+            className="pf-c-tabs__item"
             role="presentation"
           >
             <button
-              aria-controls="pf-tab-section-active-active-recordings"
-              aria-selected={true}
+              aria-selected={false}
               className="pf-c-tabs__link"
               data-ouia-component-type="PF4/TabButton"
               data-ouia-safe={true}
               data-quickstart-id="active-recordings-tab"
-              id="pf-tab-active-active-recordings"
+              id="pf-tab-active-recording-active-recordings"
               onClick={[Function]}
               role="tab"
               type="button"
@@ -50,16 +49,17 @@ exports[`<Recordings /> renders correctly 1`] = `
             </button>
           </li>
           <li
-            className="pf-c-tabs__item"
+            className="pf-c-tabs__item pf-m-current"
             role="presentation"
           >
             <button
-              aria-selected={false}
+              aria-controls="pf-tab-section-archived-recording-archived-recordings"
+              aria-selected={true}
               className="pf-c-tabs__link"
               data-ouia-component-type="PF4/TabButton"
               data-ouia-safe={true}
               data-quickstart-id="archived-recordings-tab"
-              id="pf-tab-archived-archived-recordings"
+              id="pf-tab-archived-recording-archived-recordings"
               onClick={[Function]}
               role="tab"
               type="button"
@@ -74,17 +74,17 @@ exports[`<Recordings /> renders correctly 1`] = `
         </ul>
       </div>
       <section
-        aria-labelledby="pf-tab-active-active-recordings"
+        aria-labelledby="pf-tab-archived-recording-archived-recordings"
         className="pf-c-tab-content"
         data-ouia-component-type="PF4/TabContent"
         data-ouia-safe={true}
         hidden={false}
-        id="pf-tab-section-active-active-recordings"
+        id="pf-tab-section-archived-recording-archived-recordings"
         role="tabpanel"
         tabIndex={0}
       >
         <div>
-          Active Recordings Table
+          Archived Recordings Table
         </div>
       </section>
     </div>

--- a/src/test/Settings/Settings.test.tsx
+++ b/src/test/Settings/Settings.test.tsx
@@ -50,7 +50,7 @@ import { of } from 'rxjs';
 import { renderWithServiceContextAndRouter, testT } from '../Common';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
-import { ThemeSetting, UserSetting } from '@app/Settings/SettingsUtils';
+import { UserSetting } from '@app/Settings/SettingsUtils';
 
 jest.mock('@app/Settings/NotificationControl', () => ({
   NotificationControl: {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #78 
Depends on: #925 (This PR includes refactoring to Settings and tab renaming).

## Description of the change:

Tab-based views are now routable using query paramter:

- [x] Recordings
- [x] Archives
- [x] Events
- [x] Settings

Invalid tab query param will cause the view to fall back to the first tab. This way we don't have to handle error and show empty state and the user do not have to manually clean up url.

## Motivation for the change:

This allows users to bookmark urls for later without having to click on tabs. This would mean the user can use back-button to go back to previous (very nice UX if users have back-button on mouse).

## How to manually test:
1. `Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2. Go to any route with tab-based view (e.g. Recordings). Change tab and notice the query param changes.
3. Try bookmark/save the url with tab query param. Then visit it in another tab. Notice the correct tab is present.
