### PR TITLE
fix(topology): scrollable detail sidebar

### DIFF
--- a/src/app/Shared/MatchExpression/MatchExpressionVisualizer.tsx
+++ b/src/app/Shared/MatchExpression/MatchExpressionVisualizer.tsx
@@ -297,14 +297,14 @@ const GraphView: React.FC<{ alertOptions?: AlertOptions }> = ({ alertOptions, ..
   return (
     <TopologyView
       {...props}
-      id="topology__visualization-container"
+      id="match-expression__visualization-container"
       className={css('topology__main-container')}
       controlBar={<TopologyControlBar visualization={visualization} noCollapse />}
       sideBar={sidebar}
       sideBarOpen={selectedIds.length > 0}
       sideBarResizable={true}
       minSideBarSize={`200px`}
-      defaultSideBarSize={`400px`}
+      defaultSideBarSize={`425px`}
     >
       <VisualizationProvider controller={visualization}>
         <VisualizationSurface state={{ selectedIds }} />

--- a/src/app/Topology/Actions/WarningResolver.tsx
+++ b/src/app/Topology/Actions/WarningResolver.tsx
@@ -38,7 +38,6 @@
 import { NotificationsContext } from '@app/Notifications/Notifications';
 import { CreateCredentialModal } from '@app/SecurityPanel/Credentials/CreateCredentialModal';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { Button, ButtonProps } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link, useHistory } from 'react-router-dom';
@@ -57,7 +56,7 @@ export const WarningResolverAsLink: React.FC<WarningResolverAsLinkProps> = ({ to
 
 export interface WarningResolverAsActionButtonProps extends Omit<ButtonProps, 'onClick'> {
   targetNode: TargetNode;
-  onClick?: (targetNode: TargetNode, actionUtils: ActionUtils, track: ReturnType<typeof useSubscriptions>) => void;
+  onClick?: (targetNode: TargetNode, actionUtils: ActionUtils) => void;
 }
 
 export const WarningResolverAsActionButton: React.FC<WarningResolverAsActionButtonProps> = ({
@@ -69,11 +68,10 @@ export const WarningResolverAsActionButton: React.FC<WarningResolverAsActionButt
   const history = useHistory();
   const services = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
-  const addSubscription = useSubscriptions();
 
   const handleClick = React.useCallback(() => {
-    onClick && onClick(targetNode, { history, services, notifications }, addSubscription);
-  }, [onClick, targetNode, history, services, notifications, addSubscription]);
+    onClick && onClick(targetNode, { history, services, notifications });
+  }, [onClick, targetNode, history, services, notifications]);
 
   return (
     <Button {...props} onClick={handleClick}>
@@ -81,8 +79,6 @@ export const WarningResolverAsActionButton: React.FC<WarningResolverAsActionButt
     </Button>
   );
 };
-
-export type ModalComponent = typeof CreateCredentialModal;
 
 export interface WarningResolverAsCredModalProps {
   children?: React.ReactNode;

--- a/src/app/Topology/GraphView/TopologyGraphView.tsx
+++ b/src/app/Topology/GraphView/TopologyGraphView.tsx
@@ -38,6 +38,7 @@
 import { RootState } from '@app/Shared/Redux/ReduxStore';
 import { getFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
 import { Divider, Stack, StackItem } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
 import {
   BOTTOM_LAYER,
   DEFAULT_LAYER,
@@ -280,7 +281,7 @@ export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({ transformC
             <TopologyView
               {...props}
               id="topology__visualization-container"
-              className="topology__visualization-container"
+              className={css('topology__main-container')}
               controlBar={<TopologyControlBar visualization={visualization} />}
               sideBar={sidebar}
               sideBarOpen={selectedIds.length > 0}

--- a/src/app/Topology/Shared/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Shared/Entity/EntityDetails.tsx
@@ -104,7 +104,10 @@ export interface EntityDetailsProps {
   actionFilter?: (_: NodeAction) => boolean;
 }
 
-type _supportedTab = 'details' | 'resources';
+enum EntityTab {
+  DETAIL = 'detail',
+  RESOURCE = 'resource',
+}
 
 export const EntityDetails: React.FC<EntityDetailsProps> = ({
   entity,
@@ -114,7 +117,7 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
   alertOptions,
   ...props
 }) => {
-  const [activeTab, setActiveTab] = React.useState<_supportedTab>('details');
+  const [activeTab, setActiveTab] = React.useState(EntityTab.DETAIL);
   const viewContent = React.useMemo(() => {
     if (entity && isRenderable(entity)) {
       const data: EnvironmentNode | TargetNode = entity.getData();
@@ -124,7 +127,7 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
       const _actions = actionFactory(entity, 'dropdownItem', actionFilter);
 
       return (
-        <div {...props} style={{ height: '100%' }}>
+        <>
           <EntityDetailHeader
             titleContent={titleContent}
             alertOptions={alertOptions}
@@ -136,12 +139,8 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
             }
           />
           <Divider />
-          <Tabs
-            activeKey={activeTab}
-            onSelect={(_, tab) => setActiveTab(`${tab}` as _supportedTab)}
-            className={css('entity-overview')}
-          >
-            <Tab eventKey={'details'} title={<TabTitleText>Details</TabTitleText>}>
+          <Tabs activeKey={activeTab} onSelect={(_, tab: string) => setActiveTab(tab as EntityTab)}>
+            <Tab eventKey={EntityTab.DETAIL} title={<TabTitleText>Details</TabTitleText>}>
               <div className="entity-overview__wrapper">
                 {isTarget ? (
                   <TargetDetails targetNode={data} columnModifier={columnModifier} />
@@ -150,18 +149,22 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
                 )}
               </div>
             </Tab>
-            <Tab eventKey={'resources'} title={<TabTitleText>{'Resources'}</TabTitleText>}>
+            <Tab eventKey={EntityTab.RESOURCE} title={<TabTitleText>{'Resources'}</TabTitleText>}>
               <div className="entity-overview__wrapper">
                 {isTarget ? <TargetResources targetNode={data} /> : <GroupResources envNode={data} />}
               </div>
             </Tab>
           </Tabs>
-        </div>
+        </>
       );
     }
     return null;
-  }, [entity, setActiveTab, activeTab, props, columnModifier, actionFilter, alertOptions]);
-  return <div className={css(className)}>{viewContent}</div>;
+  }, [entity, setActiveTab, activeTab, columnModifier, actionFilter, alertOptions]);
+  return (
+    <div {...props} className={css('entity-overview', className)}>
+      {viewContent}
+    </div>
+  );
 };
 
 export const constructHelperDescription = (description: React.ReactNode, kind: string, path: string | string[]) => {
@@ -375,16 +378,7 @@ export const GroupDetails: React.FC<{
 
   return (
     <DescriptionList {...props} columnModifier={columnModifier}>
-      {_transformedData.map((d) => (
-        <DescriptionListGroup key={d.key}>
-          <DescriptionListTermHelpText>
-            <Popover headerContent={d.helperTitle} bodyContent={d.helperDescription}>
-              <DescriptionListTermHelpTextButton>{d.title}</DescriptionListTermHelpTextButton>
-            </Popover>
-          </DescriptionListTermHelpText>
-          <DescriptionListDescription>{d.content}</DescriptionListDescription>
-        </DescriptionListGroup>
-      ))}
+      {_transformedData.map(mapSection)}
     </DescriptionList>
   );
 };

--- a/src/app/Topology/SideBar/TopologySideBar.tsx
+++ b/src/app/Topology/SideBar/TopologySideBar.tsx
@@ -37,8 +37,6 @@
  */
 
 import { DrawerActions, DrawerCloseButton, DrawerHead, DrawerPanelBody } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
-import { TopologySideBar as PFTopologySideBar } from '@patternfly/react-topology';
 import * as React from 'react';
 
 export interface TopologySideBarProps {
@@ -50,13 +48,15 @@ export interface TopologySideBarProps {
 // Parent will wrap this element in <DrawPaneContent />
 export const TopologySideBar: React.FC<TopologySideBarProps> = ({ children, onClose, className, ...props }) => {
   return (
-    <PFTopologySideBar resizable className={css('topology__sidebar', className)} {...props}>
+    <>
       <DrawerHead hasNoPadding>
         <DrawerActions>
           <DrawerCloseButton className="entity-overview__entity-close-button" onClick={onClose} />
         </DrawerActions>
       </DrawerHead>
-      <DrawerPanelBody hasNoPadding>{children}</DrawerPanelBody>
-    </PFTopologySideBar>
+      <DrawerPanelBody {...props} hasNoPadding>
+        {children}
+      </DrawerPanelBody>
+    </>
   );
 };

--- a/src/app/Topology/Topology.tsx
+++ b/src/app/Topology/Topology.tsx
@@ -173,7 +173,7 @@ export const Topology: React.FC<TopologyProps> = ({ ..._props }) => {
         </HintBanner>
       </FeatureFlag>
       <BreadcrumbPage pageTitle={'Topology'} {..._props}>
-        <Card isFullHeight id="topology-card" className="topology__main-container">
+        <Card isFullHeight id="topology-card">
           <CardBody style={{ padding: 0 }}>
             <DiscoveryTreeContext.Provider value={discoveryTree}>{content}</DiscoveryTreeContext.Provider>
           </CardBody>

--- a/src/app/Topology/styles/base.css
+++ b/src/app/Topology/styles/base.css
@@ -71,7 +71,6 @@ Below CSS rules only apply to Topology components
   box-shadow: 0 0.25rem 0.5rem 0rem rgba(3, 3, 3, 0.25), 0 0 0.25rem 0 rgba(3, 3, 3, 0.06);
 }
 
-
 .sample-node-donut__node-wrapper .sample-node-donut__node-icon.success {
   border: 0.8em solid var(--pf-global--success-color--100);
 }
@@ -122,9 +121,21 @@ Below CSS rules only apply to Topology components
   color: var(--pf-global--palette--black-400);
 }
 
+.entity-overview {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.entity-overview .pf-c-tab-content {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: auto;
+}
+
 .entity-overview__wrapper {
-  padding: 1.6em;
-  padding-right: 0.6em;
+  padding: 1.5em;
+  padding-right: 0.5em;
 }
 
 .entity-overview .pf-c-tabs__item-text {
@@ -239,6 +250,10 @@ Below CSS rules only apply to Topology components
   cursor: pointer;
 }
 
+#topology__visualization-container.topology__main-container  {
+  padding: 1em;
+}
+
 .topology__main-container .topology__target-node {
   cursor: pointer;
 }
@@ -265,10 +280,6 @@ Below CSS rules only apply to Topology components
   margin-right: var(--pf-c-select__menu-group-title--PaddingRight);
   margin-bottom: var(--pf-c-select__menu-group-title--PaddingBottom);
   margin-left: var(--pf-c-select__menu-group-title--PaddingLeft);
-}
-
-.topology__visualization-container {
-  padding: 1em;
 }
 
 .topology__toolbar-container {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #891 

## Description of the change:

Add some css rules to allow detail content to be scrollable. This prevents the topology view from stretching the visualization surface, causing control bar to be pushed down.

## Motivation for the change:

Nicer UX and closer to OCP design. But there is one difference. For OCP, the whole sidebar is scrollable, including headers and close button. For cryostat, only the sidebar content body is scrollable (all below the tab bar).

## Screenshots

![Screenshot from 2023-04-03 22-06-45](https://user-images.githubusercontent.com/68053619/229671909-bd1783d6-6f2e-41fb-b9f8-1d11c84ba502.png)
