### PR TITLE
fix(settings): lazy load timezones

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -35,7 +35,6 @@
   "MINUTE_other": "Minutes",
   "N/A": "N/A",
   "NAME": "Name",
-  "NEW": "New",
   "OK": "OK",
   "PRODUCTION": "PRODUCTION",
   "REMOVE": "Remove",
@@ -55,6 +54,7 @@
   "TIME": "Time",
   "UPLOAD": "Upload",
   "VIEW": "View",
+  "VIEW_MORE": "View more",
   "WARNING": "WARNING",
   "WHATS_THIS": "What's this?"
 }

--- a/src/app/DateTimePicker/TimezonePicker.tsx
+++ b/src/app/DateTimePicker/TimezonePicker.tsx
@@ -40,6 +40,7 @@ import { useDayjs } from '@app/utils/useDayjs';
 import { supportedTimezones, Timezone } from '@i18n/datetime';
 import { Button, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import { GlobeIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -117,9 +118,9 @@ export const TimezonePicker: React.FunctionComponent<TimezonePickerProps> = ({
         numOfOptions < timezones.length
           ? [
               <SelectOption key="view-more" isPlaceholder onClick={handleViewMore}>
-                <Button variant="link" isInline>
+                <span className={css('pf-c-button', 'pf-m-link', 'pf-m-inline')}>
                   {t('VIEW_MORE', { ns: 'common' })}
-                </Button>
+                </span>
               </SelectOption>,
             ]
           : []


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #938 

## Description of the change:

Lazy load timezone options. This way, first load will be quicker. 

**Note**: This added a new select item that serves as a placeholder. PF examples use `loadingVariant`, however, there is a small bug that causes `View More` to be hidden when used with inline filter (only happens on first build/render). Also, search filter will exclude options that are not shown yet.

## Motivation for the change:

See #938

## How to manually test:
1. `Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2.  Go to Settings.
3.  Notice the setting page loads faster.
4. Click on the timezone picker and scroll down to see the View More item.
5. Click on it will make the option list expands. This View More is only available when list is not fully shown

## Screenshots

![Screenshot from 2023-04-06 19-58-16](https://user-images.githubusercontent.com/68053619/230514349-5246336c-de4b-43ef-9511-3c8b75c74987.png)

![Screenshot from 2023-04-06 19-57-55](https://user-images.githubusercontent.com/68053619/230514354-19236c8e-fa3d-4d2a-9eb4-b5f37241d19f.png)


