### PR TITLE
fix(graphql): fix active recs input filter format

### DIFF
--- a/src/app/Dashboard/Charts/jfr/JFRMetricsChartController.tsx
+++ b/src/app/Dashboard/Charts/jfr/JFRMetricsChartController.tsx
@@ -152,12 +152,7 @@ export class JFRMetricsChartController {
     }
     return this._api.targetHasRecording(target, {
       state: RecordingState.RUNNING,
-      labels: this._api.stringifyRecordingLabels([
-        {
-          key: 'origin',
-          value: RECORDING_NAME,
-        },
-      ]),
+      labels: [`origin=${RECORDING_NAME}`],
     });
   }
 }

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1826,7 +1826,7 @@ export interface ActiveRecordingFilterInput {
   durationMsLessThanEqual?: number;
   startTimeMsBeforeEqual?: number;
   startTimeMsAfterEqual?: number;
-  labels?: string;
+  labels?: string[] | string;
 }
 
 export const automatedAnalysisRecordingName = 'automated-analysis';


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #937 

## Description of the change:

Updated`ActiveRecordingInputFilter` format for `metadata.labels`.

## Motivation for the change:

#937 refactored graphQL call to fetch active recording to a method in Api service. However, totally forgot that the passed labels were passed as string while it is expected as an array. Gladly, this is discovered early.

This caused the JFR chart not to discovery the expected dashboard_metric recording and only renders empty view.
