### PR TITLE
fix(topology): remove uploaded archives from resources tab

### DIFF
--- a/src/app/Topology/Shared/Entity/utils.tsx
+++ b/src/app/Topology/Shared/Entity/utils.tsx
@@ -105,7 +105,6 @@ export type ResourceTypes = Recording | EventTemplate | EventType | EventProbe |
 export const TargetOwnedResourceTypeAsArray = [
   'activeRecordings',
   'archivedRecordings',
-  'archivedUploadRecordings',
   'eventTemplates',
   'eventTypes',
   'agentProbes',
@@ -176,8 +175,6 @@ export const getResourceAddedOrModifiedEvents = (resourceType: TargetOwnedResour
       ];
     case 'archivedRecordings':
       return [NotificationCategory.ArchivedRecordingCreated, NotificationCategory.ActiveRecordingSaved];
-    case 'archivedUploadRecordings':
-      return [NotificationCategory.ArchivedRecordingCreated];
     case 'eventTemplates':
       return [NotificationCategory.TemplateUploaded];
     case 'eventTypes':
@@ -198,8 +195,6 @@ export const getResourceRemovedEvents = (resourceType: TargetOwnedResourceType |
     case 'activeRecordings':
       return [NotificationCategory.ActiveRecordingDeleted, NotificationCategory.SnapshotDeleted];
     case 'archivedRecordings':
-      return [NotificationCategory.ArchivedRecordingDeleted];
-    case 'archivedUploadRecordings':
       return [NotificationCategory.ArchivedRecordingDeleted];
     case 'eventTemplates':
       return [NotificationCategory.TemplateDeleted];
@@ -230,15 +225,6 @@ export const getResourceListPatchFn = (
   switch (resourceType) {
     case 'activeRecordings':
     case 'archivedRecordings':
-    case 'archivedUploadRecordings':
-      return (arr: Recording[], eventData: NotificationMessage, removed?: boolean) => {
-        const recording: Recording = eventData.message.recording;
-        let newArr = arr.filter((r) => r.name !== recording.name);
-        if (!removed) {
-          newArr = newArr.concat([recording]);
-        }
-        return of(newArr);
-      };
     case 'eventTemplates':
       return (arr: EventTemplate[], eventData: NotificationMessage, removed?: boolean) => {
         const template: EventTemplate = eventData.message.template;
@@ -306,8 +292,6 @@ export const getLinkPropsForTargetResource = (
       return { to: { pathname: '/recordings', search: '?tab=active-recording' } };
     case 'archivedRecordings':
       return { to: { pathname: '/recordings', search: '?tab=archived-recording' } };
-    case 'archivedUploadRecordings':
-      return { to: { pathname: '/archives', search: '?tab=uploads' } };
     case 'eventTemplates':
       return { to: { pathname: '/events', search: '?eventTab=event-template' } };
     case 'eventTypes':


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #945 

## Description of the change:

Uploaded archives should not be showned in resource tab.

## Motivation for the change:

> > Ohh thanks for noticing! I think that was meant to be removed since the target does not own uploads. I removed fetcher but should also cleanup others.

Upload archives are still defined as supported type and other handlers are still defined to work with this resource. Need removing.

## Screenshots

![Screenshot from 2023-04-13 12-06-41](https://user-images.githubusercontent.com/68053619/231819437-bd4da42c-b946-4da7-9724-f117decb4811.png)

