### PR TITLE
feat(error): set error boundary for first renders

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -49,6 +49,7 @@
   "SELECT": "Select",
   "SHOW_LESS": "Show less",
   "SHOW_MORE": "Show more",
+  "SOMETHING_WENT_WRONG": "Something went wrong",
   "SUBMIT": "Submit",
   "SUBMITTING": "Submitting",
   "SUGGESTED": "Suggested",

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -230,6 +230,10 @@
     },
     "SELECTED_DATETIME": "Selected DateTime"
   },
+  "ERROR_BOUNDARY": {
+    "ERROR_MESSAGE": "Reason: {{message}}",
+    "RESOLVE_MESSAGE": "Reload the page and try again. If the error still persists, checkout out <issue>{{knownIssue}}</issue> or <report>{{fileReport}}</report>."
+  },
   "JvmDetailsCard": {
     "CARD_DESCRIPTION": "Display details about the selected target JVM.",
     "CARD_DESCRIPTION_FULL": "View information such as the connection URL, labels, and annotations belonging to the selected target JVM.",

--- a/src/app/Shared/ErrorBoundary.tsx
+++ b/src/app/Shared/ErrorBoundary.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import build from '@app/build.json';
+import { useSubscriptions } from '@app/utils/useSubscriptions';
+import {
+  Bullseye,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Text,
+  TextVariants,
+  Title,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { ServiceContext } from './Services/Services';
+
+export interface ErrorBoundaryProps {
+  renderFallback: (error: Error) => React.ReactNode;
+  children?: React.ReactNode;
+}
+
+export interface ErrorBoundaryState {
+  error?: Error;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: undefined };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.warn(error, info.componentStack);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.error) {
+      return this.props.renderFallback(this.state.error);
+    }
+    return this.props.children;
+  }
+}
+
+export interface DefaultFallBackProps {
+  error?: Error;
+}
+
+export const DefaultFallBack: React.FC<DefaultFallBackProps> = ({ error, ...props }) => {
+  const { t } = useTranslation();
+  const addSubcription = useSubscriptions();
+  const serviceContext = React.useContext(ServiceContext);
+  const [cryostatVersion, setCryostatVersion] = React.useState(undefined as string | undefined);
+
+  React.useEffect(() => {
+    addSubcription(serviceContext.api.cryostatVersion().subscribe(setCryostatVersion));
+  }, [serviceContext, setCryostatVersion, addSubcription]);
+
+  return (
+    <Bullseye {...props}>
+      <EmptyState variant={EmptyStateVariant.large}>
+        <EmptyStateIcon icon={ExclamationCircleIcon} color="red" />
+        <Title headingLevel={'h1'}>{t('SOMETHING_WENT_WRONG', { ns: 'common' })}</Title>
+        <EmptyStateBody>
+          <p>{t('ERROR_BOUNDARY.ERROR_MESSAGE', { message: error?.message || 'Unknown error.' })}</p>
+          <Trans
+            t={t}
+            values={{
+              knownIssue: t('AboutDescription.KNOWN_ISSUES'),
+              fileReport: t('AboutDescription.FILE_A_REPORT'),
+            }}
+            components={{
+              issue: <Text component={TextVariants.a} target="_blank" href={build.knownIssuesUrl} />,
+              report: (
+                <Text
+                  component={TextVariants.a}
+                  target="_blank"
+                  href={build.fileIssueUrl.replace('__REPLACE_VERSION__', cryostatVersion || 'unknown')}
+                />
+              ),
+            }}
+          >
+            ERROR_BOUNDARY.RESOLVE_MESSAGE
+          </Trans>
+        </EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
+  );
+};

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -53,6 +53,7 @@ import CreateRule from './Rules/CreateRule';
 import Rules from './Rules/Rules';
 import SecurityPanel from './SecurityPanel/SecurityPanel';
 import Settings from './Settings/Settings';
+import { DefaultFallBack, ErrorBoundary } from './Shared/ErrorBoundary';
 import { SessionState } from './Shared/Services/Login.service';
 import { ServiceContext } from './Shared/Services/Services';
 import { FeatureLevel } from './Shared/Services/Settings.service';
@@ -245,8 +246,16 @@ const RouteWithTitleUpdates = ({ component: Component, isAsync = false, path, ti
   useA11yRouteChange(isAsync);
   useDocumentTitle(title);
 
+  const renderFallback = React.useCallback((error: Error) => {
+    return <DefaultFallBack error={error} />;
+  }, []);
+
   function routeWithTitle(routeProps: RouteComponentProps) {
-    return <Component {...rest} {...routeProps} />;
+    return (
+      <ErrorBoundary renderFallback={renderFallback}>
+        <Component {...rest} {...routeProps} />
+      </ErrorBoundary>
+    );
   }
 
   return <Route render={routeWithTitle} path={path} />;


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to: #950 

## Description of the change:

Add an error boundary around component that renders the main container view. Though, this won't completely fix the issue because we need consider more granular handling.

**Note**: this applies for first render. If later one child components build fail, no error views will be shown.

> Also bear in mind that try/catch blocks won't work on all cases.
> If a component deep in the hierarchy tries to updates and fails, the try/catch block in one of the parents won't work -- > ? because it isn't necessarily updating together with the child.

## Motivation for the change:

See #950. This applies to first renders to that errors are caught early.

## How to manually test:
1. `Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2. Try:
```diff
diff --git a/src/app/Dashboard/Dashboard.tsx b/src/app/Dashboard/Dashboard.tsx
index 6dffda0c..cdd0e35d 100644
--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -267,6 +267,7 @@ export const getDashboardCards: (featureLevel?: FeatureLevel) => DashboardCardDe
 export interface DashboardComponentProps {}
 
 export const Dashboard: React.FC<DashboardComponentProps> = (_) => {
+  throw new Error('Somehow the dashboard cannot be rendered');
   const history = useHistory();
   const serviceContext = React.useContext(ServiceContext);
   const dispatch = useDispatch<StateDispatch>();
```

## Screenshots

|Light Theme|Dark Theme|
|-----------------|------------------|
|![Screenshot from 2023-04-13 17-11-56](https://user-images.githubusercontent.com/68053619/231883807-05023771-a984-4125-a4c8-05bbaa0b4947.png)|![Screenshot from 2023-04-13 17-12-54](https://user-images.githubusercontent.com/68053619/231884096-556f5482-57f2-4b12-8ebf-a44f85a9ddbb.png)|

