### PR TITLE
fix(recordings): use a helpful error messge for http-based targets

### DIFF
--- a/src/app/Shared/Services/Target.service.tsx
+++ b/src/app/Shared/Services/Target.service.tsx
@@ -60,6 +60,8 @@ export const indexOfTarget = (arr: Target[], target: Target): number => {
 export const getTargetRepresentation = (t: Target) =>
   !t.alias || t.alias === t.connectUrl ? `${t.connectUrl}` : `${t.alias} (${t.connectUrl})`;
 
+export const isTargetAgentHttp = (t: Target) => t.connectUrl.startsWith('http');
+
 export interface Target {
   jvmId?: string; // present in responses, but we do not need to provide it in requests
   connectUrl: string;


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Temporary fixes for #944 

## Description of the change:

Use a special error message for http-based targets.

## Motivation for the change:

See #944 

## How to manually test:
1. `Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...`
2. Go to Recording tab -> Create Recording -> Select `9988` (http).
3. See the error message.

## Screenshots

|Dark Theme | Light Theme |
|---|---|
|![Screenshot from 2023-04-14 15-09-20](https://user-images.githubusercontent.com/68053619/232134997-6bafec7e-303c-499e-8c84-58117388e644.png)|![Screenshot from 2023-04-14 15-09-51](https://user-images.githubusercontent.com/68053619/232135094-f2938dc8-a5f5-434c-8463-cc35311f1457.png)|


