### PR TITLE
fix(rules): fix enable/disable rules cause them to jump on Rules table

### DIFF
--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -150,6 +150,7 @@ export const Rules: React.FC<RulesProps> = (_) => {
         { title: 'Description' },
         {
           title: 'Match Expression',
+          sortable: true,
           tooltip:
             'A code-snippet expression which must evaluate to a boolean when applied to a given target. If the expression evaluates to true then the rule applies to that target.',
         },
@@ -361,23 +362,25 @@ export const Rules: React.FC<RulesProps> = (_) => {
   const ruleRows = React.useMemo(() => {
     const { index, direction } = sortBy;
     let sorted = [...rules];
-    if (typeof index === 'number') {
-      const keys = [
-        'enabled',
-        'name',
-        'description',
-        'matchExpression',
-        'eventSpecifier',
-        'archivalPeriodSeconds',
-        'initialDelaySeconds',
-        'preservedArchives',
-        'maxAgeSeconds',
-        'maxSizeBytes',
-      ];
-      const key = keys[index];
-      sorted = rules.sort((a: Rule, b: Rule): number => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
-      sorted = direction === SortByDirection.asc ? sorted : sorted.reverse();
-    }
+
+    const sortKey = index ?? 1; // default to name
+
+    const sortableKeys = [
+      'enabled',
+      'name',
+      'description',
+      'matchExpression',
+      'eventSpecifier',
+      'archivalPeriodSeconds',
+      'initialDelaySeconds',
+      'preservedArchives',
+      'maxAgeSeconds',
+      'maxSizeBytes',
+    ];
+    const key = sortableKeys[sortKey];
+    sorted = rules.sort((a: Rule, b: Rule): number => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
+    sorted = direction === SortByDirection.asc ? sorted : sorted.reverse();
+
     return sorted.map((r: Rule, index) => (
       <Tr key={`automatic-rule-${index}`}>
         <Td key={`automatic-rule-enabled-${index}`} dataLabel={tableColumns[0].title}>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #959

## Description of the change:
The change fixes the bug where enabling and disabling rules will cause them to move to the bottom of the rules table. I've not gone through with allow users to sort on enable/disable because the rule table state depends on the response from the backend so if the sort===enabled, toggling the button would always keep the rows in a sorting state and cause the table rows to jump around, but if state was managed by the front-end, enabling/disabling rules would hopefully just remove the sorting state entirely until the user wants to sort again by pressing the sort arrows.

## How to manually test:
Go to rules table and enable/disable rules. Rules no longer jump around.
