### PR TITLE
fix(tables): table should have an intial sort order

### DIFF
--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -73,8 +73,37 @@ import {
 import * as React from 'react';
 import { combineLatest } from 'rxjs';
 import { AboutAgentCard } from './AboutAgentCard';
+import { sortResources, TableColumn } from '@app/utils/utils';
 
 export type LiveProbeActions = 'REMOVE';
+
+const tableColumns: TableColumn[] = [
+  {
+    title: 'ID',
+    keyPaths: ['id'],
+    sortable: true,
+  },
+  {
+    title: 'Name',
+    keyPaths: ['name'],
+    sortable: true,
+  },
+  {
+    title: 'Class',
+    keyPaths: ['clazz'],
+    sortable: true,
+  },
+  {
+    title: 'Description',
+    keyPaths: ['description'],
+    sortable: true,
+  },
+  {
+    title: 'Method',
+    keyPaths: ['methodName'],
+    sortable: true,
+  },
+];
 
 export interface AgentLiveProbesProps {}
 
@@ -90,8 +119,6 @@ export const AgentLiveProbes: React.FC<AgentLiveProbesProps> = (_) => {
   const [errorMessage, setErrorMessage] = React.useState('');
   const [warningModalOpen, setWarningModalOpen] = React.useState(false);
   const [actionLoadings, setActionLoadings] = React.useState<Record<LiveProbeActions, boolean>>({ REMOVE: false });
-
-  const tableColumns = React.useMemo(() => ['ID', 'Name', 'Class', 'Description', 'Method'], []);
 
   const getSortParams = React.useCallback(
     (columnIndex: number): ThProps['sort'] => ({
@@ -241,31 +268,36 @@ export const AgentLiveProbes: React.FC<AgentLiveProbesProps> = (_) => {
           t.methodName.toLowerCase().includes(ft)
       );
     }
-    const { index = 0, direction = SortByDirection.asc } = sortBy;
-    const keys = ['id', 'name', 'description', 'clazz', 'methodName'];
-    const key = keys[index];
-    const sorted = filtered.sort((a, b) => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
-    filtered = direction === SortByDirection.asc ? sorted : sorted.reverse();
-    setFilteredProbes([...filtered]);
+
+    setFilteredProbes(
+      sortResources(
+        {
+          index: sortBy.index ?? 0,
+          direction: sortBy.direction ?? SortByDirection.asc,
+        },
+        filtered,
+        tableColumns
+      )
+    );
   }, [filterText, probes, sortBy, setFilteredProbes]);
 
   const probeRows = React.useMemo(
     () =>
       filteredProbes.map((t: EventProbe, index) => (
         <Tr key={`active-probe-${index}`}>
-          <Td key={`active-probe-id-${index}`} dataLabel={tableColumns[0]}>
+          <Td key={`active-probe-id-${index}`} dataLabel={tableColumns[0].title}>
             {t.id}
           </Td>
-          <Td key={`active-probe-name-${index}`} dataLabel={tableColumns[1]}>
+          <Td key={`active-probe-name-${index}`} dataLabel={tableColumns[1].title}>
             {t.name}
           </Td>
-          <Td key={`active-probe-clazz-${index}`} dataLabel={tableColumns[2]}>
+          <Td key={`active-probe-clazz-${index}`} dataLabel={tableColumns[2].title}>
             {t.clazz}
           </Td>
-          <Td key={`active-probe-description-${index}`} dataLabel={tableColumns[3]}>
+          <Td key={`active-probe-description-${index}`} dataLabel={tableColumns[3].title}>
             {t.description}
           </Td>
-          <Td key={`active-probe-methodname-${index}`} dataLabel={tableColumns[4]}>
+          <Td key={`active-probe-methodname-${index}`} dataLabel={tableColumns[4].title}>
             {t.methodName}
           </Td>
         </Tr>
@@ -341,9 +373,9 @@ export const AgentLiveProbes: React.FC<AgentLiveProbesProps> = (_) => {
               <TableComposable aria-label="Active Probe Table" variant={TableVariant.compact}>
                 <Thead>
                   <Tr>
-                    {tableColumns.map((column, index) => (
-                      <Th key={`active-probe-header-${column}`} sort={getSortParams(index)}>
-                        {column}
+                    {tableColumns.map(({ title, sortable }, index) => (
+                      <Th key={`active-probe-header-${title}`} sort={sortable ? getSortParams(index) : undefined}>
+                        {title}
                       </Th>
                     ))}
                   </Tr>

--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -241,13 +241,11 @@ export const AgentLiveProbes: React.FC<AgentLiveProbesProps> = (_) => {
           t.methodName.toLowerCase().includes(ft)
       );
     }
-    const { index, direction } = sortBy;
-    if (typeof index === 'number') {
-      const keys = ['id', 'name', 'description', 'clazz', 'methodName'];
-      const key = keys[index];
-      const sorted = filtered.sort((a, b) => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
-      filtered = direction === SortByDirection.asc ? sorted : sorted.reverse();
-    }
+    const { index = 0, direction = SortByDirection.asc } = sortBy;
+    const keys = ['id', 'name', 'description', 'clazz', 'methodName'];
+    const key = keys[index];
+    const sorted = filtered.sort((a, b) => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
+    filtered = direction === SortByDirection.asc ? sorted : sorted.reverse();
     setFilteredProbes([...filtered]);
   }, [filterText, probes, sortBy, setFilteredProbes]);
 

--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -44,6 +44,7 @@ import { EventProbe } from '@app/Shared/Services/Api.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { sortResources, TableColumn } from '@app/utils/utils';
 import {
   Button,
   Toolbar,
@@ -73,7 +74,6 @@ import {
 import * as React from 'react';
 import { combineLatest } from 'rxjs';
 import { AboutAgentCard } from './AboutAgentCard';
-import { sortResources, TableColumn } from '@app/utils/utils';
 
 export type LiveProbeActions = 'REMOVE';
 
@@ -302,7 +302,7 @@ export const AgentLiveProbes: React.FC<AgentLiveProbesProps> = (_) => {
           </Td>
         </Tr>
       )),
-    [filteredProbes, tableColumns]
+    [filteredProbes]
   );
 
   const actionLoadingProps = React.useMemo<Record<LiveProbeActions, LoadingPropsType>>(

--- a/src/app/Agent/AgentProbeTemplates.tsx
+++ b/src/app/Agent/AgentProbeTemplates.tsx
@@ -295,7 +295,7 @@ export const AgentProbeTemplates: React.FC<AgentProbeTemplatesProps> = (props) =
           </Tr>
         );
       }),
-    [filteredTemplates, props.agentDetected, handleInsertAction, handleDeleteAction, tableColumns]
+    [filteredTemplates, props.agentDetected, handleInsertAction, handleDeleteAction]
   );
 
   if (errorMessage != '') {

--- a/src/app/Agent/AgentProbeTemplates.tsx
+++ b/src/app/Agent/AgentProbeTemplates.tsx
@@ -226,13 +226,11 @@ export const AgentProbeTemplates: React.FC<AgentProbeTemplatesProps> = (props) =
         (t: ProbeTemplate) => t.name.toLowerCase().includes(ft) || t.xml.toLowerCase().includes(ft)
       );
     }
-    const { index, direction } = sortBy;
-    if (typeof index === 'number') {
-      const keys = ['name', 'xml'];
-      const key = keys[index];
-      const sorted = filtered.sort((a, b) => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
-      filtered = direction === SortByDirection.asc ? sorted : sorted.reverse();
-    }
+    const { index = 0, direction = SortByDirection.asc } = sortBy;
+    const keys = ['name', 'xml'];
+    const key = keys[index];
+    const sorted = filtered.sort((a, b) => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
+    filtered = direction === SortByDirection.asc ? sorted : sorted.reverse();
     setFilteredTemplates([...filtered]);
   }, [filterText, templates, sortBy, setFilteredTemplates]);
 

--- a/src/app/Archives/AllArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllArchivedRecordingsTable.tsx
@@ -60,7 +60,16 @@ import {
   SplitItem,
 } from '@patternfly/react-core';
 import { HelpIcon, SearchIcon } from '@patternfly/react-icons';
-import { TableComposable, Th, Thead, Tbody, Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
+import {
+  TableComposable,
+  Th,
+  Thead,
+  Tbody,
+  Tr,
+  Td,
+  ExpandableRowContent,
+  SortByDirection,
+} from '@patternfly/react-table';
 import * as React from 'react';
 import { Observable, of } from 'rxjs';
 import { getTargetFromDirectory, includesDirectory, indexOfDirectory } from './ArchiveDirectoryUtil';
@@ -153,7 +162,15 @@ export const AllArchivedRecordingsTable: React.FC<AllArchivedRecordingsTableProp
           d.connectUrl.toLowerCase().includes(formattedSearchText)
       );
     }
-    return sortResources(sortBy, updatedSearchedDirectories, mapper, getTransform);
+    return sortResources(
+      {
+        index: sortBy.index ?? 0,
+        direction: sortBy.direction ?? SortByDirection.asc,
+      },
+      updatedSearchedDirectories,
+      mapper,
+      getTransform
+    );
   }, [directories, searchText, sortBy]);
 
   React.useEffect(() => {

--- a/src/app/Archives/AllArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllArchivedRecordingsTable.tsx
@@ -43,7 +43,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { Target } from '@app/Shared/Services/Target.service';
 import { useSort } from '@app/utils/useSort';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { portalRoot, sortResources } from '@app/utils/utils';
+import { TableColumn, portalRoot, sortResources } from '@app/utils/utils';
 import {
   Toolbar,
   ToolbarContent,
@@ -74,7 +74,7 @@ import * as React from 'react';
 import { Observable, of } from 'rxjs';
 import { getTargetFromDirectory, includesDirectory, indexOfDirectory } from './ArchiveDirectoryUtil';
 
-const tableColumns = [
+const tableColumns: TableColumn[] = [
   {
     title: 'Directory',
     keyPaths: ['connectUrl'],
@@ -91,20 +91,6 @@ const tableColumns = [
     width: 15,
   },
 ];
-
-const mapper = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].keyPaths;
-  }
-  return undefined;
-};
-
-const getTransform = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].transform;
-  }
-  return undefined;
-};
 
 type _RecordingDirectory = RecordingDirectory & { targetAsObs: Observable<Target> };
 
@@ -168,8 +154,7 @@ export const AllArchivedRecordingsTable: React.FC<AllArchivedRecordingsTableProp
         direction: sortBy.direction ?? SortByDirection.asc,
       },
       updatedSearchedDirectories,
-      mapper,
-      getTransform
+      tableColumns
     );
   }, [directories, searchText, sortBy]);
 

--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -57,7 +57,16 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { TableComposable, Th, Thead, Tbody, Tr, Td, ExpandableRowContent } from '@patternfly/react-table';
+import {
+  TableComposable,
+  Th,
+  Thead,
+  Tbody,
+  Tr,
+  Td,
+  ExpandableRowContent,
+  SortByDirection,
+} from '@patternfly/react-table';
 import * as React from 'react';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -279,7 +288,10 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
       );
     }
     return sortResources(
-      sortBy,
+      {
+        index: sortBy.index ?? 0,
+        direction: sortBy.direction ?? SortByDirection.asc,
+      },
       updated.filter((v) => !hideEmptyTargets || v.archiveCount > 0),
       mapper,
       getTransform

--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -43,7 +43,7 @@ import { includesTarget, indexOfTarget, isEqualTarget, Target } from '@app/Share
 import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 import { useSort } from '@app/utils/useSort';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { hashCode, sortResources } from '@app/utils/utils';
+import { hashCode, sortResources, TableColumn } from '@app/utils/utils';
 import {
   Toolbar,
   ToolbarContent,
@@ -71,7 +71,7 @@ import * as React from 'react';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-const tableColumns = [
+const tableColumns: TableColumn[] = [
   {
     title: 'Target',
     keyPaths: ['target'],
@@ -90,20 +90,6 @@ const tableColumns = [
     width: 15,
   },
 ];
-
-const mapper = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].keyPaths;
-  }
-  return undefined;
-};
-
-const getTransform = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].transform;
-  }
-  return undefined;
-};
 
 type ArchivesForTarget = {
   target: Target;
@@ -293,8 +279,7 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
         direction: sortBy.direction ?? SortByDirection.asc,
       },
       updated.filter((v) => !hideEmptyTargets || v.archiveCount > 0),
-      mapper,
-      getTransform
+      tableColumns
     );
   }, [searchText, archivesForTargets, sortBy, hideEmptyTargets]);
 

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -338,7 +338,7 @@ export const EventTemplates: React.FC<EventTemplatesProps> = (_) => {
           </Td>
         </Tr>
       )),
-    [actionsResolver, tableColumns, filteredTemplates]
+    [actionsResolver, filteredTemplates]
   );
 
   const handleWarningModalAccept = React.useCallback(() => {

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -130,13 +130,12 @@ export const EventTemplates: React.FC<EventTemplatesProps> = (_) => {
           t.provider.toLowerCase().includes(ft)
       );
     }
-    const { index, direction } = sortBy;
-    if (typeof index === 'number') {
-      const keys = ['name', 'description', 'provider', 'type'];
-      const key = keys[index];
-      const sorted = filtered.sort((a, b) => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
-      filtered = direction === SortByDirection.asc ? sorted : sorted.reverse();
-    }
+    const { index = 0, direction = SortByDirection.asc } = sortBy;
+
+    const keys = ['name', 'description', 'provider', 'type'];
+    const key = keys[index];
+    const sorted = filtered.sort((a, b) => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
+    filtered = direction === SortByDirection.asc ? sorted : sorted.reverse();
     setFilteredTemplates([...filtered]);
   }, [filterText, templates, sortBy]);
 

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -47,7 +47,7 @@ import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.s
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { portalRoot } from '@app/utils/utils';
+import { portalRoot, sortResources, TableColumn } from '@app/utils/utils';
 import {
   ActionGroup,
   Button,
@@ -84,6 +84,29 @@ import { useHistory } from 'react-router-dom';
 import { forkJoin, Observable, of } from 'rxjs';
 import { catchError, concatMap, defaultIfEmpty, filter, first, tap } from 'rxjs/operators';
 
+const tableColumns: TableColumn[] = [
+  {
+    title: 'Name',
+    keyPaths: ['name'],
+    sortable: true,
+  },
+  {
+    title: 'Description',
+    keyPaths: ['description'],
+    sortable: true,
+  },
+  {
+    title: 'Provider',
+    keyPaths: ['provider'],
+    sortable: true,
+  },
+  {
+    title: 'Type',
+    keyPaths: ['type'],
+    sortable: true,
+  },
+];
+
 export interface EventTemplatesProps {}
 
 export const EventTemplates: React.FC<EventTemplatesProps> = (_) => {
@@ -101,8 +124,6 @@ export const EventTemplates: React.FC<EventTemplatesProps> = (_) => {
   const [templateToDelete, setTemplateToDelete] = React.useState<EventTemplate | undefined>(undefined);
   const addSubscription = useSubscriptions();
 
-  const tableColumns = React.useMemo(() => ['Name', 'Description', 'Provider', 'Type'], []);
-
   const getSortParams = React.useCallback(
     (columnIndex: number): ThProps['sort'] => ({
       sortBy: sortBy,
@@ -118,7 +139,7 @@ export const EventTemplates: React.FC<EventTemplatesProps> = (_) => {
   );
 
   React.useEffect(() => {
-    let filtered;
+    let filtered: EventTemplate[];
     if (!filterText) {
       filtered = templates;
     } else {
@@ -130,13 +151,17 @@ export const EventTemplates: React.FC<EventTemplatesProps> = (_) => {
           t.provider.toLowerCase().includes(ft)
       );
     }
-    const { index = 0, direction = SortByDirection.asc } = sortBy;
 
-    const keys = ['name', 'description', 'provider', 'type'];
-    const key = keys[index];
-    const sorted = filtered.sort((a, b) => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
-    filtered = direction === SortByDirection.asc ? sorted : sorted.reverse();
-    setFilteredTemplates([...filtered]);
+    setFilteredTemplates(
+      sortResources(
+        {
+          index: sortBy.index ?? 0,
+          direction: sortBy.direction ?? SortByDirection.asc,
+        },
+        filtered,
+        tableColumns
+      )
+    );
   }, [filterText, templates, sortBy]);
 
   const handleTemplates = React.useCallback(
@@ -296,16 +321,16 @@ export const EventTemplates: React.FC<EventTemplatesProps> = (_) => {
     () =>
       filteredTemplates.map((t: EventTemplate, index) => (
         <Tr key={`event-template-${index}`}>
-          <Td key={`event-template-name-${index}`} dataLabel={tableColumns[0]}>
+          <Td key={`event-template-name-${index}`} dataLabel={tableColumns[0].title}>
             {t.name}
           </Td>
-          <Td key={`event-template-description-${index}`} dataLabel={tableColumns[1]}>
+          <Td key={`event-template-description-${index}`} dataLabel={tableColumns[1].title}>
             {t.description}
           </Td>
-          <Td key={`event-template-provider-${index}`} dataLabel={tableColumns[2]}>
+          <Td key={`event-template-provider-${index}`} dataLabel={tableColumns[2].title}>
             {t.provider}
           </Td>
-          <Td key={`event-template-type-${index}`} dataLabel={tableColumns[3]}>
+          <Td key={`event-template-type-${index}`} dataLabel={tableColumns[3].title}>
             {t.type.charAt(0).toUpperCase() + t.type.slice(1).toLowerCase()}
           </Td>
           <Td key={`event-template-action-${index}`} isActionCell style={{ paddingRight: '0' }}>
@@ -386,9 +411,9 @@ export const EventTemplates: React.FC<EventTemplatesProps> = (_) => {
           <TableComposable aria-label="Event Templates Table" variant={TableVariant.compact}>
             <Thead>
               <Tr>
-                {tableColumns.map((column, index) => (
-                  <Th key={`event-template-header-${column}`} sort={getSortParams(index)}>
-                    {column}
+                {tableColumns.map(({ title, sortable }, index) => (
+                  <Th key={`event-template-header-${title}`} sort={sortable ? getSortParams(index) : undefined}>
+                    {title}
                   </Th>
                 ))}
               </Tr>

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -55,7 +55,17 @@ import {
   Text,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { ExpandableRowContent, TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import {
+  ExpandableRowContent,
+  SortByDirection,
+  TableComposable,
+  TableVariant,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table';
 import * as React from 'react';
 import { concatMap, filter, first } from 'rxjs/operators';
 
@@ -190,7 +200,15 @@ export const EventTypes: React.FC<EventTypesProps> = (_) => {
       includesSubstr(t.typeId, filterText) ||
       includesSubstr(t.description, filterText) ||
       includesSubstr(getCategoryString(t), filterText);
-    return sortResources(sortBy, types.filter(withFilters), mapper, getTransform);
+    return sortResources(
+      {
+        index: sortBy.index ?? 0,
+        direction: sortBy.direction ?? SortByDirection.asc,
+      },
+      types.filter(withFilters),
+      mapper,
+      getTransform
+    );
   }, [types, filterText, sortBy]);
 
   const displayedTypeRowData = React.useMemo(() => {

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -41,7 +41,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { useSort } from '@app/utils/useSort';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { hashCode, sortResources } from '@app/utils/utils';
+import { hashCode, sortResources, TableColumn } from '@app/utils/utils';
 import {
   Toolbar,
   ToolbarContent,
@@ -96,7 +96,7 @@ const getCategoryString = (eventType: EventType): string => {
 
 const includesSubstr = (a: string, b: string) => !!a && !!b && a.toLowerCase().includes(b.trim().toLowerCase());
 
-const tableColumns = [
+const tableColumns: TableColumn[] = [
   {
     title: 'Name',
     keyPaths: ['name'],
@@ -118,15 +118,6 @@ const tableColumns = [
     sortable: true,
   },
 ];
-
-const mapper = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].keyPaths;
-  }
-  return undefined;
-};
-
-const getTransform = (_index?: number) => undefined;
 
 export interface EventTypesProps {}
 
@@ -206,8 +197,7 @@ export const EventTypes: React.FC<EventTypesProps> = (_) => {
         direction: sortBy.direction ?? SortByDirection.asc,
       },
       types.filter(withFilters),
-      mapper,
-      getTransform
+      tableColumns
     );
   }, [types, filterText, sortBy]);
 

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -81,7 +81,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { ExpandableRowContent, Tbody, Td, Tr } from '@patternfly/react-table';
+import { ExpandableRowContent, SortByDirection, Tbody, Td, Tr } from '@patternfly/react-table';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useRouteMatch } from 'react-router-dom';
@@ -346,7 +346,15 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
 
   React.useEffect(() => {
     setFilteredRecordings(
-      sortResources(sortBy, filterRecordings(recordings, targetRecordingFilters), mapper, getTransform)
+      sortResources(
+        {
+          index: sortBy.index ?? 0,
+          direction: sortBy.direction ?? SortByDirection.asc,
+        },
+        filterRecordings(recordings, targetRecordingFilters),
+        mapper,
+        getTransform
+      )
     );
   }, [sortBy, recordings, targetRecordingFilters, setFilteredRecordings]);
 

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -58,7 +58,7 @@ import { NO_TARGET } from '@app/Shared/Services/Target.service';
 import { useDayjs } from '@app/utils/useDayjs';
 import { useSort } from '@app/utils/useSort';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { sortResources } from '@app/utils/utils';
+import { sortResources, TableColumn } from '@app/utils/utils';
 import {
   Button,
   Checkbox,
@@ -99,7 +99,7 @@ export enum PanelContent {
   LABELS,
 }
 
-const tableColumns = [
+const tableColumns: TableColumn[] = [
   {
     title: 'Name',
     keyPaths: ['name'],
@@ -131,20 +131,6 @@ const tableColumns = [
     keyPaths: ['metadata', 'labels'],
   },
 ];
-
-const mapper = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].keyPaths;
-  }
-  return undefined;
-};
-
-const getTransform = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].transform;
-  }
-  return undefined;
-};
 
 export interface ActiveRecordingsTableProps {
   archiveEnabled: boolean;
@@ -352,8 +338,7 @@ export const ActiveRecordingsTable: React.FunctionComponent<ActiveRecordingsTabl
           direction: sortBy.direction ?? SortByDirection.asc,
         },
         filterRecordings(recordings, targetRecordingFilters),
-        mapper,
-        getTransform
+        tableColumns
       )
     );
   }, [sortBy, recordings, targetRecordingFilters, setFilteredRecordings]);

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -96,6 +96,9 @@ const tableColumns = [
     title: 'Name',
     keyPaths: ['name'],
     sortable: true,
+    transform: (name: string, _recording: ArchivedRecording) => {
+      return name.replace(/\.[^/.]+$/, '');
+    },
   },
   {
     title: 'Labels',
@@ -115,7 +118,12 @@ const mapper = (index?: number) => {
   return undefined;
 };
 
-const getTransform = (_index?: number) => undefined;
+const getTransform = (index?: number) => {
+  if (index !== undefined) {
+    return tableColumns[index].transform;
+  }
+  return undefined;
+};
 
 export interface ArchivedRecordingsTableProps {
   target: Observable<Target>;

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -79,7 +79,7 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { UploadIcon } from '@patternfly/react-icons';
-import { Tbody, Tr, Td, ExpandableRowContent, TableComposable } from '@patternfly/react-table';
+import { Tbody, Tr, Td, ExpandableRowContent, TableComposable, SortByDirection } from '@patternfly/react-table';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Observable, forkJoin, merge, combineLatest } from 'rxjs';
@@ -367,7 +367,15 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
 
   React.useEffect(() => {
     setFilteredRecordings(
-      sortResources(sortBy, filterRecordings(recordings, targetRecordingFilters), mapper, getTransform)
+      sortResources(
+        {
+          index: sortBy.index ?? 0,
+          direction: sortBy.direction ?? SortByDirection.asc,
+        },
+        filterRecordings(recordings, targetRecordingFilters),
+        mapper,
+        getTransform
+      )
     );
   }, [sortBy, recordings, targetRecordingFilters, setFilteredRecordings]);
 

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -58,7 +58,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { NO_TARGET, Target } from '@app/Shared/Services/Target.service';
 import { useSort } from '@app/utils/useSort';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { formatBytes, hashCode, sortResources } from '@app/utils/utils';
+import { formatBytes, hashCode, sortResources, TableColumn } from '@app/utils/utils';
 import {
   Button,
   Checkbox,
@@ -91,7 +91,7 @@ import { RecordingLabelsPanel } from './RecordingLabelsPanel';
 import { ColumnConfig, RecordingsTable } from './RecordingsTable';
 import { ReportFrame } from './ReportFrame';
 
-const tableColumns = [
+const tableColumns: TableColumn[] = [
   {
     title: 'Name',
     keyPaths: ['name'],
@@ -110,20 +110,6 @@ const tableColumns = [
     sortable: true,
   },
 ];
-
-const mapper = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].keyPaths;
-  }
-  return undefined;
-};
-
-const getTransform = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].transform;
-  }
-  return undefined;
-};
 
 export interface ArchivedRecordingsTableProps {
   target: Observable<Target>;
@@ -381,8 +367,7 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
           direction: sortBy.direction ?? SortByDirection.asc,
         },
         filterRecordings(recordings, targetRecordingFilters),
-        mapper,
-        getTransform
+        tableColumns
       )
     );
   }, [sortBy, recordings, targetRecordingFilters, setFilteredRecordings]);

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -76,6 +76,7 @@ import { Link, useHistory, useRouteMatch } from 'react-router-dom';
 import { first } from 'rxjs/operators';
 import { RuleDeleteWarningModal } from './RuleDeleteWarningModal';
 import { RuleUploadModal } from './RulesUploadModal';
+import { TableColumn, sortResources } from '@app/utils/utils';
 
 export interface Rule {
   name: string;
@@ -88,12 +89,6 @@ export interface Rule {
   preservedArchives: number;
   maxAgeSeconds: number;
   maxSizeBytes: number;
-}
-
-export interface RuleTableHeader {
-  title?: string;
-  sortable?: boolean;
-  tooltip?: React.ReactNode;
 }
 
 export const ruleObjKeys = [
@@ -118,6 +113,63 @@ export const isRule = (obj: object): boolean => {
   return true;
 };
 
+const tableColumns: TableColumn[] = [
+  {
+    title: 'Enabled',
+    keyPaths: ['enabled'],
+  },
+  {
+    title: 'Name',
+    keyPaths: ['name'],
+    sortable: true,
+  },
+  {
+    title: 'Description',
+    keyPaths: ['description'],
+  },
+  {
+    title: 'Match Expression',
+    keyPaths: ['matchExpression'],
+    sortable: true,
+    tooltip:
+      'A code-snippet expression which must evaluate to a boolean when applied to a given target. If the expression evaluates to true then the rule applies to that target.',
+  },
+  {
+    title: 'Event Specifier',
+    keyPaths: ['eventSpecifier'],
+    tooltip: 'The name and location of the Event Template applied by this rule.',
+  },
+  {
+    title: 'Archival Period',
+    keyPaths: ['archivalPeriodSeconds'],
+    tooltip:
+      'Period in seconds. Cryostat will connect to matching targets at this interval and copy the relevant recording data into its archives. Values less than 1 prevent data from being repeatedly copied into archives - recordings will be started and remain only in target JVM memory.',
+  },
+  {
+    title: 'Initial Delay',
+    keyPaths: ['initialDelaySeconds'],
+    tooltip:
+      'Initial delay in seconds. Cryostat will wait this amount of time before first copying recording data into its archives. Values less than 0 default to equal to the Archival Period. You can set a non-zero Initial Delay with a zero Archival Period, which will start a recording and copy it into archives exactly once after a set delay.',
+  },
+  {
+    title: 'Preserved Archives',
+    keyPaths: ['preservedArchives'],
+    tooltip:
+      'The number of recording copies to be maintained in the Cryostat archives. Cryostat will continue retrieving further archived copies and trimming the oldest copies from the archive to maintain this limit. Values less than 1 prevent data from being copied into archives - recordings will be started and remain only in target JVM memory.',
+  },
+  {
+    title: 'Maximum Age',
+    keyPaths: ['maxAgeSeconds'],
+    tooltip:
+      'The maximum age in seconds for data kept in the JFR recordings started by this rule. Values less than 1 indicate no limit.',
+  },
+  {
+    title: 'Maximum Size',
+    keyPaths: ['maxSizeBytes'],
+    tooltip: 'The maximum size in bytes for JFR recordings started by this rule. Values less than 1 indicate no limit.',
+  },
+];
+
 export interface RuleToDeleteOrDisable {
   rule: Rule;
   type: 'DELETE' | 'DISABLE';
@@ -138,54 +190,6 @@ export const Rules: React.FC<RulesProps> = (_) => {
   const [isUploadModalOpen, setIsUploadModalOpen] = React.useState(false);
   const [ruleToWarn, setRuleToWarn] = React.useState<RuleToDeleteOrDisable | undefined>(undefined);
   const [cleanRuleEnabled, setCleanRuleEnabled] = React.useState(true);
-
-  const tableColumns = React.useMemo(
-    () =>
-      [
-        { title: 'Enabled' },
-        {
-          title: 'Name',
-          sortable: true,
-        },
-        { title: 'Description' },
-        {
-          title: 'Match Expression',
-          sortable: true,
-          tooltip:
-            'A code-snippet expression which must evaluate to a boolean when applied to a given target. If the expression evaluates to true then the rule applies to that target.',
-        },
-        {
-          title: 'Event Specifier',
-          tooltip: 'The name and location of the Event Template applied by this rule.',
-        },
-        {
-          title: 'Archival Period',
-          tooltip:
-            'Period in seconds. Cryostat will connect to matching targets at this interval and copy the relevant recording data into its archives. Values less than 1 prevent data from being repeatedly copied into archives - recordings will be started and remain only in target JVM memory.',
-        },
-        {
-          title: 'Initial Delay',
-          tooltip:
-            'Initial delay in seconds. Cryostat will wait this amount of time before first copying recording data into its archives. Values less than 0 default to equal to the Archival Period. You can set a non-zero Initial Delay with a zero Archival Period, which will start a recording and copy it into archives exactly once after a set delay.',
-        },
-        {
-          title: 'Preserved Archives',
-          tooltip:
-            'The number of recording copies to be maintained in the Cryostat archives. Cryostat will continue retrieving further archived copies and trimming the oldest copies from the archive to maintain this limit. Values less than 1 prevent data from being copied into archives - recordings will be started and remain only in target JVM memory.',
-        },
-        {
-          title: 'Maximum Age',
-          tooltip:
-            'The maximum age in seconds for data kept in the JFR recordings started by this rule. Values less than 1 indicate no limit.',
-        },
-        {
-          title: 'Maximum Size',
-          tooltip:
-            'The maximum size in bytes for JFR recordings started by this rule. Values less than 1 indicate no limit.',
-        },
-      ] as RuleTableHeader[],
-    []
-  );
 
   const getSortParams = React.useCallback(
     (columnIndex: number): ThProps['sort'] => ({
@@ -362,24 +366,14 @@ export const Rules: React.FC<RulesProps> = (_) => {
   }, [setIsUploadModalOpen]);
 
   const ruleRows = React.useMemo(() => {
-    const { index = 1, direction = SortByDirection.asc } = sortBy;
-    let sorted = [...rules];
-
-    const sortableKeys = [
-      'enabled',
-      'name',
-      'description',
-      'matchExpression',
-      'eventSpecifier',
-      'archivalPeriodSeconds',
-      'initialDelaySeconds',
-      'preservedArchives',
-      'maxAgeSeconds',
-      'maxSizeBytes',
-    ];
-    const key = sortableKeys[index];
-    sorted = rules.sort((a: Rule, b: Rule): number => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
-    sorted = direction === SortByDirection.asc ? sorted : sorted.reverse();
+    let sorted = sortResources(
+      {
+        index: sortBy.index ?? 1,
+        direction: sortBy.direction ?? SortByDirection.asc,
+      },
+      rules,
+      tableColumns
+    );
 
     return sorted.map((r: Rule, index) => (
       <Tr key={`automatic-rule-${index}`}>
@@ -448,19 +442,19 @@ export const Rules: React.FC<RulesProps> = (_) => {
           <TableComposable aria-label="Automated Rules Table" variant={TableVariant.compact}>
             <Thead>
               <Tr>
-                {tableColumns.map((col, index) => (
+                {tableColumns.map(({ title, tooltip, sortable }, index) => (
                   <Th
-                    key={`automatic-rule-header-${col.title}`}
-                    sort={col.sortable ? getSortParams(index) : undefined}
+                    key={`automatic-rule-header-${title}`}
+                    sort={sortable ? getSortParams(index) : undefined}
                     info={
-                      col.tooltip
+                      tooltip
                         ? {
-                            tooltip: col.tooltip,
+                            tooltip: tooltip,
                           }
                         : undefined
                     }
                   >
-                    {col.title}
+                    {title}
                   </Th>
                 ))}
               </Tr>

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -235,9 +235,10 @@ export const Rules: React.FC<RulesProps> = (_) => {
     addSubscription(
       context.notificationChannel.messages(NotificationCategory.RuleUpdated).subscribe((msg) => {
         setRules((old) => {
-          const match = old.find((r) => r.name === msg.message.name);
-          if (match) {
-            return [...old.filter((r) => r.name !== msg.message.name), { ...match, enabled: msg.message.enabled }];
+          const matchIndex = old.findIndex((r) => r.name === msg.message.name);
+          if (matchIndex >= 0) {
+            old.splice(matchIndex, 1, { ...old[matchIndex], enabled: msg.message.enabled });
+            return [...old];
           }
           return old;
         });
@@ -360,10 +361,8 @@ export const Rules: React.FC<RulesProps> = (_) => {
   }, [setIsUploadModalOpen]);
 
   const ruleRows = React.useMemo(() => {
-    const { index, direction } = sortBy;
+    const { index = 1, direction = SortByDirection.asc } = sortBy;
     let sorted = [...rules];
-
-    const sortKey = index ?? 1; // default to name
 
     const sortableKeys = [
       'enabled',
@@ -377,7 +376,7 @@ export const Rules: React.FC<RulesProps> = (_) => {
       'maxAgeSeconds',
       'maxSizeBytes',
     ];
-    const key = sortableKeys[sortKey];
+    const key = sortableKeys[index];
     sorted = rules.sort((a: Rule, b: Rule): number => (a[key] < b[key] ? -1 : a[key] > b[key] ? 1 : 0));
     sorted = direction === SortByDirection.asc ? sorted : sorted.reverse();
 

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -41,6 +41,7 @@ import { DeleteOrDisableWarningType } from '@app/Modal/DeleteWarningUtils';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
+import { TableColumn, sortResources } from '@app/utils/utils';
 import {
   Button,
   Card,
@@ -76,7 +77,6 @@ import { Link, useHistory, useRouteMatch } from 'react-router-dom';
 import { first } from 'rxjs/operators';
 import { RuleDeleteWarningModal } from './RuleDeleteWarningModal';
 import { RuleUploadModal } from './RulesUploadModal';
-import { TableColumn, sortResources } from '@app/utils/utils';
 
 export interface Rule {
   name: string;
@@ -366,7 +366,7 @@ export const Rules: React.FC<RulesProps> = (_) => {
   }, [setIsUploadModalOpen]);
 
   const ruleRows = React.useMemo(() => {
-    let sorted = sortResources(
+    const sorted = sortResources(
       {
         index: sortBy.index ?? 1,
         direction: sortBy.direction ?? SortByDirection.asc,
@@ -420,7 +420,7 @@ export const Rules: React.FC<RulesProps> = (_) => {
         </Td>
       </Tr>
     ));
-  }, [rules, sortBy, tableColumns, handleToggle, actionResolver]);
+  }, [rules, sortBy, handleToggle, actionResolver]);
 
   const viewContent = React.useMemo(() => {
     if (isLoading) {
@@ -464,7 +464,7 @@ export const Rules: React.FC<RulesProps> = (_) => {
         </InnerScrollContainer>
       );
     }
-  }, [getSortParams, isLoading, rules, ruleRows, tableColumns]);
+  }, [getSortParams, isLoading, rules, ruleRows]);
 
   return (
     <>

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -237,8 +237,9 @@ export const Rules: React.FC<RulesProps> = (_) => {
         setRules((old) => {
           const matchIndex = old.findIndex((r) => r.name === msg.message.name);
           if (matchIndex >= 0) {
-            old.splice(matchIndex, 1, { ...old[matchIndex], enabled: msg.message.enabled });
-            return [...old];
+            const newArray = [...old];
+            newArray.splice(matchIndex, 1, { ...old[matchIndex], enabled: msg.message.enabled });
+            return newArray;
           }
           return old;
         });

--- a/src/app/SecurityPanel/Credentials/CredentialTestTable.tsx
+++ b/src/app/SecurityPanel/Credentials/CredentialTestTable.tsx
@@ -41,7 +41,7 @@ import { Target } from '@app/Shared/Services/Target.service';
 import { useSearchExpression } from '@app/Topology/Shared/utils';
 import { useSort } from '@app/utils/useSort';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { evaluateTargetWithExpr, portalRoot, sortResources } from '@app/utils/utils';
+import { TableColumn, evaluateTargetWithExpr, portalRoot, sortResources } from '@app/utils/utils';
 import {
   Bullseye,
   Button,
@@ -79,7 +79,7 @@ import {
 import * as React from 'react';
 import { TestPoolContext, useAuthCredential } from './utils';
 
-const tableColumns = [
+const tableColumns: TableColumn[] = [
   {
     title: 'Target',
     keyPaths: ['alias'],
@@ -94,20 +94,6 @@ const tableColumns = [
     title: 'Status',
   },
 ];
-
-const mapper = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].keyPaths;
-  }
-  return undefined;
-};
-
-const getTransform = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].transform;
-  }
-  return undefined;
-};
 
 export interface CredentialTestTableProps {}
 
@@ -147,8 +133,7 @@ export const CredentialTestTable: React.FC<CredentialTestTableProps> = ({ ...pro
           direction: sortBy.direction ?? SortByDirection.asc,
         },
         matchedTargets,
-        mapper,
-        getTransform
+        tableColumns
       ).map((t) => <CredentialTestRow target={t} key={t.connectUrl} filters={filters} searchText={searchText} />),
     [matchedTargets, filters, searchText, sortBy]
   );

--- a/src/app/SecurityPanel/Credentials/CredentialTestTable.tsx
+++ b/src/app/SecurityPanel/Credentials/CredentialTestTable.tsx
@@ -68,6 +68,7 @@ import { ExclamationCircleIcon, SearchIcon, WarningTriangleIcon } from '@pattern
 import {
   InnerScrollContainer,
   OuterScrollContainer,
+  SortByDirection,
   TableComposable,
   Tbody,
   Td,
@@ -140,9 +141,15 @@ export const CredentialTestTable: React.FC<CredentialTestTableProps> = ({ ...pro
 
   const rows = React.useMemo(
     () =>
-      sortResources(sortBy, matchedTargets, mapper, getTransform).map((t) => (
-        <CredentialTestRow target={t} key={t.connectUrl} filters={filters} searchText={searchText} />
-      )),
+      sortResources(
+        {
+          index: sortBy.index ?? 0,
+          direction: sortBy.direction ?? SortByDirection.asc,
+        },
+        matchedTargets,
+        mapper,
+        getTransform
+      ).map((t) => <CredentialTestRow target={t} key={t.connectUrl} filters={filters} searchText={searchText} />),
     [matchedTargets, filters, searchText, sortBy]
   );
 

--- a/src/app/SecurityPanel/Credentials/MatchedTargetsTable.tsx
+++ b/src/app/SecurityPanel/Credentials/MatchedTargetsTable.tsx
@@ -45,7 +45,16 @@ import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { sortResources } from '@app/utils/utils';
 import { EmptyState, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { InnerScrollContainer, TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import {
+  InnerScrollContainer,
+  SortByDirection,
+  TableComposable,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table';
 import _ from 'lodash';
 import * as React from 'react';
 
@@ -121,7 +130,15 @@ export const MatchedTargetsTable: React.FunctionComponent<MatchedTargetsTablePro
   }, [addSubscription, context, context.notificationChannel, setTargets, matchExpression]);
 
   const targetRows = React.useMemo(() => {
-    return sortResources(sortBy, targets, mapper, getTransform).map((target, idx) => {
+    return sortResources(
+      {
+        index: sortBy.index ?? 0,
+        direction: sortBy.direction ?? SortByDirection.asc,
+      },
+      targets,
+      mapper,
+      getTransform
+    ).map((target, idx) => {
       return (
         <Tr key={`target-${idx}`}>
           <Td key={`target-table-row-${idx}_0`}>

--- a/src/app/SecurityPanel/Credentials/MatchedTargetsTable.tsx
+++ b/src/app/SecurityPanel/Credentials/MatchedTargetsTable.tsx
@@ -42,7 +42,7 @@ import { Target } from '@app/Shared/Services/Target.service';
 import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 import { useSort } from '@app/utils/useSort';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { sortResources } from '@app/utils/utils';
+import { TableColumn, sortResources } from '@app/utils/utils';
 import { EmptyState, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import {
@@ -63,7 +63,7 @@ export interface MatchedTargetsTableProps {
   matchExpression: string;
 }
 
-const tableColumns = [
+const tableColumns: TableColumn[] = [
   {
     title: 'Target',
     keyPaths: ['alias'],
@@ -75,20 +75,6 @@ const tableColumns = [
     sortable: true,
   },
 ];
-
-const mapper = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].keyPaths;
-  }
-  return undefined;
-};
-
-const getTransform = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].transform;
-  }
-  return undefined;
-};
 
 export const MatchedTargetsTable: React.FunctionComponent<MatchedTargetsTableProps> = ({ id, matchExpression }) => {
   const context = React.useContext(ServiceContext);
@@ -136,8 +122,7 @@ export const MatchedTargetsTable: React.FunctionComponent<MatchedTargetsTablePro
         direction: sortBy.direction ?? SortByDirection.asc,
       },
       targets,
-      mapper,
-      getTransform
+      tableColumns
     ).map((target, idx) => {
       return (
         <Tr key={`target-${idx}`}>

--- a/src/app/SecurityPanel/Credentials/StoreCredentials.tsx
+++ b/src/app/SecurityPanel/Credentials/StoreCredentials.tsx
@@ -44,7 +44,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetDiscoveryEvent } from '@app/Shared/Services/Targets.service';
 import { useSort } from '@app/utils/useSort';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
-import { evaluateTargetWithExpr, sortResources } from '@app/utils/utils';
+import { TableColumn, evaluateTargetWithExpr, sortResources } from '@app/utils/utils';
 import {
   Badge,
   Button,
@@ -202,7 +202,7 @@ const reducer = (state: State, action) => {
   }
 };
 
-const tableColumns = [
+const tableColumns: TableColumn[] = [
   {
     title: 'Match Expression',
     keyPaths: ['matchExpression'],
@@ -214,15 +214,6 @@ const tableColumns = [
     sortable: true,
   },
 ];
-
-const mapper = (index?: number) => {
-  if (index !== undefined) {
-    return tableColumns[index].keyPaths;
-  }
-  return undefined;
-};
-
-const getTransform = (_index?: number) => undefined;
 
 const tableTitle = 'Stored Credentials';
 
@@ -378,7 +369,7 @@ export const StoreCredentials = () => {
   };
 
   const matchExpressionRows = React.useMemo(() => {
-    return sortResources(sortBy, state.credentials, mapper, getTransform).map((credential, idx) => {
+    return sortResources(sortBy, state.credentials, tableColumns).map((credential, idx) => {
       const isExpanded: boolean = state.expandedCredentials.includes(credential);
       const isChecked: boolean = state.checkedCredentials.includes(credential);
 

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -195,22 +195,39 @@ export class StreamOf<T> {
   }
 }
 
+export interface TableColumn {
+  title: string;
+  keyPaths?: string[];
+  transform?: (value: unknown, _rec: unknown) => unknown;
+  sortable?: boolean;
+  width?: number;
+}
+
+const mapper = (tableColumns: TableColumn[], index?: number) => {
+  if (index === undefined) {
+    return undefined;
+  }
+  return tableColumns[index]?.keyPaths;
+};
+
+const getTransform = (tableColumns: TableColumn[], index?: number) => {
+  if (index === undefined) {
+    return undefined;
+  }
+  return tableColumns[index]?.transform;
+};
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const getValue = (object: any, keyPath: string[]) => {
   return keyPath.reduce((acc, key) => acc[key], object);
 };
 
-export const sortResources = <R>(
-  { index, direction }: ISortBy,
-  resources: R[],
-  mapper: (index?: number) => string[] | undefined,
-  getTransform: (index?: number) => ((value: any, resource: R) => any) | undefined
-): R[] => {
-  const keyPaths = mapper(index);
+export const sortResources = <R>({ index, direction }: ISortBy, resources: R[], tableColumns: TableColumn[]): R[] => {
+  const keyPaths = mapper(tableColumns, index);
   if (!keyPaths || !keyPaths.length) {
     return resources;
   }
-  const transform = getTransform(index);
+  const transform = getTransform(tableColumns, index);
   const sorted = resources.sort((a, b) => {
     let aVal = getValue(a, keyPaths);
     let bVal = getValue(b, keyPaths);

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -197,6 +197,7 @@ export class StreamOf<T> {
 
 export interface TableColumn {
   title: string;
+  tooltip?: string;
   keyPaths?: string[];
   transform?: (value: unknown, _rec: unknown) => unknown;
   sortable?: boolean;
@@ -222,13 +223,14 @@ export const getValue = (object: any, keyPath: string[]) => {
   return keyPath.reduce((acc, key) => acc[key], object);
 };
 
+// Returned a newly sorted array)
 export const sortResources = <R>({ index, direction }: ISortBy, resources: R[], tableColumns: TableColumn[]): R[] => {
   const keyPaths = mapper(tableColumns, index);
   if (!keyPaths || !keyPaths.length) {
-    return resources;
+    return [...resources];
   }
   const transform = getTransform(tableColumns, index);
-  const sorted = resources.sort((a, b) => {
+  const sorted = [...resources].sort((a, b) => {
     let aVal = getValue(a, keyPaths);
     let bVal = getValue(b, keyPaths);
     if (transform) {
@@ -237,7 +239,7 @@ export const sortResources = <R>({ index, direction }: ISortBy, resources: R[], 
     }
     return aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
   });
-  return [...(direction === SortByDirection.asc ? sorted : sorted.reverse())];
+  return direction === SortByDirection.asc ? sorted : sorted.reverse();
 };
 
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -65,8 +65,8 @@ const mockRule: Rule = {
   maxAgeSeconds: 0,
   maxSizeBytes: 0,
 };
-const mockRuleListResponse = [mockRule] as Rule[];
-const mockRuleListEmptyResponse = [] as Rule[];
+const mockRuleListResponse: Rule[] = [mockRule];
+const mockRuleListEmptyResponse: Rule[] = [];
 
 const mockFileUpload = new File([JSON.stringify(mockRule)], `${mockRule.name}.json`, { type: 'application/json' });
 mockFileUpload.text = jest.fn(() => Promise.resolve(JSON.stringify(mockRule)));
@@ -125,14 +125,11 @@ jest
   .mockReturnValueOnce(of(mockDeleteNotification))
   .mockReturnValueOnce(of())
 
-  .mockReturnValueOnce(of()) // update a rule when receiving notification
-  .mockReturnValueOnce(of())
-  .mockReturnValueOnce(of(mockUpdateNotification))
-
   .mockReturnValue(of()); // other tests
 
 describe('<Rules />', () => {
   beforeEach(() => {
+    [updateSpy, uploadSpy, downloadSpy].forEach((spy) => jest.mocked(spy).mockClear());
     history.go(-history.length);
   });
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #960 

## Description of the change:

Saw Max's PR on the issue with rule update causes it to be pushed the end. I think it was due to notification handler just placing it at the end. This PR updates that to retain the position.

However, there are no guarantee that next time it reloads, the row order will be the same. This issue also affects other tables (e.g. archives). But @maxcao13 fixed this by setting initial sort order for rule table (thanks!). So, this PR also includes initial sort for other tables to completely capture this problem. Tho, there is a small implication that any newly added resource (i.e. recording, rule) is subjected to sort and no longer appended to the end.

There is also an issue with sort handler when sorting file names including duplicate suffix (for example, `file.jfr` is sorted after `file.1.jfr`). This also fix that issue (removing file extension) and update all tables to use the latest `sortResources` utility function. 

## Motivation for the change:

See #959 
