### PR TITLE
fix(topology): topology view should auto-refresh if enabled

### DIFF
--- a/src/app/Topology/Topology.tsx
+++ b/src/app/Topology/Topology.tsx
@@ -119,6 +119,17 @@ export const Topology: React.FC<TopologyProps> = ({ ..._props }) => {
     _refreshDiscoveryTree(() => (firstFetchRef.current = true));
   }, [_refreshDiscoveryTree, firstFetchRef]);
 
+  React.useEffect(() => {
+    if (!context.settings.autoRefreshEnabled()) {
+      return;
+    }
+    const id = window.setInterval(
+      () => _refreshDiscoveryTree(),
+      context.settings.autoRefreshPeriod() * context.settings.autoRefreshUnits()
+    );
+    return () => window.clearInterval(id);
+  }, [context.settings, _refreshDiscoveryTree]);
+
   const content = React.useMemo(() => {
     if (error) {
       return (


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #891 

## Description of the change:

Add an effect that set interval to refresh the discovery tree if enabled.

## Motivation for the change:

Missing auto-refresh. If not set, topology view never update if notification socket is not enabled or working.
