### PR TITLE
fix(topology): listview target details need fixed height

### DIFF
--- a/src/app/Topology/styles/base.css
+++ b/src/app/Topology/styles/base.css
@@ -367,6 +367,7 @@ Below CSS rules only apply to Topology components
 .topology__list-view__entity-details {
   background-color: var(--pf-global--palette--white);
   padding: 1em;
+  height: 25em !important;
 }
 
 :where(.pf-theme-dark) .topology__list-view__entity-details {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #891 

## Description of the change:

Added a fixed height for entity detail in Topology List View. This allows list view to show JVM detail.

There was a fix for JVM Detail card in #937 but that PR missed the fix for Topology ListView.

## Screenshots

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/68053619/234149872-7da87635-1ed1-4a35-8e7f-ce0ca655ff4b.png)|![Screenshot from 2023-04-24 21-52-26](https://user-images.githubusercontent.com/68053619/234155048-99c0ac74-f276-41f3-ad30-5e6cd2b05d6c.png)|
