### PR TITLE
fix(settings): hide settings that requires auth for logged-out user

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -95,7 +95,7 @@ import {
   QuestionCircleIcon,
   UserIcon,
 } from '@patternfly/react-icons';
-import * as _ from 'lodash';
+import _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, matchPath, NavLink, useHistory, useLocation } from 'react-router-dom';
@@ -104,6 +104,7 @@ import CryostatJoyride from '../Joyride/CryostatJoyride';
 import { GlobalQuickStartDrawer } from '../QuickStarts/QuickStartDrawer';
 import { AuthModal } from './AuthModal';
 import { SslErrorModal } from './SslErrorModal';
+import { useLogin } from '@app/utils/useLogin';
 interface AppLayoutProps {
   children: React.ReactNode;
 }
@@ -127,7 +128,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const [showSslErrorModal, setShowSslErrorModal] = React.useState(false);
   const [aboutModalOpen, setAboutModalOpen] = React.useState(false);
   const [isNotificationDrawerExpanded, setNotificationDrawerExpanded] = React.useState(false);
-  const [showUserIcon, setShowUserIcon] = React.useState(false);
+  const showUserIcon = useLogin();
   const [showUserInfoDropdown, setShowUserInfoDropdown] = React.useState(false);
   const [showHelpDropdown, setShowHelpDropdown] = React.useState(false);
   const [username, setUsername] = React.useState('');
@@ -286,14 +287,6 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const handleOpenNotificationCenter = React.useCallback(() => {
     notificationsContext.setDrawerState(true);
   }, [notificationsContext]);
-
-  React.useEffect(() => {
-    addSubscription(
-      serviceContext.login.getSessionState().subscribe((sessionState) => {
-        setShowUserIcon(sessionState === SessionState.USER_SESSION);
-      })
-    );
-  }, [serviceContext.login, serviceContext.login.getSessionState, setShowUserIcon, addSubscription]);
 
   const handleLogout = React.useCallback(() => {
     addSubscription(serviceContext.login.setLoggedOut().subscribe());

--- a/src/app/Settings/SettingsUtils.ts
+++ b/src/app/Settings/SettingsUtils.ts
@@ -78,6 +78,7 @@ export interface UserSetting {
   category: SettingTab;
   orderInGroup?: number; // default -1
   featureLevel?: FeatureLevel; // default PRODUCTION
+  authenticated?: boolean;
 }
 
 export const selectTab = (tabKey: SettingTab) => {

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -54,13 +54,12 @@ import Rules from './Rules/Rules';
 import SecurityPanel from './SecurityPanel/SecurityPanel';
 import Settings from './Settings/Settings';
 import { DefaultFallBack, ErrorBoundary } from './Shared/ErrorBoundary';
-import { SessionState } from './Shared/Services/Login.service';
-import { ServiceContext } from './Shared/Services/Services';
 import { FeatureLevel } from './Shared/Services/Settings.service';
 import CreateTarget from './Topology/Actions/CreateTarget';
 import Topology from './Topology/Topology';
 import { useDocumentTitle } from './utils/useDocumentTitle';
-import { useSubscriptions } from './utils/useSubscriptions';
+import { useFeatureLevel } from './utils/useFeatureLevel';
+import { useLogin } from './utils/useLogin';
 import { accessibleRouteChangeHandler } from './utils/utils';
 
 let routeFocusTimer: number;
@@ -270,22 +269,8 @@ const PageNotFound = ({ title }: { title: string }) => {
 export interface AppRoutesProps {}
 
 const AppRoutes: React.FunctionComponent<AppRoutesProps> = (_) => {
-  const context = React.useContext(ServiceContext);
-  const addSubscription = useSubscriptions();
-  const [loggedIn, setLoggedIn] = React.useState(false);
-  const [activeLevel, setActiveLevel] = React.useState(FeatureLevel.PRODUCTION);
-
-  React.useEffect(() => {
-    addSubscription(
-      context.login
-        .getSessionState()
-        .subscribe((sessionState) => setLoggedIn(sessionState === SessionState.USER_SESSION))
-    );
-  }, [addSubscription, context.login, setLoggedIn]);
-
-  React.useLayoutEffect(() => {
-    addSubscription(context.settings.featureLevel().subscribe((featureLevel) => setActiveLevel(featureLevel)));
-  }, [addSubscription, context.settings, setActiveLevel]);
+  const loggedIn = useLogin();
+  const activeLevel = useFeatureLevel();
 
   return (
     <LastLocationProvider>

--- a/src/app/utils/useFeatureLevel.ts
+++ b/src/app/utils/useFeatureLevel.ts
@@ -45,7 +45,7 @@ export function useFeatureLevel() {
   const subRef = React.useRef<Subscription>();
   const services = React.useContext(ServiceContext);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     subRef.current = services.settings.featureLevel().subscribe(setFeatureLevel);
     return () => subRef.current && subRef.current.unsubscribe();
   }, [subRef, services.settings]);

--- a/src/app/utils/useLogin.ts
+++ b/src/app/utils/useLogin.ts
@@ -35,33 +35,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
-import { AutomatedAnalysisConfigForm } from '@app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm';
-import { NO_TARGET } from '@app/Shared/Services/Target.service';
-import { TargetSelect } from '@app/TargetSelect/TargetSelect';
-import { Stack, StackItem } from '@patternfly/react-core';
+import { SessionState } from '@app/Shared/Services/Login.service';
+import { ServiceContext } from '@app/Shared/Services/Services';
 import * as React from 'react';
-import { of } from 'rxjs';
-import { SettingTab, UserSetting } from './SettingsUtils';
 
-const Component = () => {
-  const [target, setTarget] = React.useState(NO_TARGET);
-  const _targetAsObs = React.useMemo(() => of(target), [target]);
+export const useLogin = () => {
+  const context = React.useContext(ServiceContext);
+  const [loggedIn, setLoggedIn] = React.useState(false);
 
-  return (
-    <Stack hasGutter>
-      <StackItem>
-        <TargetSelect simple onSelect={setTarget} />
-      </StackItem>
-      <AutomatedAnalysisConfigForm targetObs={_targetAsObs} />
-    </Stack>
-  );
-};
+  React.useEffect(() => {
+    const sub = context.login
+      .getSessionState()
+      .subscribe((sessionState) => setLoggedIn(sessionState === SessionState.USER_SESSION));
 
-export const AutomatedAnalysisConfig: UserSetting = {
-  titleKey: 'SETTINGS.AUTOMATED_ANALYSIS_CONFIG.TITLE',
-  descConstruct: 'SETTINGS.AUTOMATED_ANALYSIS_CONFIG.DESCRIPTION',
-  content: Component,
-  category: SettingTab.DASHBOARD,
-  authenticated: true,
+    return () => sub.unsubscribe();
+  }, [context.login, setLoggedIn]);
+
+  return loggedIn;
 };

--- a/src/test/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/test/Settings/__snapshots__/Settings.test.tsx.snap
@@ -543,57 +543,6 @@ exports[`<Settings/> renders correctly 1`] = `
                               data-ouia-component-type="PF4/Title"
                               data-ouia-safe={true}
                             >
-                              Automated Analysis Recording Configuration
-                            </h2>
-                          </span>
-                        </label>
-                         
-                      </div>
-                      <div
-                        className="pf-c-form__group-control"
-                      >
-                        <div
-                          className="pf-c-helper-text"
-                        >
-                          <div
-                            className="pf-c-helper-text__item"
-                          >
-                            <span
-                              className="pf-c-helper-text__item-text"
-                            >
-                              Set the recording configuration for automated analysis recordings. You may want smaller or larger values for max-age and max-size depending on how recent you want events to be recorded from the analysis.
-                            </span>
-                          </div>
-                        </div>
-                        <p
-                          className=""
-                          data-ouia-component-id="OUIA-Generated-Text-7"
-                          data-ouia-component-type="PF4/Text"
-                          data-ouia-safe={true}
-                          data-pf-content={true}
-                        >
-                          Automated Analysis Config Component
-                        </p>
-                      </div>
-                    </div>
-                    <div
-                      className="pf-c-form__group"
-                    >
-                      <div
-                        className="pf-c-form__group-label"
-                      >
-                        <label
-                          className="pf-c-form__label"
-                        >
-                          <span
-                            className="pf-c-form__label-text"
-                          >
-                            <h2
-                              className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-8"
-                              data-ouia-component-type="PF4/Title"
-                              data-ouia-safe={true}
-                            >
                               Dashboard Metrics Configuration
                             </h2>
                           </span>
@@ -618,7 +567,7 @@ exports[`<Settings/> renders correctly 1`] = `
                         </div>
                         <p
                           className=""
-                          data-ouia-component-id="OUIA-Generated-Text-8"
+                          data-ouia-component-id="OUIA-Generated-Text-7"
                           data-ouia-component-type="PF4/Text"
                           data-ouia-safe={true}
                           data-pf-content={true}
@@ -650,7 +599,7 @@ exports[`<Settings/> renders correctly 1`] = `
                           >
                             <h2
                               className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-9"
+                              data-ouia-component-id="OUIA-Generated-Title-8"
                               data-ouia-component-type="PF4/Title"
                               data-ouia-safe={true}
                             >
@@ -680,7 +629,7 @@ exports[`<Settings/> renders correctly 1`] = `
                         </div>
                         <p
                           className=""
-                          data-ouia-component-id="OUIA-Generated-Text-9"
+                          data-ouia-component-id="OUIA-Generated-Text-8"
                           data-ouia-component-type="PF4/Text"
                           data-ouia-safe={true}
                           data-pf-content={true}
@@ -703,7 +652,7 @@ exports[`<Settings/> renders correctly 1`] = `
                           >
                             <h2
                               className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-10"
+                              data-ouia-component-id="OUIA-Generated-Title-9"
                               data-ouia-component-type="PF4/Title"
                               data-ouia-safe={true}
                             >
@@ -731,7 +680,7 @@ exports[`<Settings/> renders correctly 1`] = `
                         </div>
                         <p
                           className=""
-                          data-ouia-component-id="OUIA-Generated-Text-10"
+                          data-ouia-component-id="OUIA-Generated-Text-9"
                           data-ouia-component-type="PF4/Text"
                           data-ouia-safe={true}
                           data-pf-content={true}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #981 

## Description of the change:

Annotate each setting (requires auth) with `authenticated` field. These settings are hidden when the user is logged out.

When the user logs in, the settings are shown as usual.

## Motivation for the change:

See #981 

## Screenshots

|Before|After|
|--|--|
|![Screenshot from 2023-04-24 23-53-38](https://user-images.githubusercontent.com/68053619/234182019-a206b809-b889-4902-b2e6-c73ef2022f78.png)|![Screenshot from 2023-04-25 01-25-06](https://user-images.githubusercontent.com/68053619/234182005-9cee3fe6-028c-4740-9384-b6d14f404aaa.png)|

