### PR TITLE
fix(custom-target): loading state should show

### DIFF
--- a/src/app/Topology/Actions/CreateTarget.tsx
+++ b/src/app/Topology/Actions/CreateTarget.tsx
@@ -422,13 +422,13 @@ export const CreateTarget: React.FC<CreateTargetProps> = ({ prefilled, ..._props
                 </FormGroup>
               </GridItem>
               <GridItem {...responsiveSpans[1]} order={{ default: '1', lg: '1', xl: '1', md: '1' }}>
-                <SampleNodeDonut target={target} validation={validation} testing={loading} onClick={testTarget} />
+                <SampleNodeDonut target={target} validation={validation} testing={testing} onClick={testTarget} />
               </GridItem>
             </Grid>
             <ActionGroup>
               <Button
                 variant="primary"
-                isDisabled={!connectUrl || validConnectUrl !== ValidatedOptions.success || loading}
+                isDisabled={!connectUrl || validConnectUrl !== ValidatedOptions.success || loading || testing}
                 onClick={handleSubmit}
                 {...createButtonLoadingProps}
                 data-quickstart-id="ct-create-btn"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes:  #987 

## Description of the change:

- Sample Node loading state should be shown. Previously, the wrong state was passed into the sample node.

## Motivation for the change:

See #987

## How to manually test:

1. Use the `connection URL`: `service:jmx:rmi:///jndi/rmi://localhost:10001/jmxrmi`
2. Click sample node to start testing -> loading state is shown.