### PR TITLE
fix(archives): convert jvmId to subdirectoryName for web-client requests

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -44,11 +44,11 @@ import { Notification, NotificationsContext } from '@app/Notifications/Notificat
 import { IAppRoute, navGroups, routes } from '@app/routes';
 import { selectTab, SettingTab, tabAsParam, ThemeSetting } from '@app/Settings/SettingsUtils';
 import { DynamicFeatureFlag, FeatureFlag } from '@app/Shared/FeatureFlag/FeatureFlag';
-import { SessionState } from '@app/Shared/Services/Login.service';
 import { NotificationCategory } from '@app/Shared/Services/NotificationChannel.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
 import { saveToLocalStorage } from '@app/utils/LocalStorage';
+import { useLogin } from '@app/utils/useLogin';
 import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { useTheme } from '@app/utils/useTheme';
 import { cleanDataId, isAssetNew, openTabForUrl, portalRoot } from '@app/utils/utils';
@@ -104,7 +104,6 @@ import CryostatJoyride from '../Joyride/CryostatJoyride';
 import { GlobalQuickStartDrawer } from '../QuickStarts/QuickStartDrawer';
 import { AuthModal } from './AuthModal';
 import { SslErrorModal } from './SslErrorModal';
-import { useLogin } from '@app/utils/useLogin';
 interface AppLayoutProps {
   children: React.ReactNode;
 }

--- a/src/app/Settings/Settings.tsx
+++ b/src/app/Settings/Settings.tsx
@@ -61,9 +61,8 @@ import { css } from '@patternfly/react-styles';
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router-dom';
-import { paramAsTab, SettingTab, tabAsParam, _TransformedUserSetting } from './SettingsUtils';
-import { AutoRefresh } from './AutoRefresh';
 import { AutomatedAnalysisConfig } from './AutomatedAnalysisConfig';
+import { AutoRefresh } from './AutoRefresh';
 import { ChartCardsConfig } from './ChartCardsConfig';
 import { CredentialsStorage } from './CredentialsStorage';
 import { DatetimeControl } from './DatetimeControl';
@@ -71,6 +70,7 @@ import { DeletionDialogControl } from './DeletionDialogControl';
 import { FeatureLevels } from './FeatureLevels';
 import { Language } from './Language';
 import { NotificationControl } from './NotificationControl';
+import { paramAsTab, SettingTab, tabAsParam, _TransformedUserSetting } from './SettingsUtils';
 import { Theme } from './Theme';
 import { WebSocketDebounce } from './WebSocketDebounce';
 

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -42,7 +42,7 @@ import { Notifications } from '@app/Notifications/Notifications';
 import { RecordingLabel } from '@app/RecordingMetadata/RecordingLabel';
 import { Rule } from '@app/Rules/Rules';
 import { EnvironmentNode } from '@app/Topology/typings';
-import { createBlobURL } from '@app/utils/utils';
+import { createBlobURL, jvmIdToSubdirectoryName } from '@app/utils/utils';
 import { ValidatedOptions } from '@patternfly/react-core';
 import _ from 'lodash';
 import { EMPTY, forkJoin, from, Observable, ObservableInput, of, ReplaySubject, shareReplay, throwError } from 'rxjs';
@@ -513,7 +513,8 @@ export class ApiService {
   }
 
   // from file system path functions
-  uploadArchivedRecordingToGrafanaFromPath(subdirectoryName: string, recordingName: string): Observable<boolean> {
+  uploadArchivedRecordingToGrafanaFromPath(jvmId: string, recordingName: string): Observable<boolean> {
+    const subdirectoryName = jvmIdToSubdirectoryName(jvmId);
     return this.sendRequest('beta', `fs/recordings/${subdirectoryName}/${encodeURIComponent(recordingName)}/upload`, {
       method: 'POST',
     }).pipe(
@@ -521,7 +522,8 @@ export class ApiService {
       first()
     );
   }
-  deleteArchivedRecordingFromPath(subdirectoryName: string, recordingName: string): Observable<boolean> {
+  deleteArchivedRecordingFromPath(jvmId: string, recordingName: string): Observable<boolean> {
+    const subdirectoryName = jvmIdToSubdirectoryName(jvmId);
     return this.sendRequest('beta', `fs/recordings/${subdirectoryName}/${encodeURIComponent(recordingName)}`, {
       method: 'DELETE',
     }).pipe(
@@ -538,11 +540,8 @@ export class ApiService {
     return JSON.stringify(rawLabels);
   }
 
-  postRecordingMetadataFromPath(
-    subdirectoryName: string,
-    recordingName: string,
-    labels: RecordingLabel[]
-  ): Observable<boolean> {
+  postRecordingMetadataFromPath(jvmId: string, recordingName: string, labels: RecordingLabel[]): Observable<boolean> {
+    const subdirectoryName = jvmIdToSubdirectoryName(jvmId);
     return this.sendRequest(
       'beta',
       `fs/recordings/${subdirectoryName}/${encodeURIComponent(recordingName)}/metadata/labels`,

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -36,6 +36,7 @@
  * SOFTWARE.
  */
 
+import { UPLOADS_SUBDIRECTORY } from '@app/Shared/Services/Api.service';
 import { ISortBy, SortByDirection } from '@patternfly/react-table';
 import _ from 'lodash';
 import { useHistory } from 'react-router-dom';
@@ -308,4 +309,41 @@ export const isAssetNew = (currVerStr: string) => {
   }
   // Invalid (old) version is ignored.
   return !oldVer || compareSemVer(currVer, oldVer) > 0;
+};
+
+export const utf8ToBase32 = (str: string): string => {
+  const encoder = new TextEncoder();
+  const byteArray = encoder.encode(str);
+  const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  let bits = 0;
+  let value = 0;
+  let base32 = '';
+
+  for (let i = 0; i < byteArray.length; i++) {
+    value = (value << 8) | byteArray[i];
+    bits += 8;
+    while (bits >= 5) {
+      bits -= 5;
+      base32 += BASE32_ALPHABET[(value >>> bits) & 0x1f];
+    }
+  }
+
+  if (bits > 0) {
+    value <<= 5 - bits;
+    base32 += BASE32_ALPHABET[value & 0x1f];
+  }
+
+  const paddingLength = base32.length % 8 !== 0 ? 8 - (base32.length % 8) : 0;
+  for (let i = 0; i < paddingLength; i++) {
+    base32 += '=';
+  }
+
+  return base32;
+};
+
+export const jvmIdToSubdirectoryName = (jvmId: string): string => {
+  if (jvmId === UPLOADS_SUBDIRECTORY || jvmId === 'lost') {
+    return jvmId;
+  }
+  return utf8ToBase32(jvmId);
 };


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat/pull/1457

## Description of the change:
Forgot that the web-client actually uses the archived directory get response data to request for editing labels, viewing reports, and reviewing recordings in Grafana, per target. Particularly the subdirectoryName, since it is now replaced by the jvmId, should be converted like how the backend does it.

Before this change, the requests failed.

## How to manually test:
1. Go to archives view: try editing labels, view report, viewing recording in grafana
