### PR TITLE
fix(about): route /about should show without auth

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -92,6 +92,7 @@ const routes: IAppRoute[] = [
     title: 'About',
     description: 'Get information, help, or support for Cryostat.',
     navGroup: OVERVIEW,
+    anonymous: true,
   },
   {
     component: Dashboard,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #994 

## Description of the change:

Allow seeing `/about` route without logging in.

## Motivation for the change:

See #994 

## Screenshots

![Screenshot from 2023-04-25 16-06-09](https://user-images.githubusercontent.com/68053619/234390725-00e6b021-bc2b-4361-b5c7-3b130431546f.png)

