### PR TITLE
fix(uploads): fix archive upload modal invalid labels popover 

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -274,6 +274,10 @@
       "TITLE": "Quick Starts"
     }
   },
+  "RecordingLabelFields": {
+    "INVALID_UPLOADS_one": "The following file did not contain valid recording metadata:",
+    "INVALID_UPLOADS_other": "The following files did not contain valid recording metadata:"
+  },
   "SETTINGS": {
     "AUTO_REFRESH": {
       "CHECKBOX_LABEL": "Enabled",

--- a/src/app/Archives/ArchiveUploadModal.tsx
+++ b/src/app/Archives/ArchiveUploadModal.tsx
@@ -167,7 +167,6 @@ export const ArchiveUploadModal: React.FC<ArchiveUploadModalProps> = ({ onClose,
 
   return (
     <Modal
-      appendTo={portalRoot}
       isOpen={props.visible}
       variant={ModalVariant.large}
       showClose={true}

--- a/src/app/RecordingMetadata/RecordingLabel.tsx
+++ b/src/app/RecordingMetadata/RecordingLabel.tsx
@@ -66,8 +66,9 @@ export const parseLabelsFromFile = (file: File): Observable<RecordingLabel[]> =>
               value: labelObj[key],
             });
           });
+          return labels;
         }
-        return labels;
+        throw new Error('No labels found in file');
       })
   );
 };

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -55,6 +55,7 @@ import {
 } from '@patternfly/react-core';
 import { CloseIcon, ExclamationCircleIcon, FileIcon, PlusCircleIcon, UploadIcon } from '@patternfly/react-icons';
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { catchError, Observable, of, zip } from 'rxjs';
 
 export interface RecordingLabelFieldsProps {
@@ -82,6 +83,7 @@ export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsP
 }) => {
   const inputRef = React.useRef<HTMLInputElement>(null); // Use ref to refer to child component
   const addSubscription = useSubscriptions();
+  const { t } = useTranslation();
 
   const [loading, setLoading] = React.useState(false);
   const [invalidUploads, setInvalidUploads] = React.useState<string[]>([]);
@@ -217,9 +219,9 @@ export const RecordingLabelFields: React.FunctionComponent<RecordingLabelFieldsP
             headerIcon={<ExclamationCircleIcon />}
             bodyContent={
               <>
-                <Text component="h4">{`The following file${
-                  invalidUploads.length > 1 ? 's' : ''
-                } did not contain valid recording metadata:`}</Text>
+                <Text component="h4">
+                  {t('RecordingLabelFields.INVALID_UPLOADS', { count: invalidUploads.length })}
+                </Text>
                 <List>
                   {invalidUploads.map((uploadName) => (
                     <ListItem key={uploadName} icon={<FileIcon />}>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #997

## Description of the change:
The change reverts ArchiveUploadModal to append to document body for the popover to show again. I cannot figure out quite the reason why appending the modal to portalRoot makes popperjs think that the popper is being cutoff in some way.

According to an [article](https://dev.to/atomiks/everything-i-know-about-positioning-poppers-tooltips-popovers-dropdowns-in-uis-3nkl) I read: 
```
Popper attaches attributes in the following cases:

    data-popper-escaped: When the popper escapes the reference element's clipping container (it appears detached)
    data-popper-reference-hidden: When the reference element is hidden from view (it appears attached to nothing)
```
But it doesn't seem the reference is ever hidden from view, even when the expandedContent is expanded, and it doesn't make sense why having the modal append to portalRoot vs root/body would add these attributes.

For now, appending the modal to document body is completely ok.

The change also shows the popover if invalid jsons that dont have the `label` field are uploaded.

## How to manually test:
1. go to `Archives` -> `Upload` -> Test out bad metadata json files e.g. `{ASDfsadf}` and `{"labels":{"asdf"""":"asdf"}}`