### PR TITLE
fix(settings): set unmountOnExit behaviour for setting groups

### DIFF
--- a/src/app/Settings/Settings.tsx
+++ b/src/app/Settings/Settings.tsx
@@ -193,12 +193,10 @@ export const Settings: React.FC<SettingsProps> = (_) => {
               </Tabs>
             </SidebarPanel>
             <SidebarContent>
-              {settingGroups.map((grp) => (
-                <div
-                  key={`${grp.groupKey}-setting`}
-                  className={css('settings__content', grp.groupKey === activeTab ? 'active' : '')}
-                >
-                  <Form>
+              {settingGroups
+                .filter((grp) => grp.groupKey === activeTab)
+                .map((grp) => (
+                  <Form key={`${grp.groupKey}-setting`} className="settings__content">
                     {grp.settings.map((s, index) => (
                       <FeatureFlag level={s.featureLevel} key={`${grp.groupLabel}-${s.title}-${index}-flag`}>
                         <FormGroup
@@ -232,8 +230,7 @@ export const Settings: React.FC<SettingsProps> = (_) => {
                       </FeatureFlag>
                     ))}
                   </Form>
-                </div>
-              ))}
+                ))}
             </SidebarContent>
           </Sidebar>
         </Card>

--- a/src/app/Shared/TargetSelect.tsx
+++ b/src/app/Shared/TargetSelect.tsx
@@ -213,7 +213,7 @@ export const TargetSelect: React.FunctionComponent<TargetSelectProps> = ({ onSel
               selections={selected.alias || selected.connectUrl}
               isFlipEnabled={true}
               menuAppendTo="parent"
-              maxHeight="16em"
+              maxHeight="20em"
               isOpen={isDropdownOpen}
               aria-label="Select Target"
             >

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -523,11 +523,6 @@ input[type=number].datetime-picker__number-input {
 
 .settings__content {
   padding: 2ch;
-  display: none; /* only show when active */
-}
-
-.settings__content.active {
-  display: block;
 }
 
 .expandable-form__accordion-toggle-block {

--- a/src/test/Settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/test/Settings/__snapshots__/Settings.test.tsx.snap
@@ -185,512 +185,113 @@ exports[`<Settings/> renders correctly 1`] = `
               <div
                 className="pf-c-sidebar__content"
               >
-                <div
-                  className="settings__content active"
+                <form
+                  className="pf-c-form settings__content"
+                  noValidate={true}
                 >
-                  <form
-                    className="pf-c-form"
-                    noValidate={true}
+                  <div
+                    className="pf-c-form__group"
                   >
                     <div
-                      className="pf-c-form__group"
+                      className="pf-c-form__group-label"
                     >
-                      <div
-                        className="pf-c-form__group-label"
+                      <label
+                        className="pf-c-form__label"
                       >
-                        <label
-                          className="pf-c-form__label"
+                        <span
+                          className="pf-c-form__label-text"
                         >
-                          <span
-                            className="pf-c-form__label-text"
+                          <h2
+                            className="pf-c-title pf-m-lg"
+                            data-ouia-component-id="OUIA-Generated-Title-1"
+                            data-ouia-component-type="PF4/Title"
+                            data-ouia-safe={true}
                           >
-                            <h2
-                              className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-1"
-                              data-ouia-component-type="PF4/Title"
-                              data-ouia-safe={true}
-                            >
-                              Date & Time
-                            </h2>
-                          </span>
-                        </label>
-                         
-                      </div>
-                      <div
-                        className="pf-c-form__group-control"
-                      >
-                        <div
-                          className="pf-c-helper-text"
-                        >
-                          <div
-                            className="pf-c-helper-text__item"
-                          >
-                            <span
-                              className="pf-c-helper-text__item-text"
-                            >
-                              
-                            </span>
-                          </div>
-                        </div>
-                        <p
-                          className=""
-                          data-ouia-component-id="OUIA-Generated-Text-1"
-                          data-ouia-component-type="PF4/Text"
-                          data-ouia-safe={true}
-                          data-pf-content={true}
-                        >
-                          DatetimeControl Component
-                        </p>
-                      </div>
+                            Date & Time
+                          </h2>
+                        </span>
+                      </label>
+                       
                     </div>
                     <div
-                      className="pf-c-form__group"
+                      className="pf-c-form__group-control"
                     >
                       <div
-                        className="pf-c-form__group-label"
-                      >
-                        <label
-                          className="pf-c-form__label"
-                        >
-                          <span
-                            className="pf-c-form__label-text"
-                          >
-                            <h2
-                              className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-2"
-                              data-ouia-component-type="PF4/Title"
-                              data-ouia-safe={true}
-                            >
-                              Theme
-                            </h2>
-                          </span>
-                        </label>
-                         
-                      </div>
-                      <div
-                        className="pf-c-form__group-control"
+                        className="pf-c-helper-text"
                       >
                         <div
-                          className="pf-c-helper-text"
+                          className="pf-c-helper-text__item"
                         >
-                          <div
-                            className="pf-c-helper-text__item"
+                          <span
+                            className="pf-c-helper-text__item-text"
                           >
-                            <span
-                              className="pf-c-helper-text__item-text"
-                            >
-                              Set the current theme for web console.
-                            </span>
-                          </div>
+                            
+                          </span>
                         </div>
-                        <p
-                          className=""
-                          data-ouia-component-id="OUIA-Generated-Text-2"
-                          data-ouia-component-type="PF4/Text"
-                          data-ouia-safe={true}
-                          data-pf-content={true}
-                        >
-                          Theme Component
-                        </p>
                       </div>
+                      <p
+                        className=""
+                        data-ouia-component-id="OUIA-Generated-Text-1"
+                        data-ouia-component-type="PF4/Text"
+                        data-ouia-safe={true}
+                        data-pf-content={true}
+                      >
+                        DatetimeControl Component
+                      </p>
                     </div>
-                  </form>
-                </div>
-                <div
-                  className="settings__content"
-                >
-                  <form
-                    className="pf-c-form"
-                    noValidate={true}
+                  </div>
+                  <div
+                    className="pf-c-form__group"
                   >
                     <div
-                      className="pf-c-form__group"
+                      className="pf-c-form__group-label"
                     >
-                      <div
-                        className="pf-c-form__group-label"
+                      <label
+                        className="pf-c-form__label"
                       >
-                        <label
-                          className="pf-c-form__label"
+                        <span
+                          className="pf-c-form__label-text"
                         >
-                          <span
-                            className="pf-c-form__label-text"
+                          <h2
+                            className="pf-c-title pf-m-lg"
+                            data-ouia-component-id="OUIA-Generated-Title-2"
+                            data-ouia-component-type="PF4/Title"
+                            data-ouia-safe={true}
                           >
-                            <h2
-                              className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-3"
-                              data-ouia-component-type="PF4/Title"
-                              data-ouia-safe={true}
-                            >
-                              WebSocket Connection Debounce
-                            </h2>
-                          </span>
-                        </label>
-                         
-                      </div>
-                      <div
-                        className="pf-c-form__group-control"
-                      >
-                        <div
-                          className="pf-c-helper-text"
-                        >
-                          <div
-                            className="pf-c-helper-text__item"
-                          >
-                            <span
-                              className="pf-c-helper-text__item-text"
-                            >
-                              Set the debounce time (in milliseconds) used when establishing WebSocket connections. Increase this time if the web-interface repeatedly displays WebSocket connection/disconnection messages. Decrease this time if the web-interface takes a long time to populate on startup.
-                            </span>
-                          </div>
-                        </div>
-                        <p
-                          className=""
-                          data-ouia-component-id="OUIA-Generated-Text-3"
-                          data-ouia-component-type="PF4/Text"
-                          data-ouia-safe={true}
-                          data-pf-content={true}
-                        >
-                          WebSocket Debounce Component
-                        </p>
-                      </div>
+                            Theme
+                          </h2>
+                        </span>
+                      </label>
+                       
                     </div>
                     <div
-                      className="pf-c-form__group"
+                      className="pf-c-form__group-control"
                     >
                       <div
-                        className="pf-c-form__group-label"
-                      >
-                        <label
-                          className="pf-c-form__label"
-                        >
-                          <span
-                            className="pf-c-form__label-text"
-                          >
-                            <h2
-                              className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-4"
-                              data-ouia-component-type="PF4/Title"
-                              data-ouia-safe={true}
-                            >
-                              Auto-Refresh
-                            </h2>
-                          </span>
-                        </label>
-                         
-                      </div>
-                      <div
-                        className="pf-c-form__group-control"
+                        className="pf-c-helper-text"
                       >
                         <div
-                          className="pf-c-helper-text"
-                        >
-                          <div
-                            className="pf-c-helper-text__item"
-                          >
-                            <span
-                              className="pf-c-helper-text__item-text"
-                            >
-                              Set the refresh period for content views. Views normally update dynamically via WebSocket notifications, so this should not be needed unless WebSockets are not working.
-                            </span>
-                          </div>
-                        </div>
-                        <p
-                          className=""
-                          data-ouia-component-id="OUIA-Generated-Text-4"
-                          data-ouia-component-type="PF4/Text"
-                          data-ouia-safe={true}
-                          data-pf-content={true}
-                        >
-                          AutoRefresh Component
-                        </p>
-                      </div>
-                    </div>
-                  </form>
-                </div>
-                <div
-                  className="settings__content"
-                >
-                  <form
-                    className="pf-c-form"
-                    noValidate={true}
-                  >
-                    <div
-                      className="pf-c-form__group"
-                    >
-                      <div
-                        className="pf-c-form__group-label"
-                      >
-                        <label
-                          className="pf-c-form__label"
+                          className="pf-c-helper-text__item"
                         >
                           <span
-                            className="pf-c-form__label-text"
+                            className="pf-c-helper-text__item-text"
                           >
-                            <h2
-                              className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-5"
-                              data-ouia-component-type="PF4/Title"
-                              data-ouia-safe={true}
-                            >
-                              Notifications
-                            </h2>
+                            Set the current theme for web console.
                           </span>
-                        </label>
-                         
-                      </div>
-                      <div
-                        className="pf-c-form__group-control"
-                      >
-                        <div
-                          className="pf-c-helper-text"
-                        >
-                          <div
-                            className="pf-c-helper-text__item"
-                          >
-                            <span
-                              className="pf-c-helper-text__item-text"
-                            >
-                              
-                            </span>
-                          </div>
                         </div>
-                        <p
-                          className=""
-                          data-ouia-component-id="OUIA-Generated-Text-5"
-                          data-ouia-component-type="PF4/Text"
-                          data-ouia-safe={true}
-                          data-pf-content={true}
-                        >
-                          Notification Control Component
-                        </p>
                       </div>
+                      <p
+                        className=""
+                        data-ouia-component-id="OUIA-Generated-Text-2"
+                        data-ouia-component-type="PF4/Text"
+                        data-ouia-safe={true}
+                        data-pf-content={true}
+                      >
+                        Theme Component
+                      </p>
                     </div>
-                    <div
-                      className="pf-c-form__group"
-                    >
-                      <div
-                        className="pf-c-form__group-label"
-                      >
-                        <label
-                          className="pf-c-form__label"
-                        >
-                          <span
-                            className="pf-c-form__label-text"
-                          >
-                            <h2
-                              className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-6"
-                              data-ouia-component-type="PF4/Title"
-                              data-ouia-safe={true}
-                            >
-                              Show Deletion Dialogs
-                            </h2>
-                          </span>
-                        </label>
-                         
-                      </div>
-                      <div
-                        className="pf-c-form__group-control"
-                      >
-                        <div
-                          className="pf-c-helper-text"
-                        >
-                          <div
-                            className="pf-c-helper-text__item"
-                          >
-                            <span
-                              className="pf-c-helper-text__item-text"
-                            >
-                              
-                            </span>
-                          </div>
-                        </div>
-                        <p
-                          className=""
-                          data-ouia-component-id="OUIA-Generated-Text-6"
-                          data-ouia-component-type="PF4/Text"
-                          data-ouia-safe={true}
-                          data-pf-content={true}
-                        >
-                          Deletion Dialog Control Component
-                        </p>
-                      </div>
-                    </div>
-                  </form>
-                </div>
-                <div
-                  className="settings__content"
-                >
-                  <form
-                    className="pf-c-form"
-                    noValidate={true}
-                  >
-                    <div
-                      className="pf-c-form__group"
-                    >
-                      <div
-                        className="pf-c-form__group-label"
-                      >
-                        <label
-                          className="pf-c-form__label"
-                        >
-                          <span
-                            className="pf-c-form__label-text"
-                          >
-                            <h2
-                              className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-7"
-                              data-ouia-component-type="PF4/Title"
-                              data-ouia-safe={true}
-                            >
-                              Dashboard Metrics Configuration
-                            </h2>
-                          </span>
-                        </label>
-                         
-                      </div>
-                      <div
-                        className="pf-c-form__group-control"
-                      >
-                        <div
-                          className="pf-c-helper-text"
-                        >
-                          <div
-                            className="pf-c-helper-text__item"
-                          >
-                            <span
-                              className="pf-c-helper-text__item-text"
-                            >
-                              
-                            </span>
-                          </div>
-                        </div>
-                        <p
-                          className=""
-                          data-ouia-component-id="OUIA-Generated-Text-7"
-                          data-ouia-component-type="PF4/Text"
-                          data-ouia-safe={true}
-                          data-pf-content={true}
-                        >
-                          Chart Cards Config Component
-                        </p>
-                      </div>
-                    </div>
-                  </form>
-                </div>
-                <div
-                  className="settings__content"
-                >
-                  <form
-                    className="pf-c-form"
-                    noValidate={true}
-                  >
-                    <div
-                      className="pf-c-form__group"
-                    >
-                      <div
-                        className="pf-c-form__group-label"
-                      >
-                        <label
-                          className="pf-c-form__label"
-                        >
-                          <span
-                            className="pf-c-form__label-text"
-                          >
-                            <h2
-                              className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-8"
-                              data-ouia-component-type="PF4/Title"
-                              data-ouia-safe={true}
-                            >
-                              Credentials Storage
-                            </h2>
-                          </span>
-                        </label>
-                         
-                      </div>
-                      <div
-                        className="pf-c-form__group-control"
-                      >
-                        <div
-                          className="pf-c-helper-text"
-                        >
-                          <div
-                            className="pf-c-helper-text__item"
-                          >
-                            <span
-                              className="pf-c-helper-text__item-text"
-                            >
-                              When you attempt to connect to a target application which requires authentication, you will see a prompt for credentials to present to the application and complete the connection. You can choose where to persist these credentials. Any credentials added through the 
-                              Security
-                               panel will always be stored in Cryostat backend encrypted storage.
-                            </span>
-                          </div>
-                        </div>
-                        <p
-                          className=""
-                          data-ouia-component-id="OUIA-Generated-Text-8"
-                          data-ouia-component-type="PF4/Text"
-                          data-ouia-safe={true}
-                          data-pf-content={true}
-                        >
-                          Credentials Storage Component
-                        </p>
-                      </div>
-                    </div>
-                    <div
-                      className="pf-c-form__group"
-                    >
-                      <div
-                        className="pf-c-form__group-label"
-                      >
-                        <label
-                          className="pf-c-form__label"
-                        >
-                          <span
-                            className="pf-c-form__label-text"
-                          >
-                            <h2
-                              className="pf-c-title pf-m-lg"
-                              data-ouia-component-id="OUIA-Generated-Title-9"
-                              data-ouia-component-type="PF4/Title"
-                              data-ouia-safe={true}
-                            >
-                              Feature Level
-                            </h2>
-                          </span>
-                        </label>
-                         
-                      </div>
-                      <div
-                        className="pf-c-form__group-control"
-                      >
-                        <div
-                          className="pf-c-helper-text"
-                        >
-                          <div
-                            className="pf-c-helper-text__item"
-                          >
-                            <span
-                              className="pf-c-helper-text__item-text"
-                            >
-                              Control which graphical features appear in the application.
-                            </span>
-                          </div>
-                        </div>
-                        <p
-                          className=""
-                          data-ouia-component-id="OUIA-Generated-Text-9"
-                          data-ouia-component-type="PF4/Text"
-                          data-ouia-safe={true}
-                          data-pf-content={true}
-                        >
-                          Feature Levels Component
-                        </p>
-                      </div>
-                    </div>
-                  </form>
-                </div>
+                  </div>
+                </form>
               </div>
             </div>
           </div>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #793 

## Description of the change:

Unmount setting tab content that is not selected. This helps avoid situation where AA configurations cause the Auth modal to appear when first visiting `/settings` (users might wonder why this opens as they don't see the AA config). This also allows faster load as React only needs to build 1 tab content at a time.
 
Extend the min height for local target select to show more targets (currently it looks like, without scrolling, there is a single target).

## Motivation for the change:

AA configurations causes the setting page to show Auth modal even if the AA configuration is not visible (i.e. Dashboard tab not selected).

