### PR TITLE
fix(topology): catalog btn tooltip should not show if not needed

### DIFF
--- a/src/app/Topology/Actions/QuickSearchPanel.tsx
+++ b/src/app/Topology/Actions/QuickSearchPanel.tsx
@@ -266,6 +266,7 @@ export const QuickSearchModal: React.FC<QuickSearchModalProps> = ({
       titleIconVariant={QuickSearchIcon}
       title={'Topology Entity Catalog'}
       className={'topology__quick-search-modal'}
+      id={'topology-quick-search-modal'}
       description={<div>Select an entity to add to view. {guide}</div>}
     >
       <QuickSearchPanel />

--- a/src/app/Topology/Toolbar/QuickSearchButton.tsx
+++ b/src/app/Topology/Toolbar/QuickSearchButton.tsx
@@ -35,7 +35,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { portalRoot } from '@app/utils/utils';
+
 import { Button, Tooltip } from '@patternfly/react-core';
 import * as React from 'react';
 import QuickSearchIcon from '../Shared/QuickSearchIcon';
@@ -46,16 +46,29 @@ export interface QuickSearchButtonProps {
 }
 
 export const QuickSearchButton: React.FC<QuickSearchButtonProps> = ({ onClick, tooltipContent, ...props }) => {
+  const catalogRef = React.useRef<HTMLDivElement>(null);
+  const handleClick = React.useCallback(() => {
+    onClick();
+    catalogRef.current?.blur(); // Remove focus on the catalog button
+  }, [onClick]);
+
   return (
-    <Tooltip {...props} content={tooltipContent} appendTo={portalRoot}>
-      <Button
-        variant="plain"
-        onClick={onClick}
-        className={'topology__quick-search-button'}
-        data-quickstart-id={'topology-catalog-btn'}
+    <div id="topology-quicksearch-btn-wrapper">
+      <Tooltip
+        {...props}
+        content={tooltipContent}
+        appendTo={() => document.getElementById('topology-quicksearch-btn-wrapper') || document.body}
       >
-        <QuickSearchIcon />
-      </Button>
-    </Tooltip>
+        <Button
+          variant="plain"
+          onClick={handleClick}
+          style={{ padding: 0 }}
+          data-quickstart-id={'topology-catalog-btn'}
+          ref={catalogRef}
+        >
+          <QuickSearchIcon />
+        </Button>
+      </Tooltip>
+    </div>
   );
 };

--- a/src/app/Topology/styles/base.css
+++ b/src/app/Topology/styles/base.css
@@ -360,10 +360,6 @@ Below CSS rules only apply to Topology components
   font-size: 1.1em !important;
 }
 
-.topology__quick-search-button {
-  padding: 0;
-}
-
 .topology__list-view__entity-details {
   background-color: var(--pf-global--palette--white);
   padding: 1em;


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #891 
Related to #1008 (Thanks Max for figuring out the root issue of element focus).

## Description of the change:

Mount tooltip closer to the catalog button (modal will clip this tooltip -> close tooltip). Also, unfocus the catalog button -> do not persist tooltip.

Also, fix a css issue where the rules is not applied to the catalog button causing it to have padding.


## Motivation for the change:

Catalog button is showing the tooltip over the modal and persist the tooltip after closing modal. We should avoid this.