### PR TITLE
fix(topology): correct toolbar mode icon

### DIFF
--- a/src/app/Topology/Toolbar/TopologyToolbar.tsx
+++ b/src/app/Topology/Toolbar/TopologyToolbar.tsx
@@ -85,17 +85,17 @@ export const TopologyToolbar: React.FC<TopologyToolbarProps> = ({ variant, visua
     }
   }, [setQuicksearchOpen]);
 
-  const actionIcon = React.useMemo(
+  const modeIcon = React.useMemo(
     () => (
       <Tooltip
         entryDelay={0}
-        content={isGraphView ? 'Graph View' : 'List View'}
+        content={isGraphView ? 'List View' : 'Graph View'}
         aria="none"
         aria-live="polite"
         appendTo={portalRoot}
       >
         <Button className="topology__view-switcher" aria-label="Clipboard" variant="plain" onClick={toggleView}>
-          {isGraphView ? <TopologyIcon /> : <ListIcon />}
+          {isGraphView ? <ListIcon /> : <TopologyIcon />}
         </Button>
       </Tooltip>
     ),
@@ -192,7 +192,7 @@ export const TopologyToolbar: React.FC<TopologyToolbarProps> = ({ variant, visua
             </ToolbarItem>
           ) : null}
           {!isDisabled ? <ToolbarItem alignment={{ default: 'alignRight' }}>{shortcuts}</ToolbarItem> : null}
-          <ToolbarItem alignment={isDisabled ? { default: 'alignRight' } : undefined}>{actionIcon}</ToolbarItem>
+          <ToolbarItem alignment={isDisabled ? { default: 'alignRight' } : undefined}>{modeIcon}</ToolbarItem>
         </ToolbarContent>
       </Toolbar>
       <TopologyFilterChips className="topology__toolbar-chip-content" />


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #891 

## Description of the change:

Just switching the order of the toggle icon. The Graph View should show ListView icon, vice versa

## Motivation for the change:

To match OpenShift layout.

![Topology Red Hat OpenShift](https://user-images.githubusercontent.com/68053619/236653839-b1648ebb-2c8f-4b81-8a46-cbf4c8aba704.png)

## Screenshots

![Cryostat Topology](https://user-images.githubusercontent.com/68053619/236653867-fed90e24-93ac-44d3-8bc1-c5df88e41b21.png)


