### PR TITLE
fix(dashboard): separate display from actual option value

### DIFF
--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -467,10 +467,10 @@ interface PropsConfigFormProps {
   onChange: (config: object) => void;
 }
 
-const PropsConfigForm = ({ onChange, ...props }: PropsConfigFormProps) => {
+const PropsConfigForm: React.FC<PropsConfigFormProps> = ({ onChange, ...props }) => {
   const { t } = useTranslation();
   const handleChange = React.useCallback(
-    (k) => (e) => {
+    (k: string) => (e: unknown) => {
       const copy = { ...props.config };
       copy[k] = e;
       onChange(copy);
@@ -479,7 +479,7 @@ const PropsConfigForm = ({ onChange, ...props }: PropsConfigFormProps) => {
   );
 
   const handleNumeric = React.useCallback(
-    (k) => (e) => {
+    (k: string) => (e: React.FormEvent<HTMLInputElement>) => {
       const value = (e.target as HTMLInputElement).value;
       const copy = { ...props.config };
       copy[k] = value;
@@ -489,7 +489,7 @@ const PropsConfigForm = ({ onChange, ...props }: PropsConfigFormProps) => {
   );
 
   const handleNumericStep = React.useCallback(
-    (k, v) => (_) => {
+    (k: string, v: number) => (_: React.MouseEvent) => {
       const copy = { ...props.config };
       copy[k] = props.config[k] + v;
       onChange(copy);
@@ -582,7 +582,7 @@ interface SelectControlProps {
   selectedConfig: string | SelectOptionObject;
 }
 
-const SelectControl = ({ handleChange, control, selectedConfig }: SelectControlProps) => {
+const SelectControl: React.FC<SelectControlProps> = ({ handleChange, control, selectedConfig }) => {
   const addSubscription = useSubscriptions();
 
   const [selectOpen, setSelectOpen] = React.useState(false);
@@ -638,10 +638,13 @@ const SelectControl = ({ handleChange, control, selectedConfig }: SelectControlP
       {errored
         ? [<SelectOption key={0} value={`Load Error: ${options[0]}`} isPlaceholder isDisabled />]
         : options.map((choice, idx) => {
-            if (control.extras && control.extras.displayMapper) {
-              choice = control.extras.displayMapper(choice);
-            }
-            return <SelectOption key={idx + 1} value={choice} />;
+            const display =
+              control.extras && control.extras.displayMapper ? control.extras.displayMapper(choice) : choice;
+            return (
+              <SelectOption key={idx + 1} value={choice}>
+                {display}
+              </SelectOption>
+            );
           })}
     </Select>
   );

--- a/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
@@ -555,7 +555,7 @@ export const MBeanMetricsChartCardDescriptor: DashboardCardDescriptor = {
       name: 'CHART_CARD.PROP_CONTROLS.THEME.NAME',
       key: 'themeColor',
       values: ['blue', 'cyan', 'gold', 'gray', 'green', 'orange', 'purple'],
-      defaultValue: 'Blue',
+      defaultValue: 'blue',
       description: 'CHART_CARD.PROP_CONTROLS.THEME.DESCRIPTION',
       kind: 'select',
       extras: {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1023 
Related to: #1008

## Description of the change:

- Separate display from actual select option value + fix default value for `themeColor` prop selection.
- Add static type to parameters and component.

## Motivation for the change:

See #1023 

## References

https://www.patternfly.org/v4/components/select/#selectoption
