### PR TITLE
chore(ci): run testing jobs in parallel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,13 +15,11 @@ on:
       - cryostat-v[0-9]+.[0-9]+
 
 jobs:
-  build:
+  prettier-check:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        node-version: [16.x]
-
+        node-version: [16.x, 18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -30,6 +28,29 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - uses: bahmutov/npm-install@v1
     - run: yarn format:check
+  eslint-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - uses: bahmutov/npm-install@v1
     - run: yarn eslint:check
-    - run: yarn build:notests
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - uses: bahmutov/npm-install@v1
     - run: yarn test:ci

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -59,7 +59,6 @@ jobs:
       with:
         name: cryostat-core
         path: /home/runner/.m2/repository/io/cryostat/cryostat-core/
-
   build-image-and-push:
     runs-on: ubuntu-latest
     needs: [get-pom-properties, build-deps]


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1017 

## Description of the change:

- Split test ci steps into jobs that can be run in parallel.
- Remove `yarn build:notests` as a step since we don't need to build the asset for any tests.
- Set node version to `16.18.x` (cryostat builds use node `16.18.1`).

## Motivation for the change:

See #1017 

## Screenshots

![Screenshot from 2023-05-10 05-42-30](https://github.com/cryostatio/cryostat-web/assets/68053619/ecbeebbb-8761-465c-9bdd-3445c080e9bd)

