### PR TITLE
fix(modal): Warning modal for disabling rule should say "disable" instead of "delete"

### DIFF
--- a/src/app/Modal/DeleteWarningUtils.tsx
+++ b/src/app/Modal/DeleteWarningUtils.tsx
@@ -63,7 +63,7 @@ export const DisableAutomatedRules: DeleteOrDisableWarning = {
   id: DeleteOrDisableWarningType.DisableAutomatedRules,
   title: 'Disable your Automated Rule?',
   label: 'Disable Automated Rule',
-  description: `If you click delete, the rule will be disabled.`,
+  description: `If you click Disable, the rule will be disabled`,
   ariaLabel: 'Automated rule disable warning',
 };
 

--- a/src/app/Modal/DeleteWarningUtils.tsx
+++ b/src/app/Modal/DeleteWarningUtils.tsx
@@ -63,7 +63,7 @@ export const DisableAutomatedRules: DeleteOrDisableWarning = {
   id: DeleteOrDisableWarningType.DisableAutomatedRules,
   title: 'Disable your Automated Rule?',
   label: 'Disable Automated Rule',
-  description: `If you click Disable, the rule will be disabled`,
+  description: `If you click Disable, the rule will be disabled.`,
   ariaLabel: 'Automated rule disable warning',
 };
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1042 
Depends on #1070

## Description of the change:
*[Bug] Warning modal for disabling rule should say "disable" instead of "delete"
