### PR TITLE
feat(ci): allow preview deployment on release branches

### DIFF
--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches:
       - main
+      - v[0-9]+
+      - v[0-9]+.[0-9]+
+      - cryostat-v[0-9]+.[0-9]+
     paths:
       - 'src/**'
       - '!src/test/**'
@@ -19,8 +22,6 @@ on:
 jobs:
   build-preview:
     if: ${{ github.repository_owner == 'cryostatio' }}
-    env:
-      DEPLOY_DOMAIN: ${{ github.repository_owner }}-${{ github.event.repository.name }}-main.surge.sh
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -33,4 +34,6 @@ jobs:
       run: yarn build:preview:notests
     - name: Publish to surge
       run: |
+        FORMATTED_REF="$(echo ${{ github.ref_name }} | sed 's/\.//')"
+        DEPLOY_DOMAIN="${{ github.repository_owner }}-${{ github.event.repository.name }}-$FORMATTED_REF.surge.sh"
         npx surge --project ./dist --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #1045 

## Description of the change:

This extends workflow to run on release branches.

## Motivation for the change:

> I think we'll want to have a CI setup and deployment for the latest release branch, cryostat-v2.4 in this case in anticipation of the next release which will also contain these Mirage changes, so that the upstream website can just link to or iframe a preview of the latest upstream release, rather than development snapshots


## CI Runs

Deployment: https://tthvo-cryostat-web-cryostat-v24.surge.sh

Action: https://github.com/tthvo/cryostat-web/actions/runs/5182474577/jobs/9339300166
