### PR TITLE
fix(ci): preview ci should target all under src

### DIFF
--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -10,11 +10,11 @@ on:
     branches:
       - main
     paths:
-      - 'src/app/**'
+      - 'src/**'
+      - '!src/test/**'
       - 'webpack.*.js'
       - 'yarn.lock'
       - 'tsconfig.json'
-      - '!src/test/**'
 
 jobs:
   build-preview:


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Related to #1046 

## Description of the change:

Update path matching to include all under `src`.

## Motivation for the change:

Preview CI should target all under `src` because there are also i18next and mirage codes.

