### PR TITLE
chore(match expression): visualizer should have title

### DIFF
--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -53,6 +53,7 @@ import {
   Button,
   Card,
   CardBody,
+  CardTitle,
   Form,
   FormGroup,
   FormSelect,
@@ -659,6 +660,7 @@ const Comp: React.FC = () => {
           </GridItem>
           <GridItem xl={7} order={{ xl: '1', default: '0' }}>
             <Card isFullHeight>
+              <CardTitle>Match Expression Visualizer</CardTitle>
               <CardBody className="overflow-auto" data-quickstart-id="match-expr-card">
                 <MatchExpressionVisualizer />
               </CardBody>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1041 

## Description of the change:
This change adds a title at the top of the page for the card that contains the Match Expression Visualizer.

## Motivation for the change:
This change is helpful as suggested by doc team. The title will help users that comes across the word Match Expression Visualizer in documentations to figure out what the UI element it is referring to.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
