### PR TITLE
docs(editor): how to get rid of auto organize imports behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ $ yarn eslint:apply
 $ yarn format:apply
 ```
 
+### Getting Rid of Organize Imports Functionality
+When saving any changes before pushing the code, save would auto organize/sort the imports.
+The reason is that VSCode's setting may go agaisnt ESlin.
+To get rid of that behaviour, from `settings.json` change the ` "source.organizeImports" ` to `false`
+
+``` "redhat.telemetry.enabled": true,
+    "workbench.iconTheme": "material-icon-theme",
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": false
+    },
+```
+
 ### Inspect the bundle size
 
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ yarn format:apply
 
 ### Getting Rid of Organize Imports Functionality
 When saving any changes before pushing the code, save would auto organize/sort the imports.
-The reason is that VSCode's setting may go agaisnt ESlin.
+The reason is that VSCode's setting may go agaisnt ESLint.
 To get rid of that behaviour, from `settings.json` change the ` "source.organizeImports" ` to `false`
 
 ``` "redhat.telemetry.enabled": true,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1064 

## Description of the change:
*This change will help get rid of auto organize imports behavior that happens on save before pushing the code*

## Motivation for the change:
*This change is helpful to maintain the original code structure and readability*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
