### PR TITLE
fix(cards): replace instances of card.component.name

### DIFF
--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -119,8 +119,8 @@ export const AddCard: React.FC<AddCardProps> = ({ variant, ..._props }) => {
     setShowWizard(false);
     const config = getCardDescriptorByTitle(selection, t);
     const cardConfig: CardConfig = {
-      id: `${config.component.name}-${nanoid()}`,
-      name: config.component.name,
+      id: `${config.component.cardComponentName}-${nanoid()}`,
+      name: config.component.cardComponentName,
       span: config.cardSizes.span.default,
       props: propsConfig,
     };

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -97,7 +97,12 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { filter, first, map, tap } from 'rxjs';
-import { DashboardCardDescriptor, DashboardCardSizes, DashboardCardTypeProps } from '../dashboard-utils';
+import {
+  DashboardCardDescriptor,
+  DashboardCardFC,
+  DashboardCardSizes,
+  DashboardCardTypeProps,
+} from '../dashboard-utils';
 import { DashboardCard } from '../DashboardCard';
 import { AutomatedAnalysisCardList } from './AutomatedAnalysisCardList';
 import { AutomatedAnalysisConfigDrawer } from './AutomatedAnalysisConfigDrawer';
@@ -113,7 +118,7 @@ import { AutomatedAnalysisScoreFilter } from './Filters/AutomatedAnalysisScoreFi
 
 export interface AutomatedAnalysisCardProps extends DashboardCardTypeProps {}
 
-export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (props) => {
+export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const dispatch = useDispatch<StateDispatch>();
@@ -852,6 +857,8 @@ export const AutomatedAnalysisCard: React.FC<AutomatedAnalysisCardProps> = (prop
     </DashboardCard>
   );
 };
+
+AutomatedAnalysisCard.cardComponentName = 'AutomatedAnalysisCard';
 
 export type AutomatedAnalysisHeaderLabelType = 'critical' | 'warning' | 'ok';
 

--- a/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
@@ -15,7 +15,12 @@
  */
 
 import { CreateRecordingProps } from '@app/CreateRecording/CreateRecording';
-import { DashboardCardDescriptor, DashboardCardSizes, DashboardCardTypeProps } from '@app/Dashboard/dashboard-utils';
+import {
+  DashboardCardDescriptor,
+  DashboardCardFC,
+  DashboardCardSizes,
+  DashboardCardTypeProps,
+} from '@app/Dashboard/dashboard-utils';
 import { LoadingView } from '@app/LoadingView/LoadingView';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { FeatureLevel } from '@app/Shared/Services/Settings.service';
@@ -82,7 +87,7 @@ export function kindToId(kind: string): number {
   return JFRMetricsChartKind[kind];
 }
 
-export const JFRMetricsChartCard: React.FC<JFRMetricsChartCardProps> = (props) => {
+export const JFRMetricsChartCard: DashboardCardFC<JFRMetricsChartCardProps> = (props) => {
   const [t] = useTranslation();
   const serviceContext = React.useContext(ServiceContext);
   const controllerContext = React.useContext(ChartContext);
@@ -262,6 +267,8 @@ export const JFRMetricsChartCard: React.FC<JFRMetricsChartCardProps> = (props) =
     </DashboardCard>
   );
 };
+
+JFRMetricsChartCard.cardComponentName = 'JFRMetricsChartCard';
 
 export const JFRMetricsChartCardSizes: DashboardCardSizes = {
   span: {

--- a/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { DashboardCardDescriptor, DashboardCardSizes, DashboardCardTypeProps } from '@app/Dashboard/dashboard-utils';
+import {
+  DashboardCardDescriptor,
+  DashboardCardFC,
+  DashboardCardSizes,
+  DashboardCardTypeProps,
+} from '@app/Dashboard/dashboard-utils';
 import { ThemeSetting, ThemeType } from '@app/Settings/SettingsUtils';
 import { MBeanMetrics } from '@app/Shared/Services/Api.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
@@ -357,7 +362,7 @@ function getChartKindByName(name: string): MBeanMetricsChartKind {
   return chartKinds.filter((k) => k.displayName === name)[0];
 }
 
-export const MBeanMetricsChartCard: React.FC<MBeanMetricsChartCardProps> = (props) => {
+export const MBeanMetricsChartCard: DashboardCardFC<MBeanMetricsChartCardProps> = (props) => {
   const { t } = useTranslation();
   const [theme] = useTheme();
   const serviceContext = React.useContext(ServiceContext);
@@ -476,6 +481,8 @@ export const MBeanMetricsChartCard: React.FC<MBeanMetricsChartCardProps> = (prop
     </DashboardCard>
   );
 };
+
+MBeanMetricsChartCard.cardComponentName = 'MBeanMetricsChartCard';
 
 export const MBeanMetricsChartCardSizes: DashboardCardSizes = {
   span: {

--- a/src/app/Dashboard/ErrorCard.tsx
+++ b/src/app/Dashboard/ErrorCard.tsx
@@ -31,7 +31,13 @@ import {
 import { WrenchIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { CardConfig, CardValidationResult, DashboardCardSizes, DashboardCardTypeProps } from './dashboard-utils';
+import {
+  CardConfig,
+  CardValidationResult,
+  DashboardCardFC,
+  DashboardCardSizes,
+  DashboardCardTypeProps,
+} from './dashboard-utils';
 import { DashboardCard } from './DashboardCard';
 
 export interface ErrorCardProps extends DashboardCardTypeProps {
@@ -40,7 +46,7 @@ export interface ErrorCardProps extends DashboardCardTypeProps {
 }
 
 // TODO: Fix title + design body
-export const ErrorCard: React.FC<ErrorCardProps> = ({
+export const ErrorCard: DashboardCardFC<ErrorCardProps> = ({
   validationResult,
   cardConfig: _cardConfig,
   dashboardId,
@@ -90,6 +96,8 @@ export const ErrorCard: React.FC<ErrorCardProps> = ({
     </DashboardCard>
   );
 };
+
+ErrorCard.cardComponentName = 'ErrorCard';
 
 export const ErrorCardSizes: DashboardCardSizes = {
   span: {

--- a/src/app/Dashboard/JvmDetails/JvmDetailsCard.tsx
+++ b/src/app/Dashboard/JvmDetails/JvmDetailsCard.tsx
@@ -24,13 +24,18 @@ import { useSubscriptions } from '@app/utils/useSubscriptions';
 import { CardActions, CardBody, CardHeader } from '@patternfly/react-core';
 import { ContainerNodeIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { DashboardCardDescriptor, DashboardCardSizes, DashboardCardTypeProps } from '../dashboard-utils';
+import {
+  DashboardCardDescriptor,
+  DashboardCardFC,
+  DashboardCardSizes,
+  DashboardCardTypeProps,
+} from '../dashboard-utils';
 import { DashboardCard } from '../DashboardCard';
 import '@app/Topology/styles/base.css';
 
 export interface JvmDetailsCardProps extends DashboardCardTypeProps {}
 
-export const JvmDetailsCard: React.FC<JvmDetailsCardProps> = (props) => {
+export const JvmDetailsCard: DashboardCardFC<JvmDetailsCardProps> = (props) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
 
@@ -77,6 +82,8 @@ export const JvmDetailsCard: React.FC<JvmDetailsCardProps> = (props) => {
     </DashboardCard>
   );
 };
+
+JvmDetailsCard.cardComponentName = 'JvmDetailsCard';
 
 export const JvmDetailsCardSizes: DashboardCardSizes = {
   span: {

--- a/src/app/Dashboard/LayoutTemplateUploadModal.tsx
+++ b/src/app/Dashboard/LayoutTemplateUploadModal.tsx
@@ -96,7 +96,7 @@ export const LayoutTemplateUploadModal: React.FC<LayoutTemplateUploadModalProps>
               Object.keys(cardConfig).length !== Object.keys(mockSerialCardConfig).length ||
               cardConfig.name === undefined ||
               !getDashboardCards()
-                .map((c) => c.component.displayName)
+                .map((c) => c.component.cardComponentName)
                 .includes(cardConfig.name) ||
               cardConfig.span === undefined ||
               cardConfig.props === undefined

--- a/src/app/Dashboard/LayoutTemplateUploadModal.tsx
+++ b/src/app/Dashboard/LayoutTemplateUploadModal.tsx
@@ -96,7 +96,7 @@ export const LayoutTemplateUploadModal: React.FC<LayoutTemplateUploadModalProps>
               Object.keys(cardConfig).length !== Object.keys(mockSerialCardConfig).length ||
               cardConfig.name === undefined ||
               !getDashboardCards()
-                .map((c) => c.component.name)
+                .map((c) => c.component.displayName)
                 .includes(cardConfig.name) ||
               cardConfig.span === undefined ||
               cardConfig.props === undefined

--- a/src/app/Dashboard/dashboard-utils.tsx
+++ b/src/app/Dashboard/dashboard-utils.tsx
@@ -173,7 +173,7 @@ export const getUniqueIncrementingName = (init = 'Custom', names: string[]): str
 
 export function hasCardDescriptorByName(name: string): boolean {
   for (const choice of getDashboardCards()) {
-    if (choice.component.name === name) {
+    if (choice.component.cardComponentName === name) {
       return true;
     }
   }
@@ -182,7 +182,7 @@ export function hasCardDescriptorByName(name: string): boolean {
 
 export function getCardDescriptorByName(name: string): DashboardCardDescriptor {
   for (const choice of getDashboardCards()) {
-    if (choice.component.name === name) {
+    if (choice.component.cardComponentName === name) {
       return choice;
     }
   }
@@ -368,10 +368,15 @@ export interface DashboardCardDescriptor {
   cardSizes: DashboardCardSizes;
   description: string;
   descriptionFull: JSX.Element | string;
-  component: React.FC<any>;
+  component: DashboardCardFC<any>;
   propControls: PropControl[];
   advancedConfig?: JSX.Element;
 }
+export type DashboardCardFC<P = Props> = React.FC<P> & {
+  cardComponentName: string;
+};
+
+interface Props {}
 
 export interface PropControlExtra {
   displayMapper?: (value: string) => string /* only has effect with 'select' PropControl kind */;

--- a/src/app/Dashboard/dashboard-utils.tsx
+++ b/src/app/Dashboard/dashboard-utils.tsx
@@ -372,11 +372,9 @@ export interface DashboardCardDescriptor {
   propControls: PropControl[];
   advancedConfig?: JSX.Element;
 }
-export type DashboardCardFC<P = Props> = React.FC<P> & {
+export type DashboardCardFC<P> = React.FC<P> & {
   cardComponentName: string;
 };
-
-interface Props {}
 
 export interface PropControlExtra {
   displayMapper?: (value: string) => string /* only has effect with 'select' PropControl kind */;

--- a/src/app/Shared/Redux/Configurations/DashboardConfigSlice.tsx
+++ b/src/app/Shared/Redux/Configurations/DashboardConfigSlice.tsx
@@ -280,8 +280,8 @@ export const dashboardConfigReducer = createReducer(INITIAL_STATE, (builder) => 
     .addCase(dashboardConfigFirstRunIntent, (state) => {
       state.layouts[state.current].cards = [
         {
-          id: `${MBeanMetricsChartCardDescriptor.component.name}-1`,
-          name: MBeanMetricsChartCardDescriptor.component.name,
+          id: `${MBeanMetricsChartCardDescriptor.component.cardComponentName}-1`,
+          name: MBeanMetricsChartCardDescriptor.component.cardComponentName,
           span: MBeanMetricsChartCardDescriptor.cardSizes.span.default,
           props: {
             themeColor: 'blue',
@@ -291,8 +291,8 @@ export const dashboardConfigReducer = createReducer(INITIAL_STATE, (builder) => 
           },
         },
         {
-          id: `${MBeanMetricsChartCardDescriptor.component.name}-2`,
-          name: MBeanMetricsChartCardDescriptor.component.name,
+          id: `${MBeanMetricsChartCardDescriptor.component.cardComponentName}-2`,
+          name: MBeanMetricsChartCardDescriptor.component.cardComponentName,
           span: MBeanMetricsChartCardDescriptor.cardSizes.span.default,
           props: {
             themeColor: 'purple',
@@ -302,8 +302,8 @@ export const dashboardConfigReducer = createReducer(INITIAL_STATE, (builder) => 
           },
         },
         {
-          id: `${MBeanMetricsChartCardDescriptor.component.name}-3`,
-          name: MBeanMetricsChartCardDescriptor.component.name,
+          id: `${MBeanMetricsChartCardDescriptor.component.cardComponentName}-3`,
+          name: MBeanMetricsChartCardDescriptor.component.cardComponentName,
           span: MBeanMetricsChartCardDescriptor.cardSizes.span.default,
           props: {
             themeColor: 'green',


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] Signed the last commit: `git commit --amend --signoff`
_______________________________________________

Fixes: #1079 

## Description of the change:
With help from Thuan, we figure out the bug. This change replaces all instances where we reference the Functional component name as data related to the dashboard. We need to do this because, it seems like Webpack minifys all instances of the component name in production mode: https://stackoverflow.com/questions/43800784/get-component-name-in-react. And then we end up with weird names and bad states because of this. That's also why there was no bug if running the `yarn start:dev` dev server.

## How to manually test:
1. CD to a cryostat repo.
2.  `cd web-client` and checkout this branch in that submodule e.g. `git checkout f8592d891067c18a1f61f0cdbabc995974e56944`
3. cd back to `..` and run `mvn clean -DskipTests package`
4. Clear browser localstorage on https://localhost:8181
5. Should be solved if creating a new layout template.
