### PR TITLE
fix(semver): use semver util to check version upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "react-joyride": "^2.5.3",
     "react-redux": "^8.0.5",
     "react-router-last-location": "^2.0.1",
+    "semver": "^7.5.4",
     "showdown": "^2.1.0"
   },
   "packageManager": "yarn@3.3.0"

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -19,6 +19,8 @@ import { ISortBy, SortByDirection } from '@patternfly/react-table';
 import _ from 'lodash';
 import { useHistory } from 'react-router-dom';
 import { BehaviorSubject, Observable } from 'rxjs';
+import semverGt from 'semver/functions/gt';
+import semverValid from 'semver/functions/valid';
 import { getFromLocalStorage } from './LocalStorage';
 
 const SECOND_MILLIS = 1000;
@@ -242,46 +244,9 @@ export const getActiveTab = <T>(search: string, key: string, supportedTabs: T[],
 
 export const clickOutside = () => document.body.click();
 
-export interface SemVer {
-  major: number;
-  minor: number;
-  patch: number;
-}
-
-// https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-export const semverRegex =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
-
-export const getSemVer = (str: string): SemVer | undefined => {
-  const matched = str.match(semverRegex);
-  if (matched) {
-    const [_, major, minor, patch] = matched;
-    return {
-      major: Number(major),
-      minor: Number(minor),
-      patch: Number(patch),
-    };
-  }
-  return undefined;
-};
-
-const convert = (ver: SemVer) => ver.major * 100 + ver.minor * 10 + ver.patch;
-
-export const compareSemVer = (ver1: SemVer, ver2: SemVer): number => {
-  const _ver1 = convert(ver1);
-  const _ver2 = convert(ver2);
-  return _ver1 > _ver2 ? 1 : _ver1 < _ver2 ? -1 : 0;
-};
-
-export const isAssetNew = (currVerStr: string) => {
-  const oldVer = getSemVer(getFromLocalStorage('ASSET_VERSION', '0.0.0'));
-  const currVer = getSemVer(currVerStr);
-
-  if (!currVer) {
-    throw new Error(`Invalid asset version: ${currVer}`);
-  }
-  // Invalid (old) version is ignored.
-  return !oldVer || compareSemVer(currVer, oldVer) > 0;
+export const isAssetNew = (currVer: string) => {
+  const oldVer: string = getFromLocalStorage('ASSET_VERSION', '0.0.0');
+  return !semverValid(oldVer) || semverGt(currVer, oldVer);
 };
 
 export const utf8ToBase32 = (str: string): string => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4124,6 +4124,7 @@ __metadata:
     rimraf: ^4.1.2
     rxjs: ^7.8.0
     selenium-webdriver: ^4.10.0
+    semver: ^7.5.4
     showdown: ^2.1.0
     style-loader: ^3.3.1
     svg-url-loader: ^8.0.0
@@ -12054,6 +12055,17 @@ __metadata:
   bin:
     semver: ./bin/semver.js
   checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.5.4":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #971 

## Description of the change:

Use `semver` package to reliably compare semantic versions.

## Motivation for the change:

Previously, using the trick `major * 100 + minor * 10 + patch`, which will suffer incorrect behavior if the comparing between, for example, `1.11.0` and `0.43.0`.
