### PR TITLE
build(ts): eliminate duplicate helper code

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "ts-jest": "^27.0.5",
     "ts-loader": "^9.4.2",
     "tsconfig-paths-webpack-plugin": "^4.0.0",
-    "tslib": "^2.5.0",
+    "tslib": "^2.6.1",
     "typescript": "^4.9.5",
     "url-loader": "^4.1.1",
     "wait-on": "^7.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "strictFunctionTypes": false,
     "strict": true,
     "resolveJsonModule": true,
+    "importHelpers": true,
     "paths": {
       "@app/*": ["src/app/*"],
       "@test/*": ["src/test/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4132,7 +4132,7 @@ __metadata:
     ts-jest: ^27.0.5
     ts-loader: ^9.4.2
     tsconfig-paths-webpack-plugin: ^4.0.0
-    tslib: ^2.5.0
+    tslib: ^2.6.1
     typescript: ^4.9.5
     url-loader: ^4.1.1
     wait-on: ^7.0.1
@@ -13242,10 +13242,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.5.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0":
   version: 2.5.0
   resolution: "tslib@npm:2.5.0"
   checksum: ae3ed5f9ce29932d049908ebfdf21b3a003a85653a9a140d614da6b767a93ef94f460e52c3d787f0e4f383546981713f165037dc2274df212ea9f8a4541004e1
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.6.1":
+  version: 2.6.1
+  resolution: "tslib@npm:2.6.1"
+  checksum: b0d176d176487905b66ae4d5856647df50e37beea7571c53b8d10ba9222c074b81f1410fb91da13debaf2cbc970663609068bdebafa844ea9d69b146527c38fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1039 (production optimization started there)
Also closes #1072 

## Description of the change:

Use `importHelpers` to tell TS to import helper code (i.e. needed for backwards compatibility or downleveling) from `tslib`. This helps reducing the web asset size by eliminating duplicate code.

## Motivation for the change:

> For certain downleveling operations, TypeScript uses some helper code for operations like extending class, spreading arrays or objects, and async operations. By default, these helpers are inserted into files which use them. This can result in code duplication if the same helper is used in many different modules.

References: https://www.typescriptlang.org/tsconfig#importHelpers

Patternfly-seed: https://github.com/patternfly/patternfly-react-seed/blob/62e92b78a64c93f3fa8c059e7482aaa3192e681d/tsconfig.json#L24
