### PR TITLE
fix(web): rename connection debounce to connection retry interval

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -365,7 +365,7 @@
     },
     "WEBSOCKET_CONNECTION_DEBOUNCE": {
       "DESCRIPTION": "Set the retry interval (debounce) time (in milliseconds) used when establishing WebSocket connections. Increase this time if the web-interface repeatedly displays WebSocket connection/disconnection messages. Decrease this time if the web-interface takes a long time to populate on startup.",
-      "TITLE": "WebSocket Connection Retry Interval"
+      "TITLE": "WebSocket Retry Interval"
     }
   },
   "TimePicker": {

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -364,8 +364,8 @@
       "TITLE": "Theme"
     },
     "WEBSOCKET_CONNECTION_DEBOUNCE": {
-      "DESCRIPTION": "Set the debounce time (in milliseconds) used when establishing WebSocket connections. Increase this time if the web-interface repeatedly displays WebSocket connection/disconnection messages. Decrease this time if the web-interface takes a long time to populate on startup.",
-      "TITLE": "WebSocket Connection Debounce"
+      "DESCRIPTION": "Set the retry interval (debounce) time (in milliseconds) used when establishing WebSocket connections. Increase this time if the web-interface repeatedly displays WebSocket connection/disconnection messages. Decrease this time if the web-interface takes a long time to populate on startup.",
+      "TITLE": "WebSocket Connection Retry Interval"
     }
   },
   "TimePicker": {

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -364,7 +364,7 @@
       "TITLE": "Theme"
     },
     "WEBSOCKET_CONNECTION_DEBOUNCE": {
-      "DESCRIPTION": "Set the retry interval (debounce) time (in milliseconds) used when establishing WebSocket connections. Increase this time if the web-interface repeatedly displays WebSocket connection/disconnection messages. Decrease this time if the web-interface takes a long time to populate on startup.",
+      "DESCRIPTION": "Set the retry interval (in milliseconds) used when establishing WebSocket connections. Increase this time if the web-interface repeatedly displays WebSocket connection/disconnection messages. Decrease this time if the web-interface takes a long time to populate on startup.",
       "TITLE": "WebSocket Retry Interval"
     }
   },


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1030 

## Description of the change:
This change is more user friendly. Renaming the title from `WebSocket Connection Debounce` to `WebSocket Retry Interval` makes it more understandable for all users.

## Motivation for the change:
Pointed out by @andrewazores  to improve UX as name and description should be understandable by a typical user without having to reach for a manual page or search engine

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
