### PR TITLE
build(ci): submodule should sign commits

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -41,5 +41,5 @@ jobs:
         git config commit.gpgsign true
         git add --all
         git_hash="$(git rev-parse --short :web-client)"
-        git commit -m "build(web-client): update submodule to $git_hash" || echo "No changes to commit"
+        git commit -S -m "build(web-client): update submodule to $git_hash" || echo "No changes to commit"
         git push

--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.repository_owner == 'cryostatio' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         repository: cryostatio/cryostat
         token: "${{ secrets.SUBMODULE_TOKEN }}"
@@ -29,6 +29,13 @@ jobs:
           printf "Expected remote branch %s, found branch %s\n" "${{ github.ref_name }}" "$remote_branch" >&2
           exit 1
         fi
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v6
+      with:
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.PASSPHRASE }}
+        git_user_signingkey: true
+        git_commit_gpgsign: true
     - name: Update submodule to latest commit
       run: |
         git submodule update --init

--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: crazy-max/ghaction-import-gpg@v6
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.PASSPHRASE }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
         git_user_signingkey: true
         git_commit_gpgsign: true
     - name: Update submodule to latest commit

--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -38,6 +38,7 @@ jobs:
       run: |
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
+        git config commit.gpgsign true
         git add --all
         git_hash="$(git rev-parse --short :web-client)"
         git commit -m "build(web-client): update submodule to $git_hash" || echo "No changes to commit"

--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -38,7 +38,6 @@ jobs:
       run: |
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
-        git config commit.gpgsign true
         git add --all
         git_hash="$(git rev-parse --short :web-client)"
         git commit -S -m "build(web-client): update submodule to $git_hash" || echo "No changes to commit"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #916 

## Description of the change:
This change will sign all commits on `git submodule update`

## Motivation for the change:
All commits should be verified.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
