### PR TITLE
feat(topology): render Cryostat icon for Agent targets

### DIFF
--- a/src/app/Topology/GraphView/CustomNode.tsx
+++ b/src/app/Topology/GraphView/CustomNode.tsx
@@ -99,7 +99,7 @@ const CustomNode: React.FC<CustomNodeProps> = ({
 
   const data: TargetNode = element.getData();
 
-  const graphic = data.target.connectUrl.startsWith('http') ? cryostatSvg : openjdkSvg;
+  const graphic = React.useMemo(() => (data.target.connectUrl.startsWith('http') ? cryostatSvg : openjdkSvg), [data]);
 
   const [nodeStatus] = getStatusTargetNode(data);
 

--- a/src/app/Topology/GraphView/CustomNode.tsx
+++ b/src/app/Topology/GraphView/CustomNode.tsx
@@ -47,7 +47,7 @@ import { RESOURCE_NAME_TRUNCATE_LENGTH } from './UtilsFactory';
 
 export const NODE_ICON_PADDING = 5;
 
-export const renderIcon = (_data: TargetNode, element: Node, useAlt: boolean): React.ReactNode => {
+export const renderIcon = (graphic, _data: TargetNode, element: Node, useAlt: boolean): React.ReactNode => {
   const { width, height } = element.getDimensions();
 
   const contentSize = Math.min(width, height) - NODE_ICON_PADDING * 2;
@@ -63,7 +63,7 @@ export const renderIcon = (_data: TargetNode, element: Node, useAlt: boolean): R
           <ContainerNodeIcon width={mainContentSize} height={mainContentSize} />
         </g>
       ) : (
-        <image x={trueCx} y={trueCy} width={mainContentSize} height={mainContentSize} xlinkHref={openjdkSvg} />
+        <image x={trueCx} y={trueCy} width={mainContentSize} height={mainContentSize} xlinkHref={graphic} />
       )}
     </>
   );
@@ -98,6 +98,8 @@ const CustomNode: React.FC<CustomNodeProps> = ({
   const labelIcon = React.useMemo(() => <img src={cryostatSvg} />, []);
 
   const data: TargetNode = element.getData();
+
+  const graphic = data.target.connectUrl.startsWith('http') ? cryostatSvg : openjdkSvg;
 
   const [nodeStatus] = getStatusTargetNode(data);
 
@@ -138,7 +140,7 @@ const CustomNode: React.FC<CustomNodeProps> = ({
           showLabel
           attachments={nodeDecorators}
         >
-          <g id={'target-node-visual-inner-icon'}>{renderIcon(data, element, !showIcon)}</g>
+          <g id={'target-node-visual-inner-icon'}>{renderIcon(graphic, data, element, !showIcon)}</g>
         </DefaultNode>
       </g>
     </Layer>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1114

## Description of the change:
This updates the Topology view to render Cryostat icons for Cryostat Agent targets, and as before, OpenJDK's Duke for JMX targets.
The original note I made about dark vs. light mode and the reverse icon is ignored here because the Topology view only changes its background field colour to suit the theme, but the app icon being changed here is always presented on top of a white background.

![image](https://github.com/cryostatio/cryostat-web/assets/3787464/ae5cfa96-673a-4d07-8a2e-072f9598137b)

![image](https://github.com/cryostatio/cryostat-web/assets/3787464/ebfa0169-795b-4093-beab-6ed66c49c7b0)

## Motivation for the change:
This helps users to differentiate what kind of target node they are looking at without having to click on each to pull up the details pane and check the connection URL.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Go to Topology view
3. Ensure that Agent targets using HTTP display with a Cryostat icon, and JMX targets display with Duke
