### PR TITLE
docs(read-me): correct ci status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cryostat-web
 
-![Build Status](https://github.com/cryostatio/cryostat-web/actions/workflows/ci.yaml/badge.svg)
+[![CI](https://github.com/cryostatio/cryostat-web/actions/workflows/ci.yaml/badge.svg)](https://github.com/cryostatio/cryostat-web/actions/workflows/ci.yaml)
 [![Google Group : Cryostat Development](https://img.shields.io/badge/Google%20Group-Cryostat%20Development-blue.svg)](https://groups.google.com/g/cryostat-development)
 
 Web front-end for [Cryostat](https://github.com/cryostatio/cryostat), providing a graphical user interface for managing JFR on remote JVMs.
@@ -17,7 +17,7 @@ JFR using JDK Mission Control internals.
 for an OpenShift Operator facilitating easy setup of Cryostat in your OpenShift
 cluster as well as exposing the Cryostat API as Kubernetes Custom Resources.
 
-* [cryostat](https://github.com/cryostatio/cryostat) for the JFR management service
+* [cryostat](https://github.com/cryostatio/cryostat) for the JFR management service.
 
 ## REQUIREMENTS
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #221 

## Description of the change:

Update CI badge to point to Github Action view.

## Motivation for the change:

Previously, the badge holds the link the badge itself, not the Github Action view.