### PR TITLE
ci(submodule): remove bot user git configurations

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -41,10 +41,7 @@ jobs:
         git submodule update --init
         git submodule update --remote
     - name: Commit and push submodule
-      # User info comes from: https://github.community/t/github-actions-bot-email-address/17204/5
       run: |
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config user.name "github-actions[bot]"
         git add --all
         git_hash="$(git rev-parse --short :web-client)"
         git commit -S -m "build(web-client): update submodule to $git_hash" || echo "No changes to commit"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1113 

## Description of the change:

Remove bot user git configurations to allow the signed commits to be verified.

## Motivation for the change:

https://github.com/cryostatio/cryostat-web/pull/1113#issuecomment-1738896699