### PR TITLE
chore(react): use new JSX transformations and remove react-axe

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:@typescript-eslint/recommended",
     "plugin:import/recommended",
     "plugin:import/typescript"
@@ -29,7 +30,7 @@
   },
   "settings": {
     "react": {
-      "version": "^16.11.0"
+      "version": "detect"
     }
   },
   // includes the typescript specific rules found here: https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin#supported-rules

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "prettier": "^3.0.3",
     "prop-types": "^15.7.2",
     "raw-loader": "^4.0.2",
-    "react-axe": "^3.4.1",
     "react-router-dom": "^5.3.4",
     "regenerator-runtime": "^0.13.11",
     "rimraf": "^4.1.2",

--- a/src/app/About/About.tsx
+++ b/src/app/About/About.tsx
@@ -21,7 +21,7 @@ import build from '@app/build.json';
 import { ThemeSetting } from '@app/Settings/types';
 import { useTheme } from '@app/utils/hooks/useTheme';
 import { Brand, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { AboutDescription } from './AboutDescription';
 

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters.tsx
@@ -29,7 +29,7 @@ import {
   ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
-import React from 'react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { AutomatedAnalysisNameFilter } from './Filters/AutomatedAnalysisNameFilter';

--- a/src/app/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel.tsx
@@ -20,7 +20,7 @@ import { Label, LabelProps, Popover } from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationCircleIcon, InfoCircleIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import popoverStyles from '@patternfly/react-styles/css/components/Popover/popover';
-import React from 'react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { transformAADescription } from './utils';
 

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.tsx
@@ -17,7 +17,7 @@
 import { CategorizedRuleEvaluations } from '@app/Shared/Services/api.types';
 import { portalRoot } from '@app/utils/utils';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 
 export interface AutomatedAnalysisNameFilterProps {
   evaluations: CategorizedRuleEvaluations[];

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.tsx
@@ -27,7 +27,7 @@ import {
   TextVariants,
   Tooltip,
 } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.tsx
@@ -17,7 +17,7 @@
 import { CategorizedRuleEvaluations } from '@app/Shared/Services/api.types';
 import { portalRoot } from '@app/utils/utils';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 
 export interface AutomatedAnalysisTopicFilterProps {
   evaluations: CategorizedRuleEvaluations[];

--- a/src/app/Dashboard/AutomatedAnalysis/utils.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/utils.tsx
@@ -16,7 +16,6 @@
 import { AnalysisResult, Evaluation } from '@app/Shared/Services/api.types';
 import { Stack, StackItem, Label, Title, Text } from '@patternfly/react-core';
 import _ from 'lodash';
-import * as React from 'react';
 
 export const transformAADescription = (result: AnalysisResult): JSX.Element => {
   const format = (s: Evaluation): JSX.Element => {

--- a/src/app/Dashboard/DashboardLayoutToolbar.tsx
+++ b/src/app/Dashboard/DashboardLayoutToolbar.tsx
@@ -55,7 +55,7 @@ import {
   TrashIcon,
   UploadIcon,
 } from '@patternfly/react-icons';
-import React from 'react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { AddCard } from './AddCard';

--- a/src/app/Dashboard/DraggableRef.tsx
+++ b/src/app/Dashboard/DraggableRef.tsx
@@ -17,7 +17,7 @@
 import { dashboardConfigReorderCardIntent } from '@app/Shared/Redux/ReduxStore';
 import { clickOutside } from '@app/utils/utils';
 import { css } from '@patternfly/react-styles';
-import React from 'react';
+import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { DRAGGABLE_REF_KLAZZ } from './const';
 import { handleDisabledElements } from './ResizableRef';

--- a/src/app/Dashboard/LayoutTemplateGroup.tsx
+++ b/src/app/Dashboard/LayoutTemplateGroup.tsx
@@ -29,7 +29,7 @@ import {
   SplitItem,
   Title,
 } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import {

--- a/src/app/Dashboard/LayoutTemplatePicker.tsx
+++ b/src/app/Dashboard/LayoutTemplatePicker.tsx
@@ -72,7 +72,7 @@ import {
   UploadIcon,
 } from '@patternfly/react-icons';
 import { InnerScrollContainer, OuterScrollContainer } from '@patternfly/react-table';
-import React from 'react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { ChartContext } from './Charts/context';

--- a/src/app/Dashboard/ResizableRef.tsx
+++ b/src/app/Dashboard/ResizableRef.tsx
@@ -17,7 +17,7 @@
 import { dashboardConfigResizeCardIntent, RootState } from '@app/Shared/Redux/ReduxStore';
 import { gridSpans } from '@patternfly/react-core';
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { DashboardCardContext } from './context';
 import type { CardConfig, DashboardCardSizes } from './types';

--- a/src/app/Dashboard/SearchAutocomplete.tsx
+++ b/src/app/Dashboard/SearchAutocomplete.tsx
@@ -15,7 +15,7 @@
  */
 import { portalRoot } from '@app/utils/utils';
 import { Menu, MenuContent, MenuItem, MenuList, Popper, SearchInput } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 
 export interface SearchAutocompleteProps {
   values: string[];

--- a/src/app/DateTimePicker/DateTimePicker.tsx
+++ b/src/app/DateTimePicker/DateTimePicker.tsx
@@ -31,7 +31,7 @@ import {
   TabTitleText,
   TextInput,
 } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TimezonePicker } from './TimezonePicker';
 

--- a/src/app/Joyride/CryostatJoyride.tsx
+++ b/src/app/Joyride/CryostatJoyride.tsx
@@ -20,7 +20,7 @@ import { useJoyride } from '@app/Joyride/JoyrideProvider';
 import JoyrideTooltip from '@app/Joyride/JoyrideTooltip';
 import { ThemeSetting } from '@app/Settings/types';
 import { useTheme } from '@app/utils/hooks/useTheme';
-import React from 'react';
+import * as React from 'react';
 import ReactJoyride, { CallBackProps, ACTIONS, EVENTS, STATUS } from 'react-joyride';
 
 interface CryostatJoyrideProps {

--- a/src/app/Joyride/JoyrideProvider.tsx
+++ b/src/app/Joyride/JoyrideProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import useSetState from '@app/utils/hooks/useSetState';
-import React from 'react';
+import * as React from 'react';
 import { Step } from 'react-joyride';
 
 export interface JoyrideState {

--- a/src/app/Joyride/JoyrideTooltip.tsx
+++ b/src/app/Joyride/JoyrideTooltip.tsx
@@ -27,7 +27,7 @@ import {
   Text,
   TextContent,
 } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 import { TooltipRenderProps } from 'react-joyride';
 
 const JoyrideTooltip: React.FC<TooltipRenderProps> = ({

--- a/src/app/QuickStarts/QuickStartsCatalogPage.tsx
+++ b/src/app/QuickStarts/QuickStartsCatalogPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { QuickStartCatalogPage } from '@patternfly/quickstarts';
-import React from 'react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { withRouter } from 'react-router-dom';
 

--- a/src/app/QuickStarts/quickstarts/automated-rules-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/automated-rules-quickstart.tsx
@@ -15,7 +15,6 @@
  */
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { QuickStart } from '@patternfly/quickstarts';
-import React from 'react';
 import { CryostatIcon, conclusion } from '../quickstart-utils';
 
 const displayName = 'Get started with Automated Rules';

--- a/src/app/QuickStarts/quickstarts/dashboard-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/dashboard-quickstart.tsx
@@ -16,7 +16,6 @@
 import build from '@app/build.json';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { QuickStart } from '@patternfly/quickstarts';
-import React from 'react';
 import { CryostatIcon, conclusion } from '../quickstart-utils';
 
 const displayName = 'Get started with the Dashboard';

--- a/src/app/QuickStarts/quickstarts/generic-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/generic-quickstart.tsx
@@ -18,7 +18,6 @@ import build from '@app/build.json';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { QuickStart } from '@patternfly/quickstarts';
 import { PficonTemplateIcon } from '@patternfly/react-icons';
-import React from 'react';
 import { conclusion } from '../quickstart-utils';
 
 // Quick start name (currently cannot use [APP], there is a bug with how the title gets rendered in the quick start panel)

--- a/src/app/QuickStarts/quickstarts/settings-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/settings-quickstart.tsx
@@ -16,7 +16,6 @@
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { QuickStart } from '@patternfly/quickstarts';
 import { CogIcon } from '@patternfly/react-icons';
-import React from 'react';
 import { conclusion } from '../quickstart-utils';
 
 const displayName = 'Using Settings';

--- a/src/app/QuickStarts/quickstarts/start-a-recording.tsx
+++ b/src/app/QuickStarts/quickstarts/start-a-recording.tsx
@@ -16,7 +16,6 @@
 import build from '@app/build.json';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { QuickStart } from '@patternfly/quickstarts';
-import React from 'react';
 import { CryostatIcon, conclusion } from '../quickstart-utils';
 
 const displayName = 'Start a Recording';

--- a/src/app/QuickStarts/quickstarts/topology/custom-target-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/topology/custom-target-quickstart.tsx
@@ -17,7 +17,6 @@
 import { conclusion, CryostatIcon } from '@app/QuickStarts/quickstart-utils';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { QuickStart } from '@patternfly/quickstarts';
-import * as React from 'react';
 
 const CustomTargetQuickstart: QuickStart = {
   metadata: {

--- a/src/app/QuickStarts/quickstarts/topology/group-start-recordings.tsx
+++ b/src/app/QuickStarts/quickstarts/topology/group-start-recordings.tsx
@@ -17,7 +17,6 @@
 import { conclusion, CryostatIcon } from '@app/QuickStarts/quickstart-utils';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { QuickStart } from '@patternfly/quickstarts';
-import * as React from 'react';
 
 const GroupStartRecordingQuickStart: QuickStart = {
   apiVersion: 'v2.3.0',

--- a/src/app/RecordingMetadata/ClickableLabel.tsx
+++ b/src/app/RecordingMetadata/ClickableLabel.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Label } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 import { RecordingLabel } from './types';
 
 export interface ClickableLabelCellProps {

--- a/src/app/RecordingMetadata/LabelCell.tsx
+++ b/src/app/RecordingMetadata/LabelCell.tsx
@@ -16,7 +16,7 @@
 
 import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 import { Label, Text } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 import { ClickableLabel } from './ClickableLabel';
 import { RecordingLabel } from './types';
 import { getLabelDisplay } from './utils';

--- a/src/app/Recordings/Filters/DurationFilter.tsx
+++ b/src/app/Recordings/Filters/DurationFilter.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Checkbox, Flex, FlexItem, TextInput } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 
 export interface DurationFilterProps {
   durations: string[] | undefined;

--- a/src/app/Recordings/Filters/LabelFilter.tsx
+++ b/src/app/Recordings/Filters/LabelFilter.tsx
@@ -17,7 +17,7 @@
 import { parseLabels, getLabelDisplay } from '@app/RecordingMetadata/utils';
 import { Recording } from '@app/Shared/Services/api.types';
 import { Label, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 
 export interface LabelFilterProps {
   recordings: Recording[];

--- a/src/app/Recordings/Filters/NameFilter.tsx
+++ b/src/app/Recordings/Filters/NameFilter.tsx
@@ -16,7 +16,7 @@
 
 import { Recording } from '@app/Shared/Services/api.types';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 
 export interface NameFilterProps {
   recordings: Recording[];

--- a/src/app/Recordings/Filters/RecordingStateFilter.tsx
+++ b/src/app/Recordings/Filters/RecordingStateFilter.tsx
@@ -16,7 +16,7 @@
 
 import { RecordingState } from '@app/Shared/Services/api.types';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 
 export interface RecordingStateFilterProps {
   filteredStates: RecordingState[] | undefined;

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -34,7 +34,7 @@ import {
   ToolbarToggleGroup,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
-import React from 'react';
+import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { DateTimeFilter } from './Filters/DatetimeFilter';
 import { DurationFilter } from './Filters/DurationFilter';

--- a/src/app/Recordings/RecordingLabelsPanel.tsx
+++ b/src/app/Recordings/RecordingLabelsPanel.tsx
@@ -23,7 +23,7 @@ import {
   DrawerPanelBody,
   DrawerPanelContent,
 } from '@patternfly/react-core';
-import React from 'react';
+import * as React from 'react';
 
 export interface RecordingLabelsPanelProps {
   setShowPanel: (showPanel: React.SetStateAction<boolean>) => void;

--- a/src/app/Settings/Config/AutomatedAnalysis.tsx
+++ b/src/app/Settings/Config/AutomatedAnalysis.tsx
@@ -15,7 +15,6 @@
  */
 
 import { AutomatedAnalysisConfigForm } from '@app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm';
-import * as React from 'react';
 import { SettingTab, UserSetting } from '../types';
 
 const Component = () => {

--- a/src/app/Shared/Components/FileUploads.tsx
+++ b/src/app/Shared/Components/FileUploads.tsx
@@ -23,7 +23,7 @@ import {
   MultipleFileUploadStatusItem,
 } from '@patternfly/react-core';
 import { InProgressIcon, UploadIcon } from '@patternfly/react-icons';
-import React from 'react';
+import * as React from 'react';
 import { Prompt } from 'react-router-dom';
 import { Subject } from 'rxjs';
 

--- a/src/app/Topology/Actions/QuickSearchPanel.tsx
+++ b/src/app/Topology/Actions/QuickSearchPanel.tsx
@@ -47,7 +47,7 @@ import {
 import { SearchIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { useHover } from '@patternfly/react-topology';
-import React from 'react';
+import * as React from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import QuickSearchIcon from '../../Shared/Components/QuickSearchIcon';
 import quickSearches, { QuickSearchId, quickSearchIds } from './quicksearches/all-quick-searches';

--- a/src/app/Topology/Actions/quicksearches/custom-target.tsx
+++ b/src/app/Topology/Actions/quicksearches/custom-target.tsx
@@ -15,7 +15,6 @@
  */
 import openjdkSvg from '@app/assets/openjdk.svg';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
-import * as React from 'react';
 import { QuickSearchItem } from '../types';
 
 const _CustomTargetSearchItem: QuickSearchItem = {

--- a/src/app/Topology/Actions/quicksearches/dev-sample.tsx
+++ b/src/app/Topology/Actions/quicksearches/dev-sample.tsx
@@ -15,7 +15,6 @@
  */
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { ContainerNodeIcon } from '@patternfly/react-icons';
-import * as React from 'react';
 import { QuickSearchItem } from '../types';
 
 const _DevSampleSearchItem: QuickSearchItem = {

--- a/src/app/Topology/Actions/utils.tsx
+++ b/src/app/Topology/Actions/utils.tsx
@@ -25,7 +25,6 @@ import {
 import { getAllLeaves, isTargetNode } from '@app/Shared/Services/api.utils';
 import { NotificationService } from '@app/Shared/Services/Notifications.service';
 import { ContextMenuSeparator } from '@patternfly/react-topology';
-import * as React from 'react';
 import { merge, filter, map, debounceTime } from 'rxjs';
 import { getConnectUrlFromEvent } from '../Entity/utils';
 import { GraphElement, ListElement } from '../Shared/types';

--- a/src/app/Topology/ListView/utils.tsx
+++ b/src/app/Topology/ListView/utils.tsx
@@ -23,7 +23,6 @@ import {
   isTargetNode,
 } from '@app/Shared/Services/api.utils';
 import { Badge, Flex, FlexItem, Label, LabelGroup, TreeViewDataItem } from '@patternfly/react-core';
-import * as React from 'react';
 import { ActionDropdown } from '../Actions/NodeActions';
 import { actionFactory } from '../Actions/utils';
 import EntityDetails from '../Entity/EntityDetails';

--- a/src/app/Topology/Shared/Components/PropertyPath.tsx
+++ b/src/app/Topology/Shared/Components/PropertyPath.tsx
@@ -15,7 +15,7 @@
  */
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import _ from 'lodash';
-import React from 'react';
+import * as React from 'react';
 
 export interface PropertyPathProps {
   kind: string;

--- a/src/app/utils/withThemedIcon.tsx
+++ b/src/app/utils/withThemedIcon.tsx
@@ -15,7 +15,7 @@
  */
 import { ThemeSetting } from '@app/Settings/types';
 import { useTheme } from '@app/utils/hooks/useTheme';
-import React from 'react';
+import * as React from 'react';
 
 export const withThemedIcon = (icon: string, darkIcon: string, alt: string): React.FC => {
   const WithThemedIcon: React.FC = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { App } from '@app/index';
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 
 if (process.env.NODE_ENV !== 'production') {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,4 +17,3 @@ import { App } from '@app/index';
 import ReactDOM from 'react-dom';
 
 ReactDOM.render(<App />, document.getElementById('root') as HTMLElement);
-

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,21 +14,7 @@
  * limitations under the License.
  */
 import { App } from '@app/index';
-import * as React from 'react';
 import ReactDOM from 'react-dom';
 
-if (process.env.NODE_ENV !== 'production') {
-  const config = {
-    rules: [
-      {
-        id: 'color-contrast',
-        enabled: false,
-      },
-    ],
-  };
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, no-undef
-  const axe = require('react-axe');
-  axe(React, ReactDOM, 1000, config);
-}
-
 ReactDOM.render(<App />, document.getElementById('root') as HTMLElement);
+

--- a/src/test/About/About.test.tsx
+++ b/src/test/About/About.test.tsx
@@ -19,7 +19,6 @@ import { ThemeSetting } from '@app/Settings/types';
 import { defaultServices } from '@app/Shared/Services/Services';
 import { cleanup, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import * as React from 'react';
 import { I18nextProvider } from 'react-i18next';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';

--- a/src/test/Agent/AgentLiveProbes.test.tsx
+++ b/src/test/Agent/AgentLiveProbes.test.tsx
@@ -26,7 +26,6 @@ import { NotificationsContext, NotificationsInstance } from '@app/Shared/Service
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import '@testing-library/jest-dom';
 import { cleanup, screen, within } from '@testing-library/react';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';
 import { renderWithServiceContext } from '../Common';

--- a/src/test/Agent/AgentProbeTemplates.test.tsx
+++ b/src/test/Agent/AgentProbeTemplates.test.tsx
@@ -25,7 +25,6 @@ import {
 import { defaultServices } from '@app/Shared/Services/Services';
 import '@testing-library/jest-dom';
 import { cleanup, screen, within } from '@testing-library/react';
-import * as React from 'react';
 import { of, Subject } from 'rxjs';
 import { renderWithServiceContextAndRouter } from '../Common';
 

--- a/src/test/Archives/AllArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllArchivedRecordingsTable.test.tsx
@@ -20,7 +20,6 @@ import { NotificationsContext, NotificationsInstance } from '@app/Shared/Service
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import '@testing-library/jest-dom';
 import { cleanup, screen, within } from '@testing-library/react';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';
 import { renderWithServiceContext } from '../Common';

--- a/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
@@ -19,7 +19,6 @@ import { NotificationsContext, NotificationsInstance } from '@app/Shared/Service
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import '@testing-library/jest-dom';
 import { cleanup, screen, within } from '@testing-library/react';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';
 import { renderWithServiceContext } from '../Common';

--- a/src/test/Archives/Archives.test.tsx
+++ b/src/test/Archives/Archives.test.tsx
@@ -19,7 +19,6 @@ import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { cleanup, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { createMemoryHistory } from 'history';
-import * as React from 'react';
 import { Router } from 'react-router-dom';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';

--- a/src/test/Common.tsx
+++ b/src/test/Common.tsx
@@ -29,7 +29,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import { t, TOptions } from 'i18next';
-import React, { PropsWithChildren } from 'react';
+import * as React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 
@@ -44,7 +44,7 @@ export const renderDefault = (
     ...renderOptions
   } = {},
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
+  const Wrapper = ({ children }: React.PropsWithChildren<unknown>) => {
     return <NotificationsContext.Provider value={notifications}>{children}</NotificationsContext.Provider>;
   };
   return { user, ...render(ui, { wrapper: Wrapper, ...renderOptions }) };
@@ -60,7 +60,7 @@ export const renderWithReduxStore = (
     ...renderOptions
   } = {},
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
+  const Wrapper = ({ children }: React.PropsWithChildren<unknown>) => {
     return (
       <NotificationsContext.Provider value={notifications}>
         <Provider store={store}>{children}</Provider>
@@ -79,7 +79,7 @@ export const renderWithServiceContext = (
     ...renderOptions
   } = {},
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
+  const Wrapper = ({ children }: React.PropsWithChildren<unknown>) => {
     return (
       <ServiceContext.Provider value={services}>
         <NotificationsContext.Provider value={notifications}>{children}</NotificationsContext.Provider>
@@ -98,7 +98,7 @@ export const renderWithRouter = (
     ...renderOptions
   } = {},
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
+  const Wrapper = ({ children }: React.PropsWithChildren<unknown>) => {
     return (
       <NotificationsContext.Provider value={notifications}>
         <Router history={history}>{children}</Router>
@@ -119,7 +119,7 @@ export const renderWithServiceContextAndReduxStore = (
     ...renderOptions
   } = {},
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
+  const Wrapper = ({ children }: React.PropsWithChildren<unknown>) => {
     return (
       <ServiceContext.Provider value={services}>
         <NotificationsContext.Provider value={notifications}>
@@ -141,7 +141,7 @@ export const renderWithServiceContextAndRouter = (
     ...renderOptions
   } = {},
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
+  const Wrapper = ({ children }: React.PropsWithChildren<unknown>) => {
     return (
       <ServiceContext.Provider value={services}>
         <NotificationsContext.Provider value={notifications}>
@@ -165,7 +165,7 @@ export const renderWithServiceContextAndReduxStoreWithRouter = (
     ...renderOptions
   } = {},
 ) => {
-  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
+  const Wrapper = ({ children }: React.PropsWithChildren<unknown>) => {
     return (
       <ServiceContext.Provider value={services}>
         <NotificationsContext.Provider value={notifications}>
@@ -188,7 +188,7 @@ export const renderWithProvidersAndRedux = (
   if (providers.length < 1) {
     throw new Error('At least one provider must be specified');
   }
-  const Wrapper = ({ children }: PropsWithChildren<unknown>) => {
+  const Wrapper = ({ children }: React.PropsWithChildren<unknown>) => {
     let els = children;
     for (let i = 0; i < providers.length; i++) {
       const provider = providers[i];

--- a/src/test/CreateRecording/CustomRecordingForm.test.tsx
+++ b/src/test/CreateRecording/CustomRecordingForm.test.tsx
@@ -21,7 +21,6 @@ import { ServiceContext, Services, defaultServices } from '@app/Shared/Services/
 import { TargetService } from '@app/Shared/Services/Target.service';
 import { screen, cleanup, act as doAct } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import * as React from 'react';
 import { Router } from 'react-router-dom';
 import renderer, { act } from 'react-test-renderer';
 import { of, Subject } from 'rxjs';

--- a/src/test/CreateRecording/SnapshotRecordingForm.test.tsx
+++ b/src/test/CreateRecording/SnapshotRecordingForm.test.tsx
@@ -21,7 +21,6 @@ import { ServiceContext, Services, defaultServices } from '@app/Shared/Services/
 import { TargetService } from '@app/Shared/Services/Target.service';
 import { screen, cleanup, act as doAct } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { of, Subject } from 'rxjs';
 import { renderWithServiceContext } from '../Common';

--- a/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.test.tsx
@@ -28,7 +28,6 @@ import { automatedAnalysisConfigToRecordingAttributes } from '@app/Shared/Servic
 import { defaultServices } from '@app/Shared/Services/Services';
 import '@testing-library/jest-dom';
 import { cleanup, screen, waitFor } from '@testing-library/react';
-import * as React from 'react';
 import { of } from 'rxjs';
 import { basePreloadedState, renderWithServiceContextAndReduxStore, testT } from '../../Common';
 

--- a/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisCardList.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisCardList.test.tsx
@@ -18,7 +18,6 @@ import { store } from '@app/Shared/Redux/ReduxStore';
 import { AnalysisResult, CategorizedRuleEvaluations } from '@app/Shared/Services/api.types';
 import { NotificationsContext, NotificationsInstance } from '@app/Shared/Services/Notifications.service';
 import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
-import React from 'react';
 import { Provider } from 'react-redux';
 import renderer, { act } from 'react-test-renderer';
 

--- a/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigDrawer.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigDrawer.test.tsx
@@ -19,7 +19,6 @@ import { defaultAutomatedAnalysisRecordingConfig } from '@app/Shared/Services/se
 import { defaultServices } from '@app/Shared/Services/Services';
 import '@testing-library/jest-dom';
 import { cleanup, screen } from '@testing-library/react';
-import * as React from 'react';
 import { of } from 'rxjs';
 import { renderWithServiceContext } from '../../Common';
 

--- a/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.test.tsx
@@ -19,7 +19,6 @@ import { AutomatedAnalysisRecordingConfig } from '@app/Shared/Services/service.t
 import { defaultServices } from '@app/Shared/Services/Services';
 import '@testing-library/jest-dom';
 import { cleanup, screen } from '@testing-library/react';
-import * as React from 'react';
 import { of } from 'rxjs';
 import { renderWithServiceContext, testT } from '../../Common';
 

--- a/src/test/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel.test.tsx
@@ -17,7 +17,6 @@
 import { ClickableAutomatedAnalysisLabel } from '@app/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel';
 import { AnalysisResult } from '@app/Shared/Services/api.types';
 import { act, cleanup, screen, within } from '@testing-library/react';
-import React from 'react';
 import { renderDefault } from '../../Common';
 
 const mockRuleEvaluation1: AnalysisResult = {

--- a/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.test.tsx
@@ -17,7 +17,6 @@
 import { AutomatedAnalysisNameFilter } from '@app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter';
 import { AnalysisResult, CategorizedRuleEvaluations } from '@app/Shared/Services/api.types';
 import { cleanup, screen, within } from '@testing-library/react';
-import React from 'react';
 import { renderDefault } from '../../../Common';
 
 const mockRuleEvaluation1: AnalysisResult = {

--- a/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.test.tsx
@@ -18,7 +18,6 @@ import { AutomatedAnalysisScoreFilter } from '@app/Dashboard/AutomatedAnalysis/F
 
 import { RootState } from '@app/Shared/Redux/ReduxStore';
 import { cleanup, screen } from '@testing-library/react';
-import React from 'react';
 import { basePreloadedState, renderWithReduxStore } from '../../../Common';
 
 const onlyShowingText = (value: number) => `Only showing analysis results with severity scores ≥ ${value}:`;

--- a/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.test.tsx
@@ -17,7 +17,6 @@
 import { AutomatedAnalysisTopicFilter } from '@app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter';
 import { AnalysisResult, CategorizedRuleEvaluations } from '@app/Shared/Services/api.types';
 import { cleanup, screen, within } from '@testing-library/react';
-import React from 'react';
 import { renderDefault } from '../../../Common';
 
 const mockRuleEvaluation1: AnalysisResult = {

--- a/src/test/Dashboard/Charts/jfr/JFRMetricsChartCard.test.tsx
+++ b/src/test/Dashboard/Charts/jfr/JFRMetricsChartCard.test.tsx
@@ -27,7 +27,7 @@ import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
 import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory, MemoryHistory } from 'history';
-import React from 'react';
+import * as React from 'react';
 import { Provider } from 'react-redux';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';

--- a/src/test/Dashboard/Charts/mbean/MBeanMetricsChartCard.test.tsx
+++ b/src/test/Dashboard/Charts/mbean/MBeanMetricsChartCard.test.tsx
@@ -30,7 +30,6 @@ import '@i18n/config';
 import { defaultDatetimeFormat } from '@i18n/datetime';
 import { mockMediaQueryList } from '@test/Common';
 import { cleanup } from '@testing-library/react';
-import React from 'react';
 import { Provider } from 'react-redux';
 import renderer, { act } from 'react-test-renderer';
 import { from, of } from 'rxjs';

--- a/src/test/Dashboard/Dashboard.test.tsx
+++ b/src/test/Dashboard/Dashboard.test.tsx
@@ -25,7 +25,6 @@ import { defaultChartControllerConfig } from '@app/Shared/Services/service.utils
 import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
 import { defaultDatetimeFormat } from '@i18n/datetime';
 import { createMemoryHistory } from 'history';
-import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import renderer, { act } from 'react-test-renderer';

--- a/src/test/Dashboard/DashboardLayoutToolbar.test.tsx
+++ b/src/test/Dashboard/DashboardLayoutToolbar.test.tsx
@@ -17,7 +17,6 @@ import { DashboardLayoutToolbar } from '@app/Dashboard/DashboardLayoutToolbar';
 import { store } from '@app/Shared/Redux/ReduxStore';
 import { NotificationsContext, NotificationsInstance } from '@app/Shared/Services/Notifications.service';
 import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
-import React from 'react';
 import { Provider } from 'react-redux';
 import renderer, { act } from 'react-test-renderer';
 

--- a/src/test/DateTimePicker/DateTimePicker.test.tsx
+++ b/src/test/DateTimePicker/DateTimePicker.test.tsx
@@ -18,7 +18,6 @@ import { DateTimePicker } from '@app/DateTimePicker/DateTimePicker';
 import { defaultServices } from '@app/Shared/Services/Services';
 import dayjs, { defaultDatetimeFormat } from '@i18n/datetime';
 import { cleanup, screen, within } from '@testing-library/react';
-import * as React from 'react';
 import { of } from 'rxjs';
 import { renderWithServiceContext, testT } from '../Common';
 

--- a/src/test/DateTimePicker/MeridiemPicker.test.tsx
+++ b/src/test/DateTimePicker/MeridiemPicker.test.tsx
@@ -16,7 +16,6 @@
 
 import { MeridiemPicker } from '@app/DateTimePicker/MeridiemPicker';
 import { cleanup, screen } from '@testing-library/react';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { renderDefault, testT } from '../Common';
 

--- a/src/test/DateTimePicker/TimePicker.test.tsx
+++ b/src/test/DateTimePicker/TimePicker.test.tsx
@@ -16,7 +16,6 @@
 
 import { format2Digit } from '@i18n/datetimeUtils';
 import { cleanup, screen, within } from '@testing-library/react';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { TimePicker } from '../../app/DateTimePicker/TimePicker';
 import { renderDefault, testT } from '../Common';

--- a/src/test/DateTimePicker/TimezonePicker.test.tsx
+++ b/src/test/DateTimePicker/TimezonePicker.test.tsx
@@ -17,7 +17,6 @@ import { TimezonePicker } from '@app/DateTimePicker/TimezonePicker';
 import { defaultServices } from '@app/Shared/Services/Services';
 import dayjs, { defaultDatetimeFormat, supportedTimezones, Timezone } from '@i18n/datetime';
 import { act, cleanup, screen, within } from '@testing-library/react';
-import * as React from 'react';
 import { of } from 'rxjs';
 import { renderDefault, testT } from '../Common';
 

--- a/src/test/Events/EventTemplates.test.tsx
+++ b/src/test/Events/EventTemplates.test.tsx
@@ -22,7 +22,6 @@ import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/
 import { TargetService } from '@app/Shared/Services/Target.service';
 import '@testing-library/jest-dom';
 import { act as doAct, cleanup, screen, within } from '@testing-library/react';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { of, Subject } from 'rxjs';
 import { renderWithServiceContextAndRouter } from '../Common';

--- a/src/test/Events/EventTypes.test.tsx
+++ b/src/test/Events/EventTypes.test.tsx
@@ -21,7 +21,6 @@ import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/
 import { TargetService } from '@app/Shared/Services/Target.service';
 import { act as doAct, cleanup, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { of, Subject } from 'rxjs';
 import { renderWithServiceContext } from '../Common';

--- a/src/test/RecordingMetadata/BulkEditLabels.test.tsx
+++ b/src/test/RecordingMetadata/BulkEditLabels.test.tsx
@@ -24,7 +24,6 @@ import { NotificationsContext, NotificationsInstance } from '@app/Shared/Service
 import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import '@testing-library/jest-dom';
 import { cleanup, screen } from '@testing-library/react';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';
 import { renderWithServiceContext } from '../Common';

--- a/src/test/RecordingMetadata/ClickableLabel.test.tsx
+++ b/src/test/RecordingMetadata/ClickableLabel.test.tsx
@@ -17,7 +17,6 @@ import { ClickableLabel } from '@app/RecordingMetadata/ClickableLabel';
 import { RecordingLabel } from '@app/RecordingMetadata/types';
 import '@testing-library/jest-dom';
 import { cleanup, screen } from '@testing-library/react';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../Common';
 

--- a/src/test/RecordingMetadata/LabelCell.test.tsx
+++ b/src/test/RecordingMetadata/LabelCell.test.tsx
@@ -21,7 +21,6 @@ import { Target } from '@app/Shared/Services/api.types';
 import '@testing-library/jest-dom';
 import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../Common';
 

--- a/src/test/RecordingMetadata/RecordingLabelFields.test.tsx
+++ b/src/test/RecordingMetadata/RecordingLabelFields.test.tsx
@@ -19,7 +19,6 @@ import { ValidatedOptions } from '@patternfly/react-core';
 import '@testing-library/jest-dom';
 import * as tlr from '@testing-library/react';
 import { cleanup, screen } from '@testing-library/react';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../Common';
 

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -29,7 +29,6 @@ import { TargetService } from '@app/Shared/Services/Target.service';
 import dayjs, { defaultDatetimeFormat } from '@i18n/datetime';
 import { act, cleanup, screen, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import * as React from 'react';
 import { of, Subject } from 'rxjs';
 import {
   basePreloadedState,

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -28,7 +28,6 @@ import '@testing-library/jest-dom';
 import * as tlr from '@testing-library/react';
 import { screen, within, cleanup } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import * as React from 'react';
 import { of, Subject } from 'rxjs';
 import {
   basePreloadedState,

--- a/src/test/Recordings/Filters/DatetimeFilter.test.tsx
+++ b/src/test/Recordings/Filters/DatetimeFilter.test.tsx
@@ -19,7 +19,6 @@ import { DateTimeFilter } from '@app/Recordings/Filters/DatetimeFilter';
 import { defaultServices } from '@app/Shared/Services/Services';
 import { defaultDatetimeFormat } from '@i18n/datetime';
 import { act, cleanup, screen, within } from '@testing-library/react';
-import React from 'react';
 import { of } from 'rxjs';
 import { renderDefault, testT } from '../../Common';
 

--- a/src/test/Recordings/Filters/DurationFilter.test.tsx
+++ b/src/test/Recordings/Filters/DurationFilter.test.tsx
@@ -17,7 +17,6 @@
 import { DurationFilter } from '@app/Recordings/Filters/DurationFilter';
 import { ActiveRecording, RecordingState } from '@app/Shared/Services/api.types';
 import { cleanup, screen } from '@testing-library/react';
-import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../../Common';
 

--- a/src/test/Recordings/Filters/LabelFilter.test.tsx
+++ b/src/test/Recordings/Filters/LabelFilter.test.tsx
@@ -17,7 +17,6 @@
 import { LabelFilter } from '@app/Recordings/Filters/LabelFilter';
 import { ActiveRecording, RecordingState } from '@app/Shared/Services/api.types';
 import { cleanup, screen, within } from '@testing-library/react';
-import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../../Common';
 

--- a/src/test/Recordings/Filters/NameFilter.test.tsx
+++ b/src/test/Recordings/Filters/NameFilter.test.tsx
@@ -17,7 +17,6 @@
 import { NameFilter } from '@app/Recordings/Filters/NameFilter';
 import { ActiveRecording, RecordingState } from '@app/Shared/Services/api.types';
 import { cleanup, screen, within } from '@testing-library/react';
-import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../../Common';
 

--- a/src/test/Recordings/Filters/RecordingStateFilter.test.tsx
+++ b/src/test/Recordings/Filters/RecordingStateFilter.test.tsx
@@ -17,7 +17,6 @@
 import { RecordingStateFilter } from '@app/Recordings/Filters/RecordingStateFilter';
 import { ActiveRecording, RecordingState } from '@app/Shared/Services/api.types';
 import { cleanup, screen, within } from '@testing-library/react';
-import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../../Common';
 

--- a/src/test/Recordings/RecordingFilters.test.tsx
+++ b/src/test/Recordings/RecordingFilters.test.tsx
@@ -32,7 +32,6 @@ import { defaultDatetimeFormat } from '@i18n/datetime';
 import { Toolbar, ToolbarContent } from '@patternfly/react-core';
 import { cleanup, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { of } from 'rxjs';
 import { basePreloadedState, renderWithReduxStore } from '../Common';
 

--- a/src/test/Recordings/RecordingLabelsPanel.test.tsx
+++ b/src/test/Recordings/RecordingLabelsPanel.test.tsx
@@ -18,7 +18,6 @@ import { ArchivedRecording } from '@app/Shared/Services/api.types';
 import { Drawer, DrawerContent } from '@patternfly/react-core';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { renderDefault } from '../Common';
 

--- a/src/test/Recordings/Recordings.test.tsx
+++ b/src/test/Recordings/Recordings.test.tsx
@@ -20,7 +20,6 @@ import { ServiceContext, defaultServices } from '@app/Shared/Services/Services';
 import { cleanup, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { createMemoryHistory } from 'history';
-import * as React from 'react';
 import { Router } from 'react-router-dom';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';

--- a/src/test/Recordings/RecordingsTable.test.tsx
+++ b/src/test/Recordings/RecordingsTable.test.tsx
@@ -18,7 +18,6 @@ import { Button, Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@pat
 import { Tbody, Tr, Td } from '@patternfly/react-table';
 import '@testing-library/jest-dom';
 import { cleanup, screen } from '@testing-library/react';
-import * as React from 'react';
 import { renderDefault } from '../Common';
 
 const FakeToolbar = () => {

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -20,7 +20,6 @@ import { defaultServices } from '@app/Shared/Services/Services';
 import '@testing-library/jest-dom';
 import { cleanup, screen, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import * as React from 'react';
 import { of, throwError } from 'rxjs';
 import { renderWithServiceContextAndRouter } from '../Common';
 

--- a/src/test/Rules/Rules.test.tsx
+++ b/src/test/Rules/Rules.test.tsx
@@ -22,7 +22,6 @@ import { ServiceContext, defaultServices, Services } from '@app/Shared/Services/
 import '@testing-library/jest-dom';
 import { act as doAct, cleanup, screen, within } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import * as React from 'react';
 import { Router } from 'react-router-dom';
 import renderer, { act } from 'react-test-renderer';
 import { of, Subject } from 'rxjs';

--- a/src/test/SecurityPanel/Credentials/StoreCredentials.test.tsx
+++ b/src/test/SecurityPanel/Credentials/StoreCredentials.test.tsx
@@ -20,7 +20,6 @@ import { StoredCredential, Target, MatchedCredential, NotificationMessage } from
 import { defaultServices } from '@app/Shared/Services/Services';
 import { Modal, ModalVariant } from '@patternfly/react-core';
 import { cleanup, screen, within } from '@testing-library/react';
-import * as React from 'react';
 import { of, throwError } from 'rxjs';
 
 import { renderWithServiceContext } from '../../Common';

--- a/src/test/Settings/Settings.test.tsx
+++ b/src/test/Settings/Settings.test.tsx
@@ -21,7 +21,6 @@ import { defaultServices, ServiceContext } from '@app/Shared/Services/Services';
 import { Text } from '@patternfly/react-core';
 import { cleanup, screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import * as React from 'react';
 import { Router } from 'react-router-dom';
 import renderer, { act } from 'react-test-renderer';
 import { of } from 'rxjs';

--- a/src/test/Shared/Components/LoadingView.test.tsx
+++ b/src/test/Shared/Components/LoadingView.test.tsx
@@ -16,7 +16,6 @@
 
 import { LoadingView } from '@app/Shared/Components/LoadingView';
 import { cleanup, render, screen } from '@testing-library/react';
-import * as React from 'react';
 import renderer, { act } from 'react-test-renderer';
 
 describe('<LoadingView />', () => {

--- a/src/test/TargetView/TargetSelect.test.tsx
+++ b/src/test/TargetView/TargetSelect.test.tsx
@@ -18,7 +18,6 @@ import { defaultServices } from '@app/Shared/Services/Services';
 import { TargetSelect } from '@app/TargetView/TargetSelect';
 import '@testing-library/jest-dom';
 import { cleanup, screen } from '@testing-library/react';
-import * as React from 'react';
 import { of } from 'rxjs';
 import { renderWithServiceContext } from '../Common';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "target": "es5",
     "lib": ["es6", "dom"],
     "sourceMap": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3182,13 +3182,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:^3.5.0":
-  version: 3.5.6
-  resolution: "axe-core@npm:3.5.6"
-  checksum: 000777d2b6bf1f390beb1fb4b8714ed9127797c021c345b032db0c144e07320dbbe8cb0bcb7688b90b79cfbd3cdc1f27a4dc857804e3c61d7e0defb34deeb830
-  languageName: node
-  linkType: hard
-
 "axios@npm:^0.27.2":
   version: 0.27.2
   resolution: "axios@npm:0.27.2"
@@ -4150,7 +4143,6 @@ __metadata:
     prop-types: ^15.7.2
     raw-loader: ^4.0.2
     react: ^17.0.2
-    react-axe: ^3.4.1
     react-dom: ^17.0.2
     react-i18next: ^12.3.1
     react-joyride: ^2.5.3
@@ -11189,16 +11181,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-axe@npm:^3.4.1":
-  version: 3.5.4
-  resolution: "react-axe@npm:3.5.4"
-  dependencies:
-    axe-core: ^3.5.0
-    requestidlecallback: ^0.3.0
-  checksum: d3f3bc6de6670911ce98d2c80e40ffe71dc798df7b4a7912c1727895886837c3d13dded64dc0387b1db77d55c487365b94cf17e761d0f0f48097b1a6321f09cf
-  languageName: node
-  linkType: hard
-
 "react-dom@npm:^17.0.2":
   version: 17.0.2
   resolution: "react-dom@npm:17.0.2"
@@ -11623,13 +11605,6 @@ __metadata:
   version: 2.0.0
   resolution: "replace-ext@npm:2.0.0"
   checksum: ed640ac90d24cce4be977642847d138908d430049cc097633be33b072143515cc7d29699675a0c35f6dc3c3c73cb529ed352d59649cf15931740eb31ae083c1e
-  languageName: node
-  linkType: hard
-
-"requestidlecallback@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "requestidlecallback@npm:0.3.0"
-  checksum: 2405aef711b516e326ff18849b24ad2c0e623d2b60397bdc7919fa40d8575fce0a16a563a53f94ec89d255325a99e5deee952e6024584a5179cbbabb4469f0e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1110 
Related to #482 

## Description of the change:

- Converted default imports to namespaced imports for `react`. 
- Use new JSX Transformation available in React >= 17.
- Update eslint configurations to select react version that its detected instead of hardcoding (i.e. previously 16 tho we used 17).
- Removed `react-axe` in dev environment.

## Motivation for the change:

For references about namespaced/named imports and JSX transformation:

https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

> In addition to cleaning up unused imports, this will also help you prepare for a future major version of React (not React 17) which will support ES Modules and not have a default export.

For `react-axe`, there is a hiccup about the requirement of default imports for React. I removed it here since we are not using in dev environment, at least until #947. There, perhaps we can explore axe cli (https://github.com/dequelabs/axe-core-npm/blob/develop/packages/cli/README.md).

This is one of the first steps to upgrade to React 18 and PF 5.

## References

https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#jsx-factories