### PR TITLE
fix(requests): use relative request paths

### DIFF
--- a/src/app/Shared/Services/Login.service.tsx
+++ b/src/app/Shared/Services/Login.service.tsx
@@ -40,7 +40,7 @@ export class LoginService {
     private readonly authCredentials: AuthCredentials,
     private readonly settings: SettingsService,
   ) {
-    this.authority = process.env.CRYOSTAT_AUTHORITY || '';
+    this.authority = process.env.CRYOSTAT_AUTHORITY || '.';
     this.token.next(this.getCacheItem(this.TOKEN_KEY));
     this.username.next(this.getCacheItem(this.USER_KEY));
     this.authMethod.next(this.getCacheItem(this.AUTH_METHOD_KEY) as AuthMethod);

--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@ limitations under the License.
   <title>Cryostat</title>
   <meta id="appName" name="application-name" content="Cryostat">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <base href="/">
+  <base href="./">
 </head>
 
 <body>

--- a/src/mirage/index.ts
+++ b/src/mirage/index.ts
@@ -399,7 +399,7 @@ export const startMirage = ({ environment = 'development' } = {}) => {
         },
       ]);
       this.get('api/v2/probes', () => []);
-      this.post('/api/beta/matchExpressions', (_, request) => {
+      this.post('api/beta/matchExpressions', (_, request) => {
         const attr = JSON.parse(request.requestBody);
         if (!attr.matchExpression || !attr.targets) {
           return new Response(400);

--- a/src/test/Shared/Services/Login.service.test.tsx
+++ b/src/test/Shared/Services/Login.service.test.tsx
@@ -117,7 +117,7 @@ describe('Login.service', () => {
       it('should make expected API calls', async () => {
         await firstValueFrom(svc.setLoggedOut());
         expect(mockFromFetch).toHaveBeenCalledTimes(3);
-        expect(mockFromFetch).toHaveBeenNthCalledWith(2, `/api/v2.1/auth`, {
+        expect(mockFromFetch).toHaveBeenNthCalledWith(2, `./api/v2.1/auth`, {
           credentials: 'include',
           mode: 'cors',
           method: 'POST',
@@ -126,7 +126,7 @@ describe('Login.service', () => {
             Authorization: `Basic dXNlcjpkNzRmZjBlZThkYTNiOTgwNmIxOGM4NzdkYmYyOWJiZGU1MGI1YmQ4ZTRkYWQ3YTNhNzI1MDAwZmViODJlOGYx`,
           }),
         });
-        expect(mockFromFetch).toHaveBeenNthCalledWith(3, `/api/v2.1/logout`, {
+        expect(mockFromFetch).toHaveBeenNthCalledWith(3, `./api/v2.1/logout`, {
           credentials: 'include',
           mode: 'cors',
           method: 'POST',
@@ -230,7 +230,7 @@ describe('Login.service', () => {
         it('should make expected API calls', async () => {
           await firstValueFrom(svc.setLoggedOut());
           expect(mockFromFetch).toHaveBeenCalledTimes(3);
-          expect(mockFromFetch).toHaveBeenNthCalledWith(1, `/api/v2.1/auth`, {
+          expect(mockFromFetch).toHaveBeenNthCalledWith(1, `./api/v2.1/auth`, {
             credentials: 'include',
             mode: 'cors',
             method: 'POST',
@@ -239,7 +239,7 @@ describe('Login.service', () => {
               Authorization: `Bearer c2hhMjU2fmhlbGxvd29ybGQ`,
             }),
           });
-          expect(mockFromFetch).toHaveBeenNthCalledWith(2, `/api/v2.1/logout`, {
+          expect(mockFromFetch).toHaveBeenNthCalledWith(2, `./api/v2.1/logout`, {
             credentials: 'include',
             mode: 'cors',
             method: 'POST',
@@ -248,7 +248,7 @@ describe('Login.service', () => {
               Authorization: `Bearer c2hhMjU2fmhlbGxvd29ybGQ`,
             }),
           });
-          expect(mockFromFetch).toHaveBeenNthCalledWith(3, `/api/v2.1/auth`, {
+          expect(mockFromFetch).toHaveBeenNthCalledWith(3, `./api/v2.1/auth`, {
             credentials: 'include',
             mode: 'cors',
             method: 'POST',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -153,8 +153,8 @@ module.exports = (env) => {
       chunkFilename: '[id].[contenthash].bundle.js', // lazy-load modules
       hashFunction: "xxhash64",
       path: path.resolve(__dirname, 'dist'),
-      publicPath: './',
-      clean: true,
+      publicPath: 'auto',
+      clean: true
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.jsx'],

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -3,7 +3,6 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 const BG_IMAGES_DIRNAME = 'bgimages';
-const ASSET_PATH = process.env.ASSET_PATH || '/';
 
 module.exports = (env) => {
   return {
@@ -154,8 +153,8 @@ module.exports = (env) => {
       chunkFilename: '[id].[contenthash].bundle.js', // lazy-load modules
       hashFunction: "xxhash64",
       path: path.resolve(__dirname, 'dist'),
-      publicPath: ASSET_PATH,
-      clean: true
+      publicPath: './',
+      clean: true,
     },
     resolve: {
       extensions: ['.ts', '.tsx', '.js', '.jsx'],


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes https://github.com/cryostatio/cryostat/issues/1810

## Description of the change:
Sets up the `index.html` to use a `<base href="./">`, which indicates to the user's browser that all of the other assets referenced by the index should be resolved relative to the location where the browser found the index on the server.

In the usual case where the Cryostat server responds to requests like `GET /` with `index.html`, the browser will see the associated resources like `favicon.ico` and look for it with a `GET /favicon.ico`. Likewise, the web-client JavaScript resolves API requests assuming that the paths start from the server root location, ex. `/api/v1/recordings`.

If a user were to deploy Cryostat such that it is not on the root path, for example using a proxy like in the linked issue where `/cryostat/foo` on the proxy gets mapped to `/foo` on Cryostat, then this setup is broken. Currently, this results in `index.html` being loaded, but instructing the browser to look for `/favicon.ico` whereas the browser must now instead request `/cryostat/favicon.ico`. Likewise, the JavaScript requests should go to ex. `/cryostat/api/v1/recordings`, but will instead incorrectly go to `/api/v1/recordings`.

## Motivation for the change:
Without this change, the `<base href="/">` used means that the `index.html` tells the browser to always look for the associated assets at the server root path, rather than look for them relative to where `index.html` was found.

If a user deploys Cryostat behind a proxy that places it on a non-root path, for example, then this breaks the browser's ability to load resources other than `index.html` - see https://github.com/cryostatio/cryostat/issues/1810 .

Similarly, the JavaScript of the web-client makes requests to the Cryostat server assuming that it should be reached at the absolute path `/`, so all API requests resolve to ex. `/api/v1/recordings`. This change also allows these requests to be relative to the document location, ex. `/test/api/v1/recordings`, so that the API requests would be handled by the proxy and routed back to the Cryostat server, back through the router, then back to the browser.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Clone https://github.com/andrewazores/proxy-test, `./build.bash && ./run.bash`
3. Open web browser to `https://localhost:8181` and ensure Cryostat still works as expected in the normal case where it is not behind any proxy and is located on the root path
4. Go to `http://localhost:7878` and ensure an Nginx default page appears, indicating that the proxy is running.
5. Go to `http://localhost:7878/test` - the reverse proxy will accept requests here and pass them to Cryostat, but with the `/test/` portion at the beginning of the path removed. To be sure, do a hard refresh here or use a private/incognito window so that your browser is not using cached assets. You should still be able to load the Cryostat web-client UI and click around.

Note: There is a bug in the proxy setup where it unencodes URI segments before passing them to the server, so some views will look broken due to HTTP 404s - verify that if these occur, the browser's devtools network tab shows that the correct request with the encoded path was made, but the proxy and server logs show that the server received a request for an unencoded path:

![Screenshot_2023-12-07_09-50-30](https://github.com/cryostatio/cryostat-web/assets/3787464/c91489b1-a794-4c10-a872-a342eae846e2)

```
INFO: 10.0.2.100 - - [Thu, 7 Dec 2023 14:50:13 GMT] 4ms "GET /api/v1/targets HTTP/1.0" 200 1 KB "http://localhost:7878/test/" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0"
Dec 07, 2023 2:50:13 PM org.slf4j.impl.JDK14LoggerAdapter fillCallerData
INFO: 10.0.2.100 - - [Thu, 7 Dec 2023 14:50:13 GMT] 6ms "GET /api/v1/recordings HTTP/1.0" 200 2 bytes "http://localhost:7878/test/" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0"
Dec 07, 2023 2:50:13 PM org.slf4j.impl.JDK14LoggerAdapter fillCallerData
INFO: 10.0.2.100 - - [Thu, 7 Dec 2023 14:50:13 GMT] 1ms "GET /api/v1/recordings HTTP/1.0" 200 2 bytes "http://localhost:7878/test/" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0"
Dec 07, 2023 2:50:17 PM org.slf4j.impl.JDK14LoggerAdapter fillCallerData
WARNING: 10.0.2.100 - - [Thu, 7 Dec 2023 14:50:17 GMT] 0ms "GET /api/v1/targets/service:jmx:rmi:/jndi/rmi:/localhost:0/jmxrmi/recordings HTTP/1.0" 404 53 bytes "http://localhost:7878/recordings" "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0"
```

You will probably hit the web-client's 404 page when first visiting `/test/` on the proxy - this seems like a relatively minor bug and goes away once you click around anywhere else in the UI. There might be something to do to fix this but it seems minor enough to just live with for now.

![Screenshot_2023-12-07_10-01-54](https://github.com/cryostatio/cryostat-web/assets/3787464/70b0fc93-786b-4735-bf8d-bacaa59b8db8)

To compare against the existing behaviour, run the same steps as above, but with a plain upstream `main` image rather than the CI-built image here. The usual `https://localhost:8181` should be the normal baseline for comparison. Running the proxy and going to `http://localhost:7878/test` should illustrate the broken behaviour: the browser will load `index.html`, but fail to load all other CSS, JS, etc. resources.