### PR TITLE
ci(submodule): remove config for updating old 2.x repo

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -19,40 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        repository: cryostatio/cryostat
-        token: "${{ secrets.SUBMODULE_TOKEN }}"
-        ref: "${{ github.ref_name }}"
-    - name: Check remote submodule branch
-      run: |
-        remote_branch="$(git config --get -f .gitmodules submodule.web-client.branch)"
-        if [[ "$remote_branch" != "${{ github.ref_name }}" ]]; then
-          printf "Expected remote branch %s, found branch %s\n" "${{ github.ref_name }}" "$remote_branch" >&2
-          exit 1
-        fi
-    - name: Import GPG key
-      uses: crazy-max/ghaction-import-gpg@v6
-      with:
-        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.GPG_PASSPHRASE }}
-        git_user_signingkey: true
-        git_commit_gpgsign: true
-    - name: Update submodule to latest commit
-      run: |
-        git submodule update --init
-        git submodule update --remote
-    - name: Commit and push submodule
-      run: |
-        git add --all
-        git_hash="$(git rev-parse --short :web-client)"
-        git commit -S -m "build(web-client): update submodule to $git_hash" || echo "No changes to commit"
-        git push
-
-  update-cryostat3-submodule:
-    if: ${{ github.repository_owner == 'cryostatio' }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
         repository: cryostatio/cryostat3
         token: "${{ secrets.SUBMODULE_TOKEN }}"
         ref: "${{ github.ref_name }}"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #<issue number>

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
