### PR TITLE
feat(recording): API v3 downloads

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -775,26 +775,6 @@ export class ApiService {
     );
   }
 
-  downloadReport(recording: Recording): void {
-    const body = new window.FormData();
-    if (isActiveRecording(recording)) {
-      body.append('resource', recording.reportUrl.replace('/api/v1', '/api/v2.1'));
-    } else {
-      body.append('resource', recording.reportUrl.concat('/jwt'));
-    }
-    this.sendRequest('v2.1', 'auth/token', {
-      method: 'POST',
-      body,
-    })
-      .pipe(
-        concatMap((resp) => resp.json()),
-        map((response: AssetJwtResponse) => response.data.result.resourceUrl),
-      )
-      .subscribe((resourceUrl) => {
-        this.downloadFile(resourceUrl, `${recording.name}.report.json`, false);
-      });
-  }
-
   downloadRecording(recording: Recording): void {
     const body = new window.FormData();
     if (isActiveRecording(recording)) {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -61,7 +61,7 @@ import {
   XMLHttpRequestConfig,
   XMLHttpResponse,
 } from './api.types';
-import { isHttpError, isActiveRecording, includesTarget, isHttpOk, isXMLHttpError } from './api.utils';
+import { isHttpError, includesTarget, isHttpOk, isXMLHttpError } from './api.utils';
 import { LoginService } from './Login.service';
 import { NotificationService } from './Notifications.service';
 import { SessionState } from './service.types';

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -776,27 +776,11 @@ export class ApiService {
   }
 
   downloadRecording(recording: Recording): void {
-    const body = new window.FormData();
-    if (isActiveRecording(recording)) {
-      body.append('resource', recording.downloadUrl.replace('/api/v1', '/api/v2.1'));
-    } else {
-      body.append('resource', recording.downloadUrl.concat('/jwt'));
-    }
-    this.sendRequest('v2.1', 'auth/token', {
-      method: 'POST',
-      body,
-    })
-      .pipe(
-        concatMap((resp) => resp.json()),
-        map((response: AssetJwtResponse) => response.data.result.resourceUrl),
-      )
-      .subscribe((resourceUrl) => {
-        this.downloadFile(resourceUrl, recording.name + (recording.name.endsWith('.jfr') ? '' : '.jfr'));
-        this.downloadFile(
-          createBlobURL(JSON.stringify(recording.metadata), 'application/json'), // Blob for metadata
-          recording.name.replace(/\.jfr$/, '') + '.metadata.json',
-        );
-      });
+    this.downloadFile(recording.downloadUrl, recording.name + (recording.name.endsWith('.jfr') ? '' : '.jfr'));
+    this.downloadFile(
+      createBlobURL(JSON.stringify(recording.metadata), 'application/json'),
+      recording.name.replace(/\.jfr$/, '') + '.metadata.json',
+    );
   }
 
   downloadTemplate(template: EventTemplate): void {

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -82,7 +82,6 @@ jest.spyOn(defaultServices.api, 'archiveRecording').mockReturnValue(of(true));
 jest.spyOn(defaultServices.api, 'deleteRecording').mockReturnValue(of(true));
 jest.spyOn(defaultServices.api, 'doGet').mockReturnValue(of([mockRecording]));
 jest.spyOn(defaultServices.api, 'downloadRecording').mockReturnValue(void 0);
-jest.spyOn(defaultServices.api, 'downloadReport').mockReturnValue(void 0);
 jest.spyOn(defaultServices.api, 'grafanaDashboardUrl').mockReturnValue(of('/grafanaUrl'));
 jest.spyOn(defaultServices.api, 'grafanaDatasourceUrl').mockReturnValue(of('/datasource'));
 jest.spyOn(defaultServices.api, 'stopRecording').mockReturnValue(of(true));

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -101,7 +101,6 @@ jest.mock('@app/Recordings/RecordingFilters', () => {
 
 jest.spyOn(defaultServices.api, 'deleteArchivedRecording').mockReturnValue(of(true));
 jest.spyOn(defaultServices.api, 'downloadRecording').mockReturnValue();
-jest.spyOn(defaultServices.api, 'downloadReport').mockReturnValue();
 jest.spyOn(defaultServices.api, 'grafanaDatasourceUrl').mockReturnValue(of('/datasource'));
 jest.spyOn(defaultServices.api, 'grafanaDashboardUrl').mockReturnValue(of('/grafanaUrl'));
 jest.spyOn(defaultServices.api, 'graphql').mockReturnValue(of(mockArchivedRecordingsResponse));


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to cryostatio/cryostat3#2
Depends on https://github.com/cryostatio/cryostat3/pull/235

## Description of the change:
Removes the old API V2.1 JWT download flow in favour of simply following the new API V3 download URL redirect flow.

## Motivation for the change:
This restores the web UI's ability to download active and archived recording files with the new V3 API, which does not re-implement the previous JWT flow.

## How to test:
See  https://github.com/cryostatio/cryostat3/pull/235
