### PR TITLE
chore(templates): remove auth token download flow

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -791,24 +791,12 @@ export class ApiService {
         map(
           (target) =>
             `${this.login.authority}/api/v2.1/targets/${encodeURIComponent(
-              target?.connectUrl || '',
+              target!.connectUrl,
             )}/templates/${encodeURIComponent(template.name)}/type/${encodeURIComponent(template.type)}`,
         ),
       )
-      .subscribe((resource) => {
-        const body = new window.FormData();
-        body.append('resource', resource);
-        this.sendRequest('v2.1', 'auth/token', {
-          method: 'POST',
-          body,
-        })
-          .pipe(
-            concatMap((resp) => resp.json()),
-            map((response: AssetJwtResponse) => response.data.result.resourceUrl),
-          )
-          .subscribe((resourceUrl) => {
-            this.downloadFile(resourceUrl, `${template.name}.jfc`);
-          });
+      .subscribe((resourceUrl) => {
+        this.downloadFile(resourceUrl, `${template.name}.jfc`);
       });
   }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat3/pull/290
Depends on https://github.com/cryostatio/cryostat3/pull/290

## Description of the change:
Removes the old API v2.1 auth token download flow in the middle of the event template download action. In 3.0 the client can simply request the file.

## Motivation for the change:
This enables the "Events -> Event Templates -> SomeTemplate -> Download" feature to work again with 3.0.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
