### PR TITLE
fix(graphql): emit notifications on server error response

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -770,6 +770,14 @@ export class ApiService {
     ).pipe(
       map((resp) => resp.json()),
       concatMap(from),
+      tap(resp => {
+        if (suppressNotifications || !resp?.errors?.length) {
+          return;
+        }
+        resp.errors.forEach(err =>
+          this.notifications.danger(`Request failed (${err.extensions.classification})`, err.message)
+        );
+      }),
       first(),
     );
   }

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -770,12 +770,12 @@ export class ApiService {
     ).pipe(
       map((resp) => resp.json()),
       concatMap(from),
-      tap(resp => {
+      tap((resp) => {
         if (suppressNotifications || !resp?.errors?.length) {
           return;
         }
-        resp.errors.forEach(err =>
-          this.notifications.danger(`Request failed (${err.extensions.classification})`, err.message)
+        resp.errors.forEach((err) =>
+          this.notifications.danger(`Request failed (${err.extensions.classification})`, err.message),
         );
       }),
       first(),


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #65
Related to #410
Related to https://github.com/cryostatio/cryostat3/issues/11

## Description of the change:
GraphQL queries which do not explicitly suppress notifications will emit a graphical notification box if there are GraphQL errors in the response.

## Motivation for the change:
Previously, notifications would only be displayed if the GraphQL response status code was `4xx/5xx`. With this change, `2xx` responses which contain a GraphQL error response will also display notifications. This provides the user (or developer) more information about what went wrong with the request.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
