### PR TITLE
fix(rules): correct removal of 'id' field from Rule object

### DIFF
--- a/src/app/Rules/RulesUploadModal.tsx
+++ b/src/app/Rules/RulesUploadModal.tsx
@@ -36,7 +36,7 @@ export const parseRule = (file: File): Observable<Rule> => {
     file.text().then((content) => {
       const obj = JSON.parse(content);
       if (obj.id) {
-        obj.remove('id');
+        delete obj.id;
       }
       if (isRule(obj)) {
         return obj;


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1211

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
