### PR TITLE
fix(graphql): query target nodes by targets' IDs rather than connectUrls

### DIFF
--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -223,8 +223,8 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
       addSubscription(
         context.api
           .graphql<any>(
-            `query ArchiveCountForTarget($connectUrl: String) {
-              targetNodes(filter: { name: $connectUrl }) {
+            `query ArchiveCountForTarget($id: BigInteger!) {
+              targetNodes(filter: { targetIds: [$id] }) {
                 target {
                   archivedRecordings {
                     data {
@@ -248,7 +248,7 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
                 }
               }
             }`,
-            { connectUrl: target.connectUrl },
+            { id: target.id! },
           )
           .subscribe((v) => {
             setArchivesForTargets((old) => {

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -189,8 +189,8 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
             filter((target) => !!target),
             concatMap((target: Target) =>
               context.api.graphql<any>(
-                `query ArchivedRecordingsForTarget($connectUrl: String) {
-                targetNodes(filter: { name: $connectUrl }) {
+                `query ArchivedRecordingsForTarget($id: BigInteger!) {
+                targetNodes(filter: { targetIds: [$id] }) {
                   target {
                     archivedRecordings {
                       data {
@@ -210,7 +210,7 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
                   }
                 }
               }`,
-                { connectUrl: target.connectUrl },
+                { id: target.id! },
               ),
             ),
             map((v) => v.data.targetNodes[0].target.archivedRecordings.data as ArchivedRecording[]),

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -187,12 +187,12 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
   );
 
   const queryTargetRecordings = React.useCallback(
-    (connectUrl: string) => {
+    (targetId: number) => {
       /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
       return context.api.graphql<any>(
         `
-      query ArchivedRecordingsForTarget($connectUrl: String) {
-        targetNodes(filter: { name: $connectUrl }) {
+      query ArchivedRecordingsForTarget($id: BigInteger!) {
+        targetNodes(filter: { targetIds: [$id] }) {
           target {
             archivedRecordings {
               data {
@@ -211,7 +211,7 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
           }
         }
       }`,
-        { connectUrl },
+        { id: targetId },
       );
     },
     [context.api],
@@ -259,7 +259,7 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
           .pipe(
             filter((target) => !!target),
             first(),
-            concatMap((target: Target) => queryTargetRecordings(target.connectUrl)),
+            concatMap((target: Target) => queryTargetRecordings(target.id!)),
             map((v) => v.data.targetNodes[0].target.archivedRecordings.data as ArchivedRecording[]),
           )
           .subscribe({

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -945,8 +945,8 @@ export class ApiService {
       concatMap((target) =>
         this.graphql<any>(
           `
-        query PostRecordingMetadata($connectUrl: String, $recordingName: String, $labels: [Entry_String_StringInput]) {
-          targetNodes(filter: { name: $connectUrl }) {
+        query PostRecordingMetadata($id: BigInteger!, $recordingName: String, $labels: [Entry_String_StringInput]) {
+          targetNodes(filter: { targetIds: [$id] }) {
             target {
               archivedRecordings(filter: { name: $recordingName }) {
                 data {
@@ -966,7 +966,7 @@ export class ApiService {
           }
         }`,
           {
-            connectUrl: target.connectUrl,
+            id: target.id!,
             recordingName,
             labels: labels.map((label) => ({ key: label.key, value: label.value })),
           },
@@ -1010,8 +1010,8 @@ export class ApiService {
       concatMap((target: Target) =>
         this.graphql<any>(
           `
-        query PostActiveRecordingMetadata($connectUrl: String, $recordingName: String, $labels: [Entry_String_StringInput]) {
-          targetNodes(filter: { name: $connectUrl }) {
+        query PostActiveRecordingMetadata($id: BigInteger!, $recordingName: String, $labels: [Entry_String_StringInput]) {
+          targetNodes(filter: { targetIds: [$id] }) {
             target {
               activeRecordings(filter: { name: $recordingName }) {
                 data {
@@ -1031,7 +1031,7 @@ export class ApiService {
           }
         }`,
           {
-            connectUrl: target.connectUrl,
+            id: target.id!,
             recordingName,
             labels: labels.map((label) => ({ key: label.key, value: label.value })),
           },
@@ -1193,8 +1193,8 @@ export class ApiService {
   targetHasRecording(target: TargetStub, filter: ActiveRecordingsFilterInput = {}): Observable<boolean> {
     return this.graphql<RecordingCountResponse>(
       `
-        query ActiveRecordingsForJFRMetrics($connectUrl: String, $recordingFilter: ActiveRecordingsFilterInput) {
-          targetNodes(filter: { name: $connectUrl }) {
+        query ActiveRecordingsForJFRMetrics($id: BigInteger!, $recordingFilter: ActiveRecordingsFilterInput) {
+          targetNodes(filter: { targetIds: [$id] }) {
             target {
               activeRecordings(filter: $recordingFilter) {
                 aggregate {
@@ -1205,7 +1205,7 @@ export class ApiService {
           }
         }`,
       {
-        connectUrl: target.connectUrl,
+        id: target.id!,
         recordingFilter: filter,
       },
       true,
@@ -1280,8 +1280,8 @@ export class ApiService {
   getTargetMBeanMetrics(target: TargetStub, queries: string[]): Observable<MBeanMetrics> {
     return this.graphql<MBeanMetricsResponse>(
       `
-        query MBeanMXMetricsForTarget($connectUrl: String) {
-          targetNodes(filter: { name: $connectUrl }) {
+        query MBeanMXMetricsForTarget($id: BigInteger!) {
+          targetNodes(filter: { targetIds: [$id] }) {
             target {
               mbeanMetrics {
                 ${queries.join('\n')}
@@ -1289,7 +1289,7 @@ export class ApiService {
             }
           }
         }`,
-      { connectUrl: target.connectUrl },
+      { id: target.id! },
     ).pipe(
       map((resp) => {
         const nodes = resp.data.targetNodes;
@@ -1305,8 +1305,8 @@ export class ApiService {
   getTargetArchivedRecordings(target: TargetStub): Observable<ArchivedRecording[]> {
     return this.graphql<any>(
       `
-        query ArchivedRecordingsForTarget($connectUrl: String) {
-          targetNodes(filter: { name: $connectUrl }) {
+        query ArchivedRecordingsForTarget($id: BigInteger!) {
+          targetNodes(filter: { targetIds: [$id] }) {
             target {
               archivedRecordings {
                 data {
@@ -1326,7 +1326,7 @@ export class ApiService {
             }
           }
         }`,
-      { connectUrl: target.connectUrl },
+      { id: target.id! },
       true,
       true,
     ).pipe(map((v) => v.data.targetNodes[0].target.archivedRecordings.data as ArchivedRecording[]));

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -269,7 +269,7 @@ const MBeanDetails: React.FC<{
         context.api
           .graphql<MBeanMetricsResponse>(
             `
-            query MBeanMXMetricsForTarget(id: BigInteger!) {
+            query MBeanMXMetricsForTarget($id: BigInteger!) {
               targetNodes(filter: { targetIds: [$id] }) {
                 target {
                   mbeanMetrics {

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -247,7 +247,7 @@ export const TargetDetails: React.FC<{
         onToggle={onToggle}
         isExpanded={isExpanded}
       >
-        <MBeanDetails isExpanded={isExpanded} connectUrl={serviceRef.connectUrl} columnModifier={columnModifier} />
+        <MBeanDetails isExpanded={isExpanded} targetId={serviceRef.id!} columnModifier={columnModifier} />
       </ExpandableSection>
     </>
   );
@@ -255,9 +255,9 @@ export const TargetDetails: React.FC<{
 
 const MBeanDetails: React.FC<{
   isExpanded: boolean;
-  connectUrl: string;
+  targetId: number;
   columnModifier?: React.ComponentProps<typeof DescriptionList>['columnModifier'];
-}> = ({ isExpanded, connectUrl, columnModifier }) => {
+}> = ({ isExpanded, targetId, columnModifier }) => {
   const context = React.useContext(ServiceContext);
   const [dayjs, dateTimeFormat] = useDayjs();
   const addSubscription = useSubscriptions();
@@ -269,8 +269,8 @@ const MBeanDetails: React.FC<{
         context.api
           .graphql<MBeanMetricsResponse>(
             `
-            query MBeanMXMetricsForTarget($connectUrl: String) {
-              targetNodes(filter: { name: $connectUrl }) {
+            query MBeanMXMetricsForTarget(id: BigInteger!) {
+              targetNodes(filter: { targetIds: [$id] }) {
                 target {
                   mbeanMetrics {
                     runtime {
@@ -297,7 +297,7 @@ const MBeanDetails: React.FC<{
                 }
               }
             }`,
-            { connectUrl },
+            { id: targetId },
           )
           .pipe(
             map((resp) => resp.data.targetNodes[0].target.mbeanMetrics || {}),
@@ -306,7 +306,7 @@ const MBeanDetails: React.FC<{
           .subscribe(setMbeanMetrics),
       );
     }
-  }, [isExpanded, addSubscription, connectUrl, context.api, setMbeanMetrics]);
+  }, [isExpanded, addSubscription, targetId, context.api, setMbeanMetrics]);
 
   const _collapsedData = React.useMemo((): DescriptionConfig[] => {
     return [


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1244
Depends on https://github.com/cryostatio/cryostat3/pull/342 (`targetIds` filter is added here)

## Description of the change:
Updates GraphQL queries that act upon particular targets to do so by their IDs, rather than using the `connectUrl` as the node name filter.

## Motivation for the change:
It is not guaranteed, and is not true for Cryostat Agent instances, that the discovery nodes' names are equal to their connection URLs. This fixes queries being unable to locate such nodes.

## How to manually test:
1. Combine with https://github.com/cryostatio/cryostat3/pull/342
2. Select `quarkus-test-agent` target
3. Go to Recordings, create a new recording, wait a few moments, then archive it
4. Click the Archived recordings tab. The recording should appear in the table
