### PR TITLE
fix(graphql): handle nullable response fields that can occur when there are server errors

### DIFF
--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -199,15 +199,17 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
         )
         .pipe(
           map((v) => {
-            return v.data?.targetNodes?.map((node) => {
-              const target: Target = node?.target;
-              return {
-                target,
-                targetAsObs: of(target),
-                archiveCount: node?.target?.archivedRecordings?.aggregate?.count ?? 0,
-                recordings: node?.target?.archivedRecordings?.data as ArchivedRecording[] ?? [],
-              };
-            }).filter(v => !!v.target);
+            return v.data?.targetNodes
+              ?.map((node) => {
+                const target: Target = node?.target;
+                return {
+                  target,
+                  targetAsObs: of(target),
+                  archiveCount: node?.target?.archivedRecordings?.aggregate?.count ?? 0,
+                  recordings: (node?.target?.archivedRecordings?.data as ArchivedRecording[]) ?? [],
+                };
+              })
+              .filter((v) => !!v.target);
           }),
         )
         .subscribe({

--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -199,15 +199,15 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
         )
         .pipe(
           map((v) => {
-            return v.data.targetNodes.map((node) => {
-              const target: Target = node.target;
+            return v.data?.targetNodes?.map((node) => {
+              const target: Target = node?.target;
               return {
                 target,
                 targetAsObs: of(target),
-                archiveCount: node.target.archivedRecordings.aggregate.count,
-                recordings: node.target.archivedRecordings.data as ArchivedRecording[],
+                archiveCount: node?.target?.archivedRecordings?.aggregate?.count ?? 0,
+                recordings: node?.target?.archivedRecordings?.data as ArchivedRecording[] ?? [],
               };
-            });
+            }).filter(v => !!v.target);
           }),
         )
         .subscribe({
@@ -258,7 +258,7 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
                   target: target,
                   targetAsObs: of(target),
                   archiveCount: v.data.targetNodes[0]?.target?.archivedRecordings?.aggregate?.count ?? 0,
-                  recordings: v.data.targetNodes[0]?.target?.archivedRecordings,
+                  recordings: v.data.targetNodes[0]?.target?.archivedRecordings ?? [],
                 },
               ];
             });

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -313,7 +313,7 @@ export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> 
           queryArchivedRecordings(target.id!)
             .pipe(
               first(),
-              map((v) => v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[] ?? []),
+              map((v) => (v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[]) ?? []),
             )
             .subscribe({
               next: (recordings) => {

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -313,7 +313,7 @@ export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> 
           queryArchivedRecordings(target.id!)
             .pipe(
               first(),
-              map((v) => v.data.targetNodes[0].target.archivedRecordings.data as ArchivedRecording[]),
+              map((v) => v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[] ?? []),
             )
             .subscribe({
               next: (recordings) => {
@@ -368,7 +368,7 @@ export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> 
                     }
                   }
                 }),
-                map((v) => v.data.targetNodes[0].target.activeRecordings.data[0] as Recording),
+                map((v) => v.data?.targetNodes[0]?.target?.activeRecordings?.data[0] as Recording),
                 tap((recording) => {
                   if (recording === null || recording === undefined) {
                     throw new Error(NO_RECORDINGS_MESSAGE);

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -182,7 +182,7 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
               { filter: { sourceTarget: UPLOADS_SUBDIRECTORY } },
             )
             .pipe(
-              map((v) => v.data.archivedRecordings.data as ArchivedRecording[]),
+              map((v) => v.data?.archivedRecordings?.data as ArchivedRecording[] ?? []),
               first(),
             )
         : context.target.target().pipe(
@@ -213,7 +213,7 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
                 { id: target.id! },
               ),
             ),
-            map((v) => v.data.targetNodes[0].target.archivedRecordings.data as ArchivedRecording[]),
+            map((v) => v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[] ?? []),
             first(),
           );
     }

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -182,7 +182,7 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
               { filter: { sourceTarget: UPLOADS_SUBDIRECTORY } },
             )
             .pipe(
-              map((v) => v.data?.archivedRecordings?.data as ArchivedRecording[] ?? []),
+              map((v) => (v.data?.archivedRecordings?.data as ArchivedRecording[]) ?? []),
               first(),
             )
         : context.target.target().pipe(
@@ -213,7 +213,7 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
                 { id: target.id! },
               ),
             ),
-            map((v) => v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[] ?? []),
+            map((v) => (v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[]) ?? []),
             first(),
           );
     }

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -247,7 +247,7 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
     } else if (isUploadsTable) {
       addSubscription(
         queryUploadedRecordings()
-          .pipe(map((v) => v.data.archivedRecordings.data as ArchivedRecording[]))
+          .pipe(map((v) => v?.data?.archivedRecordings?.data as ArchivedRecording[] ?? []))
           .subscribe({
             next: handleRecordings,
             error: handleError,
@@ -260,7 +260,7 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
             filter((target) => !!target),
             first(),
             concatMap((target: Target) => queryTargetRecordings(target.id!)),
-            map((v) => v.data.targetNodes[0].target.archivedRecordings.data as ArchivedRecording[]),
+            map((v) => v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[] ?? []),
           )
           .subscribe({
             next: handleRecordings,

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -247,7 +247,7 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
     } else if (isUploadsTable) {
       addSubscription(
         queryUploadedRecordings()
-          .pipe(map((v) => v?.data?.archivedRecordings?.data as ArchivedRecording[] ?? []))
+          .pipe(map((v) => (v?.data?.archivedRecordings?.data as ArchivedRecording[]) ?? []))
           .subscribe({
             next: handleRecordings,
             error: handleError,
@@ -260,7 +260,7 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
             filter((target) => !!target),
             first(),
             concatMap((target: Target) => queryTargetRecordings(target.id!)),
-            map((v) => v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[] ?? []),
+            map((v) => (v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[]) ?? []),
           )
           .subscribe({
             next: handleRecordings,

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -591,7 +591,7 @@ export class ApiService {
         recordingName,
         labels: labels.map((label) => ({ key: label.key, value: label.value })),
       },
-    ).pipe(map((v) => v.data.archivedRecordings.data as ArchivedRecording[]));
+    ).pipe(map((v) => v.data?.archivedRecordings?.data as ArchivedRecording[] ?? []));
   }
 
   isProbeEnabled(): Observable<boolean> {
@@ -972,7 +972,7 @@ export class ApiService {
           },
         ),
       ),
-      map((v) => v.data.targetNodes[0].target.archivedRecordings as ArchivedRecording[]),
+      map((v) => v.data?.targetNodes[0]?.target?.archivedRecordings as ArchivedRecording[] ?? []),
     );
   }
 
@@ -1000,7 +1000,7 @@ export class ApiService {
         recordingName,
         labels: labels.map((label) => ({ key: label.key, value: label.value })),
       },
-    ).pipe(map((v) => v.data.archivedRecordings.data as ArchivedRecording[]));
+    ).pipe(map((v) => v.data?.archivedRecordings?.data as ArchivedRecording[] ?? []));
   }
 
   postTargetRecordingMetadata(recordingName: string, labels: KeyValue[]): Observable<ActiveRecording[]> {
@@ -1037,7 +1037,7 @@ export class ApiService {
           },
         ),
       ),
-      map((v) => v.data.targetNodes[0].target.activeRecordings as ActiveRecording[]),
+      map((v) => v.data?.targetNodes[0]?.target?.activeRecordings as ActiveRecording[] ?? []),
     );
   }
 
@@ -1180,7 +1180,7 @@ export class ApiService {
     ).pipe(
       first(),
       map((body) =>
-        body.data.environmentNodes[0].descendantTargets.reduce(
+        (body.data?.environmentNodes[0]?.descendantTargets ?? []).reduce(
           (acc: number, curr) => acc + curr.target.activeRecordings.aggregate.count,
           0,
         ),
@@ -1212,11 +1212,11 @@ export class ApiService {
       true,
     ).pipe(
       map((resp) => {
-        const nodes = resp.data.targetNodes;
+        const nodes = resp.data?.targetNodes ?? [];
         if (nodes.length === 0) {
           return false;
         }
-        const count = nodes[0].target.activeRecordings.aggregate.count;
+        const count = nodes[0]?.target?.activeRecordings?.aggregate?.count ?? 0;
         return count > 0;
       }),
       catchError((_) => of(false)),
@@ -1292,11 +1292,11 @@ export class ApiService {
       { id: target.id! },
     ).pipe(
       map((resp) => {
-        const nodes = resp.data.targetNodes;
+        const nodes = resp.data?.targetNodes ?? [];
         if (!nodes || nodes.length === 0) {
           return {};
         }
-        return nodes[0]?.target.mbeanMetrics;
+        return nodes[0]?.target?.mbeanMetrics ?? {};
       }),
       catchError((_) => of({})),
     );
@@ -1329,7 +1329,7 @@ export class ApiService {
       { id: target.id! },
       true,
       true,
-    ).pipe(map((v) => v.data.targetNodes[0].target.archivedRecordings.data as ArchivedRecording[]));
+    ).pipe(map((v) => v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[] ?? []));
   }
 
   getTargetActiveRecordings(target: TargetStub): Observable<ActiveRecording[]> {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -591,7 +591,7 @@ export class ApiService {
         recordingName,
         labels: labels.map((label) => ({ key: label.key, value: label.value })),
       },
-    ).pipe(map((v) => v.data?.archivedRecordings?.data as ArchivedRecording[] ?? []));
+    ).pipe(map((v) => (v.data?.archivedRecordings?.data as ArchivedRecording[]) ?? []));
   }
 
   isProbeEnabled(): Observable<boolean> {
@@ -972,7 +972,7 @@ export class ApiService {
           },
         ),
       ),
-      map((v) => v.data?.targetNodes[0]?.target?.archivedRecordings as ArchivedRecording[] ?? []),
+      map((v) => (v.data?.targetNodes[0]?.target?.archivedRecordings as ArchivedRecording[]) ?? []),
     );
   }
 
@@ -1000,7 +1000,7 @@ export class ApiService {
         recordingName,
         labels: labels.map((label) => ({ key: label.key, value: label.value })),
       },
-    ).pipe(map((v) => v.data?.archivedRecordings?.data as ArchivedRecording[] ?? []));
+    ).pipe(map((v) => (v.data?.archivedRecordings?.data as ArchivedRecording[]) ?? []));
   }
 
   postTargetRecordingMetadata(recordingName: string, labels: KeyValue[]): Observable<ActiveRecording[]> {
@@ -1037,7 +1037,7 @@ export class ApiService {
           },
         ),
       ),
-      map((v) => v.data?.targetNodes[0]?.target?.activeRecordings as ActiveRecording[] ?? []),
+      map((v) => (v.data?.targetNodes[0]?.target?.activeRecordings as ActiveRecording[]) ?? []),
     );
   }
 
@@ -1329,7 +1329,7 @@ export class ApiService {
       { id: target.id! },
       true,
       true,
-    ).pipe(map((v) => v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[] ?? []));
+    ).pipe(map((v) => (v.data?.targetNodes[0]?.target?.archivedRecordings?.data as ArchivedRecording[]) ?? []));
   }
 
   getTargetActiveRecordings(target: TargetStub): Observable<ActiveRecording[]> {

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -300,7 +300,7 @@ const MBeanDetails: React.FC<{
             { id: targetId },
           )
           .pipe(
-            map((resp) => resp.data.targetNodes[0].target.mbeanMetrics || {}),
+            map((resp) => resp.data?.targetNodes[0]?.target?.mbeanMetrics ?? {}),
             catchError((_) => of({})),
           )
           .subscribe(setMbeanMetrics),


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See https://github.com/cryostatio/cryostat3/issues/389
Based on #1245

## Description of the change:
Adds handling of potentially null/undefined GraphQL API response fields.

## Motivation for the change:
GraphQL responses may contain null/undefined fields when execution errors occurred. Notification popups appear to inform the user of these errors, but the views invoking these API calls should not render an overall broken error view state. It's better to render what content was available from the response, if any, rather than an overall broken view when only some subset of the data may not be available.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
