### PR TITLE
fix(topology): delete action should be available for custom targets

### DIFF
--- a/src/app/Topology/Actions/types.ts
+++ b/src/app/Topology/Actions/types.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { NodeType } from '@app/Shared/Services/api.types';
 import { NotificationService } from '@app/Shared/Services/Notifications.service';
 import type { FeatureLevel } from '@app/Shared/Services/service.types';
 import { Services } from '@app/Shared/Services/Services';
@@ -73,8 +72,8 @@ export interface NodeAction {
   readonly title?: React.ReactNode;
   readonly isSeparator?: boolean;
   readonly isDisabled?: (element: GraphElement | ListElement, actionUtils: ActionUtils) => Observable<boolean>;
-  readonly includeList?: NodeType[]; // Empty means all
-  readonly blockList?: NodeType[]; // Empty means none
+  readonly allowed?: (element: GraphElement | ListElement) => boolean; // Undefined means allowing all
+  readonly blocked?: (element: GraphElement | ListElement) => boolean; // Undefined means blocking none
 }
 
 export type GroupActionResponse = {

--- a/src/app/Topology/Actions/utils.tsx
+++ b/src/app/Topology/Actions/utils.tsx
@@ -111,7 +111,12 @@ export const nodeActions: NodeAction[] = [
       services.api.deleteTarget(targetNode.target).subscribe(() => undefined);
     },
     title: 'Delete Target',
-    includeList: [NodeType.CUSTOM_TARGET],
+    allowed: (element) => {
+      const targetNode: TargetNode = element.getData();
+      const realm = targetNode.target.annotations.cryostat.find((label) => label.key === 'REALM')?.value;
+
+      return targetNode.nodeType === NodeType.JVM && realm === 'Custom Targets';
+    },
   },
   {
     key: 'GROUP_START_RECORDING',
@@ -342,8 +347,8 @@ export const actionFactory = (
     return (
       actionFilter(action) &&
       (action.isGroup || false) === isGroup &&
-      (!action.includeList || action.includeList.includes(data.nodeType)) &&
-      (!action.blockList || !action.blockList.includes(data.nodeType))
+      (!action.allowed || action.allowed(element)) &&
+      (!action.blocked || !action.blocked(element))
     );
   });
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1251 

## Description of the change:

- Update the `allowList` and `blockList` to be more flexible based on the tree element.
- Added check for `REALM` annotation to ensure that only Custom Target is allowed to be deleted.

![image](https://github.com/cryostatio/cryostat-web/assets/68053619/7c3c26f0-a05d-4e5b-b076-9471150faf35)


## Motivation for the change:

See #1251 

