### PR TITLE
fix(GraphQL): fix VallidationError: null ID for non-null `BigInteger!`

### DIFF
--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -133,6 +133,7 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
       setArchivesForTargets(
         targetNodes.map((node) => {
           const target: Target = {
+            id: node.target.id,
             jvmId: node.target.jvmId,
             connectUrl: node.target.connectUrl,
             alias: node.target.alias,
@@ -171,6 +172,7 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
           `query AllTargetsArchives {
             targetNodes {
               target {
+                id
                 connectUrl
                 alias
                 jvmId


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: [437](https://github.com/cryostatio/cryostat3/issues/437)

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
mentioned by @andrewazores on [https://github.com/cryostatio/cryostat3/issues/437](https://github.com/cryostatio/cryostat3/issues/437)

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. Archive a recording and go  to `Archives -> All Targets` and try to expand the table row corresponding to the related target. You should be able to see the `archived recordings`.
