### PR TITLE
fix(custom-targets): lock form Create button until successful test

### DIFF
--- a/src/app/Topology/Actions/CreateTarget.tsx
+++ b/src/app/Topology/Actions/CreateTarget.tsx
@@ -409,7 +409,7 @@ export const CreateTarget: React.FC<CreateTargetProps> = ({ prefilled }) => {
             <ActionGroup>
               <Button
                 variant="primary"
-                isDisabled={!connectUrl || validConnectUrl !== ValidatedOptions.success || loading || testing}
+                isDisabled={validation.option !== ValidatedOptions.success}
                 onClick={handleSubmit}
                 {...createButtonLoadingProps}
                 data-quickstart-id="ct-create-btn"

--- a/src/app/Topology/Actions/CreateTarget.tsx
+++ b/src/app/Topology/Actions/CreateTarget.tsx
@@ -185,9 +185,10 @@ export const CreateTarget: React.FC<CreateTargetProps> = ({ prefilled }) => {
           if (option === ValidatedOptions.success) {
             exitForm();
           } else {
+            let errorMessage = (body as any)?.data?.reason || 'Connection test failure';
             setValidation({
               option: option,
-              errorMessage: body['data']['reason'],
+              errorMessage,
             });
           }
         }),


### PR DESCRIPTION
- **fix(custom-targets): handle case where response does not include data or reason fields**
- **fix(custom-targets): lock form Create button until successful test**

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1261

## Description of the change:
- handles the case where the response body does not have `.data.reason` fields. This can happen if the server encounters an unexpected error and responds with an HTTP 500, in which case the response format is not a Cryostat API V2 format but a standard Quarkus 500 format.
- locks the Custom Target creation form Create button until a successful connection test is performed. If the form is updated (URL or credentials) the button is re-locked.

## Motivation for the change:
When creating a custom target the server will already perform a connection test anyway. However, the UI is more informative and makes more sense if the user is first required to perform a successful connection test before they can create the target definition.

## How to manually test:
1. Check out and build cryostat3 with this PR
2. `./smoketest.bash -Otr`
3. Try to create some custom target definitions, like `cryostat3:9091`, `localhost:0`, `sample-app-1:9093`, `reports:11124`, `jfr-datasource:11223`, `cryostat:9091`
