### PR TITLE
fix(auth): render username in top bar

### DIFF
--- a/src/mirage/index.ts
+++ b/src/mirage/index.ts
@@ -78,7 +78,7 @@ export const startMirage = ({ environment = 'development' } = {}) => {
       this.post('api/v2.1/auth', () => {
         return new Response(
           200,
-          { 'X-WWW-Authenticate': 'None' },
+          {},
           {
             meta: {
               status: 'OK',

--- a/src/test/Shared/Services/Login.service.test.tsx
+++ b/src/test/Shared/Services/Login.service.test.tsx
@@ -108,8 +108,14 @@ describe('Login.service', () => {
 
       it('should make expected API calls', async () => {
         await firstValueFrom(svc.setLoggedOut());
-        expect(mockFromFetch).toHaveBeenCalledTimes(1);
-        expect(mockFromFetch).toHaveBeenNthCalledWith(1, `./api/v2.1/logout`, {
+        expect(mockFromFetch).toHaveBeenCalledTimes(2);
+        expect(mockFromFetch).toHaveBeenNthCalledWith(1, `./api/v2.1/auth`, {
+          credentials: 'include',
+          mode: 'cors',
+          method: 'POST',
+          body: null,
+        });
+        expect(mockFromFetch).toHaveBeenNthCalledWith(2, `./api/v2.1/logout`, {
           credentials: 'include',
           mode: 'cors',
           method: 'POST',


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes https://github.com/cryostatio/cryostat3/issues/489
Related to https://github.com/cryostatio/cryostat3/pull/490

## Description of the change:
If the response from the server includes the `Gap-Auth` header, use that to determine the user's logged in username. If not, fall back to using the `POST /api/v2.1/auth` response body. If anything is blank or fails then use the empty string, which the UI already renders as the anonymous user icon.

## How to manually test:
1. Check out cryostat3 and build with this PR
2. `./smoketest.bash -O`
3. Verify that the username `user` appears on the top bar
4. Restart smoketest as `./smoketest.bash -Op` to disable the auth proxy
5. Verify that the anonymous user icon appears on the top bar
