### PR TITLE
fix(quickstarts): remove outdated feature descriptions

### DIFF
--- a/src/app/QuickStarts/quickstarts/automated-rules-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/automated-rules-quickstart.tsx
@@ -26,7 +26,6 @@ const AutomatedRulesQuickStart: QuickStart = {
     order: 3,
   },
   spec: {
-    version: 2.3,
     displayName: displayName,
     durationMinutes: 5,
     icon: <CryostatIcon />,

--- a/src/app/QuickStarts/quickstarts/dashboard-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/dashboard-quickstart.tsx
@@ -29,7 +29,6 @@ const DashboardQuickStart: QuickStart = {
     order: 2,
   },
   spec: {
-    version: 2.3,
     displayName: displayName,
     durationMinutes: 10,
     icon: <CryostatIcon />,
@@ -163,7 +162,7 @@ You can rename, delete and quickly switch between **Dashboard Layouts** for diff
     conclusion: conclusion(
       displayName,
       'Dashboard',
-      `For more information about the new <strong>Dashboard</strong> and <strong>Dashboard Cards</strong> in [APP] ${build.version}, read our guides on the <a href="${build.dashboardGuideUrl}" target="_blank">Cryostat documentation</a>.`,
+      `For more information about the <strong>Dashboard</strong> and <strong>Dashboard Cards</strong> in [APP] ${build.version}, read our guides on the <a href="${build.dashboardGuideUrl}" target="_blank">Cryostat documentation</a>.`,
     ),
     type: {
       text: 'Introduction',

--- a/src/app/QuickStarts/quickstarts/generic-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/generic-quickstart.tsx
@@ -32,7 +32,6 @@ const GenericQuickStart: QuickStart = {
     // you can add additional metadata here
   },
   spec: {
-    version: 2.3, // versioning for each release of the quick start
     displayName: displayName,
     durationMinutes: 10,
     type: {

--- a/src/app/QuickStarts/quickstarts/settings-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/settings-quickstart.tsx
@@ -102,7 +102,7 @@ The **automated analysis** Dashboard Card allows you to automatically start an a
 1. Click [Advanced]{{highlight settings-advanced-tab}}.
 2. Configure the **feature level** settings.
 
-  The **feature level** setting enables you to enable or disable beta features.
+  The **feature level** setting enables you to enable or disable beta features. This is a client-side switch that only applies to the particular web browser and Cryostat instance where it is set.
 
 `,
       },

--- a/src/app/QuickStarts/quickstarts/settings-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/settings-quickstart.tsx
@@ -64,7 +64,7 @@ The **General** settings tab is where you can adjust various general settings to
 The **Connectivity** tab enables you to configure the WebSocket connection between the browser and the [APP] backend.
 
 1. Click [Connectivity]{{highlight settings-connectivity-tab}}.
-2. Configure the **WebSocket Connection Debounce** time.
+2. Configure the **WebSocket retry interval** time.
 3. Configure the **Auto-refresh** period for content-views.
 [To use the **Auto-refresh** feature, make sure to enable the [Auto-refresh]{{highlight settings-connectivity-tab-auto-refresh}} checkbox.]{{admonition tip}}
 `,

--- a/src/app/QuickStarts/quickstarts/settings-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/settings-quickstart.tsx
@@ -27,7 +27,6 @@ const SettingsQuickStart: QuickStart = {
     order: 100,
   },
   spec: {
-    version: 2.3,
     displayName: displayName,
     durationMinutes: 5,
     icon: <CogIcon />,

--- a/src/app/QuickStarts/quickstarts/settings-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/settings-quickstart.tsx
@@ -100,10 +100,7 @@ The **automated analysis** Dashboard Card allows you to automatically start an a
 [APP] has a few advanced settings that can be configured.
 
 1. Click [Advanced]{{highlight settings-advanced-tab}}.
-2. Configure the **Credentials Storage** settings.
-
-  Credentials are necessary to authenticate with the target JVMs that [APP] communicates with, if JMX auth is enabled or if a [APP] agent authenticated connection is required. If you prefer not to store these credentials in the [APP] backend, you can opt to store them in local session storage instead.
-3. Configure the **feature level** settings.
+2. Configure the **feature level** settings.
 
   The **feature level** setting enables you to enable or disable beta features.
 

--- a/src/app/QuickStarts/quickstarts/start-a-recording.tsx
+++ b/src/app/QuickStarts/quickstarts/start-a-recording.tsx
@@ -27,7 +27,6 @@ const RecordingQuickStart: QuickStart = {
     order: 1,
   },
   spec: {
-    version: 2.3,
     displayName: displayName,
     durationMinutes: 10,
     icon: <CryostatIcon />,

--- a/src/app/QuickStarts/quickstarts/start-a-recording.tsx
+++ b/src/app/QuickStarts/quickstarts/start-a-recording.tsx
@@ -128,14 +128,13 @@ Downloading a Recording will save the Recording to your local machine as a JFR f
         title: 'View an analysis report',
         description: `
 [APP] is able to generate an **Automated analysis report** using a JFR Recording. The **Java Mission Control** rules engine analyzes your Recording, looks for common problems, and assigns a severity score from 0 (no problem) to 100 (potentially severe problem) to each problem.
-1. Click the [kebab menu]{{highlight recording-kebab}} next to the Recording that you want to view an analysis report for.
-2. Click \`View Report ...\` to view an analysis report of the Recording in a new tab.
-3. *Optional:* Right click on the page and select \`Save Page As...\` to download the report HTML file to your local machine.
+1. Click the [row chevron]{{highlight recording-chevron}} next to the Recording that you want to view an analysis report for.
+2. If no tile groups appear then no problems were detected in your Recording. If any tiles do appear you can click on each one to view its severity score and see any suggestions to fix the problem.
 `,
         review: {
           instructions: '#### Verify that you can see an analysis report of the Recording.',
           failedTaskHelp:
-            'The kebab `⁝` should be next to the Recording row in the Active Recordings table. Clicking the kebab icon should show a menu with the `View Report ...` option.',
+            'The chevron `>` should be at the beginning of the Recording row in the **Active Recordings** or **Archived Recordings** tables. Clicking the chevron should expand the table row and reveal the analysis report tiles',
         },
       },
       {

--- a/src/app/QuickStarts/quickstarts/topology/custom-target-quickstart.tsx
+++ b/src/app/QuickStarts/quickstarts/topology/custom-target-quickstart.tsx
@@ -24,7 +24,6 @@ const CustomTargetQuickstart: QuickStart = {
     featureLevel: FeatureLevel.PRODUCTION,
   },
   spec: {
-    version: 2.3,
     displayName: 'Create a Custom Target',
     durationMinutes: 10,
     icon: <CryostatIcon />,

--- a/src/app/QuickStarts/quickstarts/topology/group-start-recordings.tsx
+++ b/src/app/QuickStarts/quickstarts/topology/group-start-recordings.tsx
@@ -19,13 +19,11 @@ import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { QuickStart } from '@patternfly/quickstarts';
 
 const GroupStartRecordingQuickStart: QuickStart = {
-  apiVersion: 'v2.3.0',
   metadata: {
     name: 'topology/start-group-recording',
     featureLevel: FeatureLevel.PRODUCTION,
   },
   spec: {
-    version: 2.3,
     displayName: 'Start Recording on multiple target JVMs',
     durationMinutes: 5,
     icon: <CryostatIcon />,

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -931,6 +931,7 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
             isExpanded: isExpanded,
             onToggle: handleToggle,
           }}
+          data-quickstart-id="recording-chevron"
         />
         <Td key={`active-table-row-${index}_2`} dataLabel={tableColumns[0].title}>
           {recording.name}

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -874,6 +874,7 @@ export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
             isExpanded: isExpanded,
             onToggle: handleToggle,
           }}
+          data-quickstart-id="recording-chevron"
         />
         <Td key={`archived-table-row-${index}_2`} dataLabel={tableColumns[0].title}>
           {recording.name}


### PR DESCRIPTION
- **fix(quickstart): rename WebSocket Connection Debouce -> WebSocket retry interval**
- **remove explicit versioning, quickstarts correspond to whichever release they are developed with and embedded into**
- **remove mention of "View Report" action from recording quickstart**
- **remove mention of credentials storage location**
- **add note about client-side feature flags**

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1265
Fixes: #1266
Fixes: #1267

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
