### PR TITLE
fix(matchexpr): tooltip hint checks for annotation existence before asserting value

### DIFF
--- a/src/app/Shared/Components/MatchExpression/MatchExpressionHint.tsx
+++ b/src/app/Shared/Components/MatchExpression/MatchExpressionHint.tsx
@@ -31,7 +31,9 @@ export const MatchExpressionHint: React.FC<MatchExpressionHintProps> = ({ target
     if (!target || !target.alias || !target.connectUrl) {
       body = 'true';
     } else {
-      body = `target.alias == '${target.alias}' || ('PORT' in target.annotations.cryostat && target.annotations.cryostat.PORT == ${getAnnotation(
+      body = `target.alias == '${
+        target.alias
+      }' || ('PORT' in target.annotations.cryostat && target.annotations.cryostat.PORT == ${getAnnotation(
         target.annotations.cryostat,
         'PORT',
       )})`;

--- a/src/app/Shared/Components/MatchExpression/MatchExpressionHint.tsx
+++ b/src/app/Shared/Components/MatchExpression/MatchExpressionHint.tsx
@@ -31,10 +31,10 @@ export const MatchExpressionHint: React.FC<MatchExpressionHintProps> = ({ target
     if (!target || !target.alias || !target.connectUrl) {
       body = 'true';
     } else {
-      body = `target.alias == '${target.alias}' || target.annotations.cryostat['PORT'] == ${getAnnotation(
+      body = `target.alias == '${target.alias}' || ('PORT' in target.annotations.cryostat && target.annotations.cryostat.PORT == ${getAnnotation(
         target.annotations.cryostat,
         'PORT',
-      )}`;
+      )})`;
     }
     body = JSON.stringify(body, null, 2);
     body = body.substring(1, body.length - 1);


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat3/issues/511

## Description of the change:
Adds a check that the annotation exists before reading it to compare its value.

## Motivation for the change:
In the old JavaScript-based expression evaluation, indexing the map with a nonexistent key would simply result in an `undefined` value which would compare as `false` against the test value. In CEL it is a runtime error to index with a nonexistent key, so there should be an existence check before the access and comparison to ensure that the result comes back as a successful evaluation with a `false` result, rather than as an error.

## How to manually test:
1. Check out cryostat3 with this PR and build
2. `./smoketest.bash -Ot`
3. Go to Automated Rules > Create, click a target in the miniature topology view
4. Click the match expression tooltip `?` icon. Copy the suggested expression and paste it into the match expression box.
5. If the suggested annotation exists only on some targets and not others, then the evaluation would fail prior to this PR.
