### PR TITLE
fix(matchexpr): fix bug in evaluator List view

### DIFF
--- a/src/app/Shared/Components/MatchExpression/MatchExpressionVisualizer.tsx
+++ b/src/app/Shared/Components/MatchExpression/MatchExpressionVisualizer.tsx
@@ -388,7 +388,7 @@ const ListView: React.FC<{ alertOptions?: AlertOptions }> = ({ alertOptions, ...
               isHidden={!expanded.includes(connectUrl)}
             >
               <EntityDetails
-                entity={{ getData: () => target }}
+                entity={{ getData: () => ({ target }) }}
                 columnModifier={{ default: '3Col' }}
                 alertOptions={alertOptions}
                 className="topology__list-view__entity-details"

--- a/src/app/Shared/Services/api.types.ts
+++ b/src/app/Shared/Services/api.types.ts
@@ -500,6 +500,7 @@ export enum NodeType {
   ENDPOINT = 'Endpoint',
   // Standalone targets
   TARGET = 'Target',
+  NODE = 'Node', // Default/fallback for unknown
 }
 
 interface _AbstractNode {

--- a/src/app/Topology/Shared/utils.tsx
+++ b/src/app/Topology/Shared/utils.tsx
@@ -38,7 +38,7 @@ export const DiscoveryTreeContext = React.createContext(DEFAULT_EMPTY_UNIVERSE);
 
 export const COLLAPSE_EXEMPTS = [NodeType.NAMESPACE, NodeType.REALM, NodeType.UNIVERSE];
 
-export const nodeTypeToAbbr = (type: NodeType): string => {
+export const nodeTypeToAbbr = (type: NodeType = NodeType.NODE): string => {
   // Keep uppercases (or uppercase whole word if none) and retain first 4 charaters.
   return (type.replace(/[^A-Z]/g, '') || type.toUpperCase()).slice(0, 4);
 };


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1277

## Description of the change:
The root of the bug is that the object passed in to the entity details view is the Target object itself, whereas it should be the Discovery TargetNode which contains the Target as a property.

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
