### PR TITLE
test(mirage): correct server authority string in preview builds

### DIFF
--- a/src/mirage/index.ts
+++ b/src/mirage/index.ts
@@ -20,7 +20,6 @@ import { Server as WSServer, Client } from 'mock-socket';
 import factories from './factories';
 import models from './models';
 import { Resource } from './typings';
-import { sizeUnits } from 'src/app/utils/utils';
 
 export const startMirage = ({ environment = 'development' } = {}) => {
   const wsUrl = `ws://localhost:9091/api/notifications`;

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -42,7 +42,7 @@ module.exports = merge(common('production'), {
       chunkFilename: '[name].[contenthash].bundle.css' // lazy-load css
     }),
     new EnvironmentPlugin({
-      CRYOSTAT_AUTHORITY: '',
+      CRYOSTAT_AUTHORITY: process.env.PREVIEW ? 'http://localhost:8181' : '',
       PREVIEW: process.env.PREVIEW || 'false'
     })
   ],


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1271

## How to manually test:
1. Check out PR
2. `yarn start:dev:preview` should bring up the preview/demo UI. There should be a Fake Target, with a Demo template. Topology view should work, dashboard should work, recording start/stop/archive/delete should work, expanding recording for automated analysis should work. GraphQL-powered things will not work, snapshot recording creation does not work.
3. `yarn run build:preview:notests && cd dist && python3 -m http.server`, then open `http://localhost:8000` in a browser. The preview should work just the same as in the step above.
