### PR TITLE
fix(dashboard): correct chart source url for jfr-metrics charts

### DIFF
--- a/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
@@ -116,7 +116,7 @@ export const JFRMetricsChartCard: DashboardCardFC<JFRMetricsChartCardProps> = (p
     if (!dashboardUrl) {
       return;
     }
-    const u = new URL('/d-solo/main', dashboardUrl);
+    const u = new URL('d-solo/main', new URL(dashboardUrl, window.location.href));
     u.searchParams.append('theme', theme);
     u.searchParams.append('panelId', String(kindToId(props.chartKind)));
     u.searchParams.append('to', 'now');

--- a/src/app/Dashboard/cryostat-dashboard-templates.tsx
+++ b/src/app/Dashboard/cryostat-dashboard-templates.tsx
@@ -401,7 +401,7 @@ const JFRMonitoringLayout: LayoutTemplate = {
       span: 3,
       props: {
         theme: 'light',
-        chartKind: 'Recording start time',
+        chartKind: 'Recording Start Time',
         duration: 120,
         period: 10,
       },


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1297 

## Description of the change:

- Corrected chart source url construct for jft-metrics charts.
- Fix `Recording Start Time` metric chart kind. Previously, throwing `Invalid Value` error (due to mismatched kind name).

![image](https://github.com/cryostatio/cryostat-web/assets/68053619/eb8eab3a-e5b0-4c92-9fa5-893428687ad9)



## Motivation for the change:

See #1297 