### PR TITLE
feat(dev-server): configure request proxy for dev-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ $ bash smoketest.bash
 Then, run:
 
 ```bash
-$ yarn start:dev
+# By default, CRYOSTAT_URL is set to http://localhost:8080
+$ CRYOSTAT_URL=https://localhost:8443 yarn start:dev 
 ```
 
 The dev server will proxy API requests to Cryostat and Grafana.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,11 @@ $ bash smoketest.bash
 Then, run:
 
 ```bash
-# By default, CRYOSTAT_URL is set to http://localhost:8080
-$ CRYOSTAT_URL=https://localhost:8443 yarn start:dev 
+# To configure the URL pointing to Cryostat, set CRYOSTAT_PROXY_URL
+# By default, CRYOSTAT_PROXY_URL is set to https://localhost:8443
+$ yarn start:dev
+# or without TLS
+$ CRYOSTAT_PROXY_URL=http://localhost:8080 yarn start:dev
 ```
 
 The dev server will proxy API requests to Cryostat and Grafana.

--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ Development environment supports hot reload with Webpack's [Hot Module Replaceme
 
 ### With Cryostat
 
-First, launch a [`Cryostat`](https://github.com/cryostatio/cryostat) instance with CORS enabled by setting `CRYOSTAT_CORS_ORIGIN` to `http://localhost:9000`. For example:
-
+First, launch a [`Cryostat`](https://github.com/cryostatio/cryostat) instance:
 ```bash
 $ cd /path/to/cryostat
-$ CRYOSTAT_DISABLE_SSL=true CRYOSTAT_CORS_ORIGIN=http://localhost:9000 sh run.sh
+$ bash smoketest.bash
 ```
 
 Then, run:
@@ -58,6 +57,8 @@ Then, run:
 ```bash
 $ yarn start:dev
 ```
+
+The dev server will proxy API requests to Cryostat and Grafana.
 
 ### Without Cryostat
 

--- a/src/app/Shared/Services/Report.service.tsx
+++ b/src/app/Shared/Services/Report.service.tsx
@@ -34,11 +34,9 @@ export class ReportService {
     }
     const headers = new Headers();
     headers.append('Accept', 'application/json');
-    let url = recording.reportUrl;
-    if (!url.startsWith(this.login.authority)) {
-      url = `${this.login.authority}/${recording.reportUrl}`;
-    }
-    return fromFetch(url, {
+    let url = new URL(recording.reportUrl, document.location.href);
+
+    return fromFetch(url.toString(), {
       method: 'GET',
       mode: 'cors',
       credentials: 'include',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -17,7 +17,7 @@ module.exports = merge(common('development'), {
     hot: true,
     open: true,
     port: PORT,
-    proxy: [
+    proxy: process.env.PREVIEW? undefined: [
       {
         context: ["/api", "/health", "/grafana"],
         target: process.env.CRYOSTAT_AUTHORITY ?? "http://localhost:8080",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -21,10 +21,11 @@ module.exports = merge(common('development'), {
     proxy: process.env.PREVIEW? undefined: [
       {
         context: ['/api', '/health', '/grafana'],
-        target: process.env.CRYOSTAT_AUTHORITY ?? 'http://localhost:8080',
+        target: process.env.CRYOSTAT_PROXY_URL ?? 'http://localhost:8080',
         secure: false, // ignore insecure tls
         auth: 'user:pass',
         ws: true,
+        followRedirects: true,
       }
     ]
   },

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -17,10 +17,19 @@ module.exports = merge(common('development'), {
     hot: true,
     open: true,
     port: PORT,
+    proxy: [
+      {
+        context: ["/api", "/health", "/grafana"],
+        target: process.env.CRYOSTAT_AUTHORITY ?? "http://localhost:8080",
+        secure: false, // ignore insecure tls
+        auth: "user:pass",
+        ws: true,
+      }
+    ]
   },
   plugins: [
     new EnvironmentPlugin({
-      CRYOSTAT_AUTHORITY: 'http://localhost:8181',
+      CRYOSTAT_AUTHORITY: '', // requests are proxied by dev-server
       PREVIEW: process.env.PREVIEW || 'false'
     })
   ],

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -21,7 +21,7 @@ module.exports = merge(common('development'), {
     proxy: process.env.PREVIEW? undefined: [
       {
         context: ['/api', '/health', '/grafana'],
-        target: process.env.CRYOSTAT_PROXY_URL ?? 'http://localhost:8080',
+        target: process.env.CRYOSTAT_PROXY_URL ?? 'https://localhost:8443',
         secure: false, // ignore insecure tls
         auth: 'user:pass',
         ws: true,

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -17,19 +17,22 @@ module.exports = merge(common('development'), {
     hot: true,
     open: true,
     port: PORT,
+    // In preview mode, requests are intercepted with miragejs
     proxy: process.env.PREVIEW? undefined: [
       {
-        context: ["/api", "/health", "/grafana"],
-        target: process.env.CRYOSTAT_AUTHORITY ?? "http://localhost:8080",
+        context: ['/api', '/health', '/grafana'],
+        target: process.env.CRYOSTAT_AUTHORITY ?? 'http://localhost:8080',
         secure: false, // ignore insecure tls
-        auth: "user:pass",
+        auth: 'user:pass',
         ws: true,
       }
     ]
   },
   plugins: [
     new EnvironmentPlugin({
-      CRYOSTAT_AUTHORITY: '', // requests are proxied by dev-server
+      // Requests are proxied by dev-server
+      // In preview mode, a base url is required.
+      CRYOSTAT_AUTHORITY: process.env.PREVIEW? 'http://localhost:8181': '', 
       PREVIEW: process.env.PREVIEW || 'false'
     })
   ],


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat/issues/328
Related to https://github.com/cryostatio/cryostat/pull/327

## Description of the change:

- Configure dev-server to proxy API requests to Cryostat and Grafana.

## Motivation for the change:

This should allow development of web without having to rebuild the container image all the time. I think this is a bit simpler than handling CORS.

This idea comes from the fact that Grafana proxies its client's requests to jfr-datasource so I guess dev-server can do the same. What do you think @andrewazores?

## References

https://webpack.js.org/configuration/dev-server/#devserverproxy
