### PR TITLE
fix(masthead): correct styling of masthead icons and quickstart menu item

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -396,7 +396,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                     onClick={handleNotificationCenterToggle}
                     aria-label="Notifications"
                   >
-                    <BellIcon />
+                    <Icon>
+                      <BellIcon />
+                    </Icon>
                   </NotificationBadge>
                 </ToolbarItem>
                 <ToolbarItem>
@@ -407,7 +409,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                     data-quickstart-id="settings-link"
                     component={(props) => <Link {...props} to="/settings" />}
                   >
-                    <CogIcon />
+                    <Icon>
+                      <CogIcon />
+                    </Icon>
                   </Button>
                 </ToolbarItem>
                 <ToolbarItem>
@@ -481,7 +485,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
               data-quickstart-id="nav-toggle-btn"
               data-tour-id="nav-toggle-btn"
             >
-              <BarsIcon />
+              <Icon>
+                <BarsIcon />
+              </Icon>
             </PageToggleButton>
           </MastheadToggle>
           <MastheadMain>

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -424,6 +424,8 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                       ></MenuToggle>
                     )}
                     isOpen={showHelpDropdown}
+                    onOpenChange={(v) => setShowHelpDropdown(v)}
+                    onOpenChangeKeys={['Escape']}
                     popperProps={{
                       position: 'right',
                     }}
@@ -437,6 +439,8 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                   onSelect={() => setShowUserInfoDropdown(false)}
                   toggle={UserInfoToggle}
                   isOpen={showUserInfoDropdown}
+                  onOpenChange={(v) => setShowUserInfoDropdown(v)}
+                  onOpenChangeKeys={['Escape']}
                   popperProps={{
                     position: 'right',
                   }}

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -434,7 +434,6 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
               </ToolbarGroup>
               <ToolbarItem visibility={{ default: 'visible' }}>
                 <Dropdown
-                  isPlain
                   onSelect={() => setShowUserInfoDropdown(false)}
                   toggle={UserInfoToggle}
                   isOpen={showUserInfoDropdown}

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -73,7 +73,6 @@ import {
   BellIcon,
   CaretDownIcon,
   CogIcon,
-  EllipsisVIcon,
   ExternalLinkAltIcon,
   PlusCircleIcon,
   QuestionCircleIcon,
@@ -297,13 +296,12 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
 
   const UserInfoToggle = React.useCallback(
     (toggleRef: React.Ref<MenuToggleElement>) => (
-      <MenuToggle ref={toggleRef} onClick={handleUserInfoToggle} icon={CaretDownIcon}>
+      <MenuToggle variant="plainText" ref={toggleRef} onClick={handleUserInfoToggle} icon={CaretDownIcon}>
         {username || (
           <Icon size="sm">
             <UserIcon color="white" />
           </Icon>
         )}
-        <EllipsisVIcon />
       </MenuToggle>
     ),
     [username, handleUserInfoToggle],
@@ -333,8 +331,8 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
 
   const helpItems = React.useMemo(() => {
     return [
-      <DropdownItem key={'Quickstarts'}>
-        <NavLink to="/quickstarts">{t('AppLayout.APP_LAUNCHER.QUICKSTARTS')}</NavLink>
+      <DropdownItem key={'Quickstarts'} component={(props) => <Link {...props} to="/quickstarts" />}>
+        {t('AppLayout.APP_LAUNCHER.QUICKSTARTS')}
       </DropdownItem>,
       <DropdownItem key={'Documentation'} onClick={handleOpenDocumentation}>
         <span>{t('AppLayout.APP_LAUNCHER.DOCUMENTATION')}</span>
@@ -409,9 +407,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                     data-quickstart-id="settings-link"
                     component={(props) => <Link {...props} to="/settings" />}
                   >
-                    <Icon size="sm">
-                      <CogIcon />
-                    </Icon>
+                    <CogIcon />
                   </Button>
                 </ToolbarItem>
                 <ToolbarItem>
@@ -421,12 +417,11 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                     toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
                       <MenuToggle
                         ref={toggleRef}
+                        variant="plainText"
                         icon={<QuestionCircleIcon />}
                         className="application-launcher"
                         onClick={() => handleHelpToggle()}
-                      >
-                        <EllipsisVIcon />
-                      </MenuToggle>
+                      ></MenuToggle>
                     )}
                     isOpen={showHelpDropdown}
                     popperProps={{

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -421,11 +421,14 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                     toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
                       <MenuToggle
                         ref={toggleRef}
-                        variant="plainText"
-                        icon={<QuestionCircleIcon />}
+                        variant="plain"
                         className="application-launcher"
                         onClick={() => handleHelpToggle()}
-                      ></MenuToggle>
+                      >
+                        <Icon>
+                          <QuestionCircleIcon />
+                        </Icon>
+                      </MenuToggle>
                     )}
                     isOpen={showHelpDropdown}
                     onOpenChange={(v) => setShowHelpDropdown(v)}

--- a/src/app/Settings/Config/FeatureLevels.tsx
+++ b/src/app/Settings/Config/FeatureLevels.tsx
@@ -71,10 +71,10 @@ const Component = () => {
             .filter((v) => typeof v === 'string')
             .map((v): { key: string; value: number } => ({ key: String(v), value: FeatureLevel[v] }))
             .filter((v) => {
-              if (!process.env.CRYOSTAT_AUTHORITY) {
-                return v.value !== FeatureLevel.DEVELOPMENT;
+              if ((process.env.NODE_ENV ?? '').toLowerCase() === 'development') {
+                return true;
               }
-              return true;
+              return v.value !== FeatureLevel.DEVELOPMENT;
             })
             .map((level) => (
               <SelectOption key={level.key} value={level.value}>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1303

## Description of the change:
Fixes up the styling of the settings cog, help menu, and user menu on the masthead, as well as the Quick Starts item under the help menu.

![image](https://github.com/user-attachments/assets/8ee4d83d-20a0-4c36-9eff-80cf251c0e78)
