### PR TITLE
chore(pf5): upgrade Recording view to Patternfly 5

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -52,6 +52,7 @@
   "OK": "OK",
   "PRESERVED_ARCHIVES": "Preserved Archives",
   "PRODUCTION": "PRODUCTION",
+  "REFRESH": "Refresh",
   "REMOVE": "Remove",
   "RENAME": "Rename",
   "RESET": "Reset",

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -249,7 +249,8 @@
       "DISPLAY_SELECTED_DATETIME": "Displayed selected datetime",
       "TABS": "Select a date or time tab"
     },
-    "SELECTED_DATETIME": "Selected DateTime"
+    "SELECTED_DATETIME": "Selected Date and Time",
+    "SELECTED_TIMEZONE": "Selected Timezone"
   },
   "ERROR_BOUNDARY": {
     "ERROR_MESSAGE": "Reason: {{message}}",

--- a/src/app/CreateRecording/CreateRecording.tsx
+++ b/src/app/CreateRecording/CreateRecording.tsx
@@ -15,7 +15,7 @@
  */
 
 import { TargetView } from '@app/TargetView/TargetView';
-import { Card, CardBody, Tab, Tabs } from '@patternfly/react-core';
+import { Card, CardBody, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import * as React from 'react';
 import { CustomRecordingForm } from './CustomRecordingForm';
 import { SnapshotRecordingForm } from './SnapshotRecordingForm';
@@ -33,10 +33,10 @@ export const CreateRecording: React.FC = () => {
       <Card>
         <CardBody>
           <Tabs activeKey={activeTab} onSelect={onTabSelect}>
-            <Tab eventKey={0} title="Custom Flight Recording">
+            <Tab eventKey={0} title={<TabTitleText>Custom Flight Recording</TabTitleText>}>
               <CustomRecordingForm />
             </Tab>
-            <Tab eventKey={1} title="Snapshot Recording">
+            <Tab eventKey={1} title={<TabTitleText>Snapshot Recording</TabTitleText>}>
               <SnapshotRecordingForm />
             </Tab>
           </Tabs>

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -614,6 +614,7 @@ export const CustomRecordingForm: React.FC = () => {
               </SplitItem>
               <SplitItem>
                 <FormSelect
+                  className="recording-create__form_select"
                   value={formData.maxAgeUnit}
                   onChange={handleMaxAgeUnitChange}
                   aria-label="Max Age units Input"

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -501,7 +501,7 @@ export const CustomRecordingForm: React.FC = () => {
               <HelperTextItem variant={!formData.template?.name ? ValidatedOptions.default : ValidatedOptions.success}>
                 {formData.template?.name
                   ? 'The Event Template to be applied in this Recording'
-                  : 'A Template must be selected'}
+                  : 'A Template must be selected.'}
               </HelperTextItem>
             </HelperText>
           </FormHelperText>
@@ -525,6 +525,12 @@ export const CustomRecordingForm: React.FC = () => {
               </Tooltip>
             }
           >
+            <RecordingLabelFields
+              labels={formData.labels}
+              setLabels={handleLabelsChange}
+              setValid={handleLabelValidationChange}
+              isDisabled={loading}
+            />
             <FormHelperText>
               <HelperText>
                 <HelperTextItem
@@ -537,12 +543,6 @@ export const CustomRecordingForm: React.FC = () => {
                 </HelperTextItem>
               </HelperText>
             </FormHelperText>
-            <RecordingLabelFields
-              labels={formData.labels}
-              setLabels={handleLabelsChange}
-              setValid={handleLabelValidationChange}
-              isDisabled={loading}
-            />
           </FormGroup>
         </ExpandableSection>
         <ExpandableSection

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -48,6 +48,7 @@ import {
   Split,
   SplitItem,
   Text,
+  TextContent,
   TextInput,
   TextVariants,
   Tooltip,
@@ -403,11 +404,13 @@ export const CustomRecordingForm: React.FC = () => {
 
   return (
     <>
-      <Text component={TextVariants.small}>
-        JDK Flight Recordings are compact records of events which have occurred within the Target JVM. Many event types
-        are built in to the JVM itself, while others are user defined.
-      </Text>
       <Form isHorizontal>
+        <TextContent>
+          <Text component={TextVariants.p}>
+            JDK Flight Recordings are compact records of events which have occurred within the Target JVM. Many event
+            types are built in to the JVM itself, while others are user defined.
+          </Text>
+        </TextContent>
         <FormGroup label="Name" isRequired fieldId="recording-name">
           <TextInput
             value={formData.name}

--- a/src/app/CreateRecording/SnapshotRecordingForm.tsx
+++ b/src/app/CreateRecording/SnapshotRecordingForm.tsx
@@ -18,7 +18,7 @@ import { authFailMessage, isAuthFail, missingSSLMessage } from '@app/ErrorView/t
 import { LoadingProps } from '@app/Shared/Components/types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
-import { ActionGroup, Button, Form, Text, TextVariants } from '@patternfly/react-core';
+import { ActionGroup, Button, Form, Text, TextContent, TextVariants } from '@patternfly/react-core';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { first } from 'rxjs';
@@ -109,12 +109,14 @@ export const SnapshotRecordingForm: React.FC<SnapshotRecordingFormProps> = (_) =
   return (
     <>
       <Form isHorizontal>
-        <Text component={TextVariants.p}>
-          A Snapshot Recording is one which contains all information about all events that have been captured in the
-          current session by <i>other,&nbsp; non-Snapshot</i> Recordings. Snapshots do not themselves define which
-          events are enabled, their thresholds, or any other options. A Snapshot is only ever in the STOPPED state from
-          the moment it is created.
-        </Text>
+        <TextContent>
+          <Text component={TextVariants.p}>
+            A Snapshot Recording is one which contains all information about all events that have been captured in the
+            current session by <i>other, non-Snapshot</i> Recordings. Snapshots do not themselves define which events
+            are enabled, their thresholds, or any other options. A Snapshot is only ever in the STOPPED state from the
+            moment it is created.
+          </Text>
+        </TextContent>
         <ActionGroup>
           <Button variant="primary" onClick={handleCreateSnapshot} isDisabled={loading} {...createButtonLoadingProps}>
             {loading ? 'Creating' : 'Create'}

--- a/src/app/DateTimePicker/DateTimePicker.tsx
+++ b/src/app/DateTimePicker/DateTimePicker.tsx
@@ -22,8 +22,6 @@ import {
   Bullseye,
   Button,
   CalendarMonth,
-  Flex,
-  FlexItem,
   Form,
   FormGroup,
   Tab,
@@ -158,20 +156,16 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({ onSelect, onDism
         </Tab>
       </Tabs>
       <FormGroup label={t('DateTimePicker.SELECTED_DATETIME')}>
-        <Flex>
-          <FlexItem>
-            <TextInput
-              id="selected-datetime"
-              aria-label={t('DateTimePicker.ARIA_LABELS.DISPLAY_SELECTED_DATETIME') || ''}
-              className="datetime-picker__datetime-selected-display"
-              readOnly
-              value={selectedDatetimeDisplay}
-            />
-          </FlexItem>
-          <FlexItem>
-            <TimezonePicker menuAppendTo={document.body} onTimezoneChange={setTimezone} selected={timezone} isCompact />
-          </FlexItem>
-        </Flex>
+        <TextInput
+          id="selected-datetime"
+          aria-label={t('DateTimePicker.ARIA_LABELS.DISPLAY_SELECTED_DATETIME') || ''}
+          className="datetime-picker__datetime-selected-display"
+          readOnlyVariant="default"
+          value={selectedDatetimeDisplay}
+        />
+      </FormGroup>
+      <FormGroup label={t('DateTimePicker.SELECTED_TIMEZONE')}>
+        <TimezonePicker onTimezoneChange={setTimezone} selected={timezone} />
       </FormGroup>
       <ActionGroup style={{ marginTop: 0 }}>
         <Button variant="primary" onClick={handleSubmit}>

--- a/src/app/DateTimePicker/TimePicker.tsx
+++ b/src/app/DateTimePicker/TimePicker.tsx
@@ -108,9 +108,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
                   onChange={onSecondSelect}
                 />
               </LevelItem>
-              {is24h ? (
-                <></>
-              ) : (
+              {is24h ? null : (
                 <LevelItem key={'meridiem'}>
                   <MeridiemPicker isAM={meridiemAM} onSelect={onMeridiemSelect} />
                 </LevelItem>
@@ -200,16 +198,14 @@ const TimeSpinner: React.FC<TimeSpinnerProps> = ({ variant, onChange, selected, 
             {label}
           </Title>
         </StackItem>
-      ) : (
-        <></>
-      )}
+      ) : null}
       <StackItem key={`${variant}-increment`}>
         <Button
           className={css('datetime-picker__time-spin-box', 'up')}
           onClick={handleIncrement}
           aria-label={t(`TimeSpinner.INCREMENT_${variant.toUpperCase()}_VALUE`) || ''}
         >
-          <Icon size="md">
+          <Icon size="lg">
             <AngleUpIcon />
           </Icon>
         </Button>
@@ -232,7 +228,7 @@ const TimeSpinner: React.FC<TimeSpinnerProps> = ({ variant, onChange, selected, 
           onClick={handleDecrement}
           aria-label={t(`TimeSpinner.DECREMENT_${variant.toUpperCase()}_VALUE`) || ''}
         >
-          <Icon size="md">
+          <Icon size="lg">
             <AngleDownIcon />
           </Icon>
         </Button>

--- a/src/app/DurationPicker/DurationPicker.tsx
+++ b/src/app/DurationPicker/DurationPicker.tsx
@@ -48,6 +48,7 @@ export const DurationPicker: React.FC<DurationPickerProps> = ({
         </SplitItem>
         <SplitItem>
           <FormSelect
+            className="duration-picker__form_select"
             value={unitScalar}
             onChange={(_event, v) => onUnitScalarChange(Number(v))}
             aria-label="Duration Picker Units Input"

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -34,6 +34,7 @@ import {
   Button,
   HelperText,
   HelperTextItem,
+  Label,
   Stack,
   StackItem,
   Title,
@@ -50,6 +51,7 @@ export interface BulkEditLabelsProps {
   checkedIndices: number[];
   directory?: RecordingDirectory;
   directoryRecordings?: ArchivedRecording[];
+  closePanelFn: () => void;
 }
 
 export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
@@ -58,6 +60,7 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
   checkedIndices,
   directory,
   directoryRecordings,
+  closePanelFn,
 }) => {
   const context = React.useContext(ServiceContext);
   const [recordings, setRecordings] = React.useState<Recording[]>([]);
@@ -84,10 +87,10 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
     recordings.forEach((r: Recording) => {
       const idx = getIdxFromRecording(r);
       if (checkedIndices.includes(idx)) {
-        let updatedLabels = [...r.metadata.labels, ...commonLabels];
-        updatedLabels = updatedLabels.filter((label) => {
-          return !includesLabel(toDelete, label);
-        });
+        const updatedLabels = [...r.metadata.labels, ...commonLabels].filter(
+          (label) => !includesLabel(toDelete, label),
+        );
+
         if (directory) {
           tasks.push(context.api.postRecordingMetadataForJvmId(directory.jvmId, r.name, updatedLabels).pipe(first()));
         }
@@ -122,11 +125,12 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
 
   const handleCancel = React.useCallback(() => {
     setCommonLabels(savedCommonLabels);
-  }, [setCommonLabels, savedCommonLabels]);
+    closePanelFn();
+  }, [setCommonLabels, savedCommonLabels, closePanelFn]);
 
   const updateCommonLabels = React.useCallback(
     (setLabels: (l: KeyValue[]) => void) => {
-      const allRecordingLabels = [] as KeyValue[][];
+      const allRecordingLabels: KeyValue[][] = [];
 
       recordings.forEach((r: Recording) => {
         const idx = getIdxFromRecording(r);
@@ -293,8 +297,8 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
         <StackItem>
           <HelperText>
             <HelperTextItem>
-              Labels present on all selected Recordings will appear here. Editing the Labels will affect all selected
-              Recordings.
+              Labels present on all selected Recordings will appear here. Editing the labels will affect all selected
+              Recordings. Specify labels with format <Label isCompact>key=value</Label>.
             </HelperTextItem>
           </HelperText>
         </StackItem>

--- a/src/app/RecordingMetadata/BulkEditLabels.tsx
+++ b/src/app/RecordingMetadata/BulkEditLabels.tsx
@@ -51,7 +51,7 @@ export interface BulkEditLabelsProps {
   checkedIndices: number[];
   directory?: RecordingDirectory;
   directoryRecordings?: ArchivedRecording[];
-  closePanelFn: () => void;
+  closePanelFn?: () => void;
 }
 
 export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
@@ -125,7 +125,7 @@ export const BulkEditLabels: React.FC<BulkEditLabelsProps> = ({
 
   const handleCancel = React.useCallback(() => {
     setCommonLabels(savedCommonLabels);
-    closePanelFn();
+    closePanelFn && closePanelFn();
   }, [setCommonLabels, savedCommonLabels, closePanelFn]);
 
   const updateCommonLabels = React.useCallback(

--- a/src/app/RecordingMetadata/ClickableLabel.tsx
+++ b/src/app/RecordingMetadata/ClickableLabel.tsx
@@ -26,22 +26,7 @@ export interface ClickableLabelCellProps {
 }
 
 export const ClickableLabel: React.FC<ClickableLabelCellProps> = ({ label, isSelected, onLabelClick }) => {
-  const [isHoveredOrFocused, setIsHoveredOrFocused] = React.useState(false);
   const labelColor = React.useMemo(() => (isSelected ? 'blue' : 'grey'), [isSelected]);
-
-  const handleHoveredOrFocused = React.useCallback(() => setIsHoveredOrFocused(true), [setIsHoveredOrFocused]);
-  const handleNonHoveredOrFocused = React.useCallback(() => setIsHoveredOrFocused(false), [setIsHoveredOrFocused]);
-
-  const style = React.useMemo(() => {
-    if (isHoveredOrFocused) {
-      const defaultStyle = { cursor: 'pointer', '--pf-c-label__content--before--BorderWidth': '2.5px' };
-      if (isSelected) {
-        return { ...defaultStyle, '--pf-c-label__content--before--BorderColor': '#06c' };
-      }
-      return { ...defaultStyle, '--pf-c-label__content--before--BorderColor': '#8a8d90' };
-    }
-    return {};
-  }, [isSelected, isHoveredOrFocused]);
 
   const handleLabelClicked = React.useCallback(() => onLabelClick(label), [label, onLabelClick]);
 
@@ -49,11 +34,7 @@ export const ClickableLabel: React.FC<ClickableLabelCellProps> = ({ label, isSel
     <>
       <Label
         aria-label={keyValueToString(label)}
-        style={style}
         textMaxWidth={LABEL_TEXT_MAXWIDTH}
-        onMouseEnter={handleHoveredOrFocused}
-        onMouseLeave={handleNonHoveredOrFocused}
-        onFocus={handleHoveredOrFocused}
         onClick={handleLabelClicked}
         key={label.key}
         color={labelColor}

--- a/src/app/RecordingMetadata/LabelCell.tsx
+++ b/src/app/RecordingMetadata/LabelCell.tsx
@@ -17,7 +17,7 @@
 import { EmptyText } from '@app/Shared/Components/EmptyText';
 import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 import { KeyValue, keyValueToString } from '@app/Shared/Services/api.types';
-import { Label } from '@patternfly/react-core';
+import { Label, LabelGroup } from '@patternfly/react-core';
 import * as React from 'react';
 import { ClickableLabel } from './ClickableLabel';
 
@@ -47,6 +47,7 @@ export const LabelCell: React.FC<LabelCellProps> = ({ target, labels, clickableO
     (label: KeyValue) => (isLabelSelected(label) ? 'blue' : 'grey'),
     [isLabelSelected],
   );
+
   const onLabelSelectToggle = React.useCallback(
     (clickedLabel: KeyValue) => {
       if (clickableOptions) {
@@ -62,21 +63,23 @@ export const LabelCell: React.FC<LabelCellProps> = ({ target, labels, clickableO
 
   return (
     <>
-      {!!labels && labels.length ? (
-        labels.map((label) =>
-          clickableOptions ? (
-            <ClickableLabel
-              key={label.key}
-              label={label}
-              isSelected={isLabelSelected(label)}
-              onLabelClick={onLabelSelectToggle}
-            />
-          ) : (
-            <Label aria-label={keyValueToString(label)} key={label.key} color={getLabelColor(label)}>
-              {keyValueToString(label)}
-            </Label>
-          ),
-        )
+      {labels.length ? (
+        <LabelGroup>
+          {labels.map((label) =>
+            clickableOptions ? (
+              <ClickableLabel
+                key={label.key}
+                label={label}
+                isSelected={isLabelSelected(label)}
+                onLabelClick={onLabelSelectToggle}
+              />
+            ) : (
+              <Label aria-label={keyValueToString(label)} key={label.key} color={getLabelColor(label)}>
+                {keyValueToString(label)}
+              </Label>
+            ),
+          )}
+        </LabelGroup>
       ) : (
         <EmptyText text="No labels" />
       )}

--- a/src/app/RecordingMetadata/LabelCell.tsx
+++ b/src/app/RecordingMetadata/LabelCell.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { EmptyText } from '@app/Shared/Components/EmptyText';
 import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 import { KeyValue, keyValueToString } from '@app/Shared/Services/api.types';
 import { Label, Text } from '@patternfly/react-core';
@@ -77,7 +78,7 @@ export const LabelCell: React.FC<LabelCellProps> = ({ target, labels, clickableO
           ),
         )
       ) : (
-        <Text>-</Text>
+        <EmptyText text="No labels" />
       )}
     </>
   );

--- a/src/app/RecordingMetadata/LabelCell.tsx
+++ b/src/app/RecordingMetadata/LabelCell.tsx
@@ -17,7 +17,7 @@
 import { EmptyText } from '@app/Shared/Components/EmptyText';
 import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 import { KeyValue, keyValueToString } from '@app/Shared/Services/api.types';
-import { Label, Text } from '@patternfly/react-core';
+import { Label } from '@patternfly/react-core';
 import * as React from 'react';
 import { ClickableLabel } from './ClickableLabel';
 

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -16,20 +16,13 @@
 import { LoadingView } from '@app/Shared/Components/LoadingView';
 import { KeyValue, keyValueToString } from '@app/Shared/Services/api.types';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
-import { LABEL_TEXT_MAXWIDTH, portalRoot } from '@app/utils/utils';
+import { portalRoot } from '@app/utils/utils';
 import { Button, Label, LabelGroup, List, ListItem, Popover, Text, ValidatedOptions } from '@patternfly/react-core';
 import { ExclamationCircleIcon, FileIcon, UploadIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { catchError, Observable, of, zip } from 'rxjs';
-import {
-  isValidLabel,
-  getValidatedOption,
-  isDuplicateKey,
-  parseLabelsFromFile,
-  isValidLabelInput,
-  getLabelFromInput,
-} from './utils';
+import { isValidLabel, getValidatedOption, isDuplicateKey, parseLabelsFromFile, getLabelFromInput } from './utils';
 
 export interface RecordingLabelFieldsProps {
   labels: KeyValue[];

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -133,7 +133,7 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
       } // Ignore initial empty key inputs
     });
     return arr;
-  }, [labels, isDuplicateKey]);
+  }, [labels]);
 
   return loading ? (
     <LoadingView />

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -66,11 +66,13 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
   const handleLabelEdit = React.useCallback(
     (idx: number, keyValue: string) => {
       const label = getLabelFromInput(keyValue);
+      const updatedLabels = [...labels];
       if (label) {
-        const updatedLabels = [...labels];
         updatedLabels[idx] = label;
-        setLabels(updatedLabels);
+      } else {
+        updatedLabels.splice(idx);
       }
+      setLabels(updatedLabels);
     },
     [labels, setLabels],
   );
@@ -188,7 +190,7 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
       )}
       <LabelGroup
         categoryName="Recording Labels"
-        numLabels={5}
+        numLabels={10}
         isEditable
         addLabelControl={
           <Label color="blue" variant="outline" isDisabled={isDisabled} onClick={handleAddLabelButtonClick}>

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -21,6 +21,8 @@ import {
   ActionList,
   ActionListItem,
   Button,
+  HelperText,
+  HelperTextItem,
   Label,
   LabelGroup,
   List,
@@ -121,6 +123,16 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
     inputRef.current && inputRef.current.click();
   }, [inputRef]);
 
+  const validLabels: boolean[] = React.useMemo(() => {
+    const arr = Array(labels.length).fill(false);
+    labels.forEach((label, index) => {
+      if (label.key.length > 0) {
+        arr[index] = isValidLabel(label) && !isDuplicateKey(label.key, labels);
+      } // Ignore initial empty key inputs
+    });
+    return arr;
+  }, [labels, isDuplicateKey]);
+
   return loading ? (
     <LoadingView />
   ) : (
@@ -188,7 +200,7 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
           <Label
             key={label.key}
             id={label.key}
-            color="grey"
+            color={validLabels[idx] ? 'grey' : 'red'}
             isEditable
             onClose={() => handleDeleteLabelButtonClick(idx)}
             isDisabled={isDisabled}
@@ -199,6 +211,11 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
           </Label>
         ))}
       </LabelGroup>
+      {validLabels.some((v) => !v) ? (
+        <HelperText>
+          <HelperTextItem variant="error">Keys must be unique. Labels should not contain empty spaces.</HelperTextItem>
+        </HelperText>
+      ) : null}
     </>
   );
 };

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -14,25 +14,11 @@
  * limitations under the License.
  */
 import { LoadingView } from '@app/Shared/Components/LoadingView';
-import { KeyValue } from '@app/Shared/Services/api.types';
+import { KeyValue, keyValueToString } from '@app/Shared/Services/api.types';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot } from '@app/utils/utils';
-import {
-  Button,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
-  Icon,
-  List,
-  ListItem,
-  Popover,
-  Split,
-  SplitItem,
-  Text,
-  TextInput,
-  ValidatedOptions,
-} from '@patternfly/react-core';
-import { CloseIcon, ExclamationCircleIcon, FileIcon, PlusCircleIcon, UploadIcon } from '@patternfly/react-icons';
+import { Button, Label, LabelGroup, List, ListItem, Popover, Text, ValidatedOptions } from '@patternfly/react-core';
+import { ExclamationCircleIcon, FileIcon, UploadIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { catchError, Observable, of, zip } from 'rxjs';
@@ -162,15 +148,6 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
     <LoadingView />
   ) : (
     <>
-      <Button
-        aria-label="Add Label"
-        onClick={handleAddLabelButtonClick}
-        variant="link"
-        icon={<PlusCircleIcon />}
-        isDisabled={isDisabled}
-      >
-        Add Label
-      </Button>
       {isUploadable && (
         <>
           <Popover
@@ -217,7 +194,23 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
           />
         </>
       )}
-      {labels.map((label, idx) => (
+      <LabelGroup
+        categoryName="Recording Labels"
+        numLabels={5}
+        isEditable
+        addLabelControl={
+          <Label color="blue" variant="outline" isOverflowLabel onClick={() => {}}>
+            Add label
+          </Label>
+        }
+      >
+        {labels.map((label, idx) => (
+          <Label key={label.key} id={label.key} color="blue" onClose={() => handleDeleteLabelButtonClick(idx)}>
+            {keyValueToString(label)}
+          </Label>
+        ))}
+      </LabelGroup>
+      {/* {labels.map((label, idx) => (
         <Split hasGutter key={idx}>
           <SplitItem isFilled>
             <TextInput
@@ -270,7 +263,7 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
             />
           </SplitItem>
         </Split>
-      ))}
+      ))} */}
     </>
   );
 };

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -17,7 +17,18 @@ import { LoadingView } from '@app/Shared/Components/LoadingView';
 import { KeyValue, keyValueToString } from '@app/Shared/Services/api.types';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot } from '@app/utils/utils';
-import { Button, Label, LabelGroup, List, ListItem, Popover, Text, ValidatedOptions } from '@patternfly/react-core';
+import {
+  ActionList,
+  ActionListItem,
+  Button,
+  Label,
+  LabelGroup,
+  List,
+  ListItem,
+  Popover,
+  Text,
+  ValidatedOptions,
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon, FileIcon, UploadIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -116,48 +127,51 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
     <>
       {isUploadable && (
         <>
-          <Popover
-            appendTo={portalRoot}
-            isVisible={!!invalidUploads.length}
-            aria-label="uploading warning"
-            alertSeverityVariant="danger"
-            headerContent="Invalid Selection"
-            headerComponent="h1"
-            shouldClose={closeWarningPopover}
-            headerIcon={<ExclamationCircleIcon />}
-            bodyContent={
-              <>
-                <Text component="h4">
-                  {t('RecordingLabelFields.INVALID_UPLOADS', { count: invalidUploads.length })}
-                </Text>
-                <List>
-                  {invalidUploads.map((uploadName) => (
-                    <ListItem key={uploadName} icon={<FileIcon />}>
-                      {uploadName}
-                    </ListItem>
-                  ))}
-                </List>
-              </>
-            }
-          >
-            <Button
-              aria-label="Upload Labels"
-              onClick={openLabelFileBrowse}
-              variant="link"
-              icon={<UploadIcon />}
-              isDisabled={isDisabled}
-            >
-              Upload Labels
-            </Button>
-          </Popover>
-          <input
-            ref={inputRef}
-            accept={'.json'}
-            type="file"
-            style={{ display: 'none' }}
-            onChange={handleUploadLabel}
-            multiple
-          />
+          <ActionList style={{ marginBottom: '1em' }}>
+            <ActionListItem>
+              <Popover
+                appendTo={portalRoot}
+                isVisible={!!invalidUploads.length}
+                aria-label="uploading warning"
+                alertSeverityVariant="danger"
+                headerContent="Invalid Selection"
+                headerComponent="h1"
+                shouldClose={closeWarningPopover}
+                headerIcon={<ExclamationCircleIcon />}
+                bodyContent={
+                  <>
+                    <Text component="h4">
+                      {t('RecordingLabelFields.INVALID_UPLOADS', { count: invalidUploads.length })}
+                    </Text>
+                    <List>
+                      {invalidUploads.map((uploadName) => (
+                        <ListItem key={uploadName} icon={<FileIcon />}>
+                          {uploadName}
+                        </ListItem>
+                      ))}
+                    </List>
+                  </>
+                }
+              >
+                <Button
+                  aria-label="Upload Labels"
+                  onClick={openLabelFileBrowse}
+                  variant="secondary"
+                  isDisabled={isDisabled}
+                >
+                  <UploadIcon />
+                </Button>
+              </Popover>
+              <input
+                ref={inputRef}
+                accept={'.json'}
+                type="file"
+                style={{ display: 'none' }}
+                onChange={handleUploadLabel}
+                multiple
+              />
+            </ActionListItem>
+          </ActionList>
         </>
       )}
       <LabelGroup

--- a/src/app/RecordingMetadata/utils.ts
+++ b/src/app/RecordingMetadata/utils.ts
@@ -49,10 +49,25 @@ export const parseLabelsFromFile = (file: File): Observable<KeyValue[]> => {
 };
 export const LabelPattern = /^\S+$/;
 
-export const getValidatedOption = (isValid: boolean) => {
-  return isValid ? ValidatedOptions.success : ValidatedOptions.error;
+export const LabelInputPattern = /^(\S+)=(\S+)$/;
+
+export const getValidatedOption = (isValid: boolean) => (isValid ? ValidatedOptions.success : ValidatedOptions.error);
+
+export const getLabelFromInput = (labelInput: string): KeyValue | undefined => {
+  if (!isValidLabelInput(labelInput)) {
+    return undefined;
+  }
+  const matches = labelInput.match(LabelInputPattern);
+  if (!matches) {
+    return undefined;
+  }
+
+  return { key: matches[1], value: matches[2] };
 };
 
-export const matchesLabelSyntax = (l: KeyValue) => {
-  return l && LabelPattern.test(l.key) && LabelPattern.test(l.value);
-};
+export const isDuplicateKey = (key: string, labels: KeyValue[]) =>
+  labels.filter((label) => label.key === key).length > 1;
+
+export const isValidLabel = (l: KeyValue) => l && LabelPattern.test(l.key) && LabelPattern.test(l.value);
+
+export const isValidLabelInput = (labelInput: string) => LabelInputPattern.test(labelInput);

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -990,7 +990,7 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
         <Td key={`active-table-row-${index}_6`} dataLabel={tableColumns[4].title}>
           <LabelGroup isVertical style={{ padding: '0.2em' }}>
             {recordingOptions(recording).map((options) => (
-              <Label color="blue" key={options.key} textMaxWidth={LABEL_TEXT_MAXWIDTH}>
+              <Label color="purple" key={options.key} textMaxWidth={LABEL_TEXT_MAXWIDTH}>
                 {keyValueToString(options)}
               </Label>
             ))}

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -76,6 +76,11 @@ import {
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
+  Divider,
+  Panel,
+  PanelHeader,
+  PanelMain,
+  PanelMainBody,
 } from '@patternfly/react-core';
 import { EllipsisVIcon, RedoIcon } from '@patternfly/react-icons';
 import { ExpandableRowContent, SortByDirection, Tbody, Td, Tr } from '@patternfly/react-table';
@@ -1019,44 +1024,56 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
       <Tr key={`${index}_child`} isExpanded={isExpanded}>
         <Td key={`active-ex-expand-${index}`} dataLabel={'Content Details'} colSpan={tableColumns.length + 3}>
           <ExpandableRowContent>
-            <Title headingLevel={'h5'}>
-              <Button
-                variant="plain"
-                size="sm"
-                isDisabled={loadingAnalysis}
-                onClick={handleLoadAnalysis}
-                icon={<RedoIcon />}
-              />
-              Automated analysis
-            </Title>
-            <Grid>
-              {loadingAnalysis ? (
-                <Bullseye>
-                  <Spinner />
-                </Bullseye>
-              ) : (
-                analyses.map(([topic, evaluations]) => {
-                  return (
-                    <GridItem className="automated-analysis-grid-item" span={2} key={`gridItem-${topic}`}>
-                      <LabelGroup
-                        className="automated-analysis-topic-label-groups"
-                        categoryName={topic}
-                        isVertical
-                        numLabels={2}
-                        isCompact
-                        key={topic}
-                      >
-                        {evaluations.map((evaluation) => {
-                          return (
-                            <ClickableAutomatedAnalysisLabel result={evaluation} key={clickableAutomatedAnalysisKey} />
-                          );
-                        })}
-                      </LabelGroup>
-                    </GridItem>
-                  );
-                })
-              )}
-            </Grid>
+            <Panel>
+              <PanelHeader>
+                <Title headingLevel={'h5'}>
+                  Automated analysis
+                  <Button
+                    variant="plain"
+                    size="sm"
+                    isDisabled={loadingAnalysis}
+                    onClick={handleLoadAnalysis}
+                    icon={<RedoIcon />}
+                  />
+                </Title>
+              </PanelHeader>
+              <Divider />
+              <PanelMain>
+                <PanelMainBody>
+                  <Grid>
+                    {loadingAnalysis ? (
+                      <Bullseye>
+                        <Spinner />
+                      </Bullseye>
+                    ) : (
+                      analyses.map(([topic, evaluations]) => {
+                        return (
+                          <GridItem className="automated-analysis-grid-item" span={2} key={`gridItem-${topic}`}>
+                            <LabelGroup
+                              className="automated-analysis-topic-label-groups"
+                              categoryName={topic}
+                              isVertical
+                              numLabels={2}
+                              isCompact
+                              key={topic}
+                            >
+                              {evaluations.map((evaluation) => {
+                                return (
+                                  <ClickableAutomatedAnalysisLabel
+                                    result={evaluation}
+                                    key={clickableAutomatedAnalysisKey}
+                                  />
+                                );
+                              })}
+                            </LabelGroup>
+                          </GridItem>
+                        );
+                      })
+                    )}
+                  </Grid>
+                </PanelMainBody>
+              </PanelMain>
+            </Panel>
           </ExpandableRowContent>
         </Td>
       </Tr>

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -732,7 +732,12 @@ const ActiveRecordingsToolbar: React.FC<ActiveRecordingsToolbarProps> = (props) 
           </Button>
         ),
         collapsed: (
-          <OverflowMenuDropdownItem key={'Stop'} isShared onClick={props.handleStopRecordings}>
+          <OverflowMenuDropdownItem
+            key={'Stop'}
+            isShared
+            onClick={props.handleStopRecordings}
+            isDisabled={isStopDisabled}
+          >
             {props.actionLoadings['STOP'] ? 'Stopping' : 'Stop'}
           </OverflowMenuDropdownItem>
         ),

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -995,6 +995,7 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
           index={index}
           recording={recording}
           uploadFn={() => context.api.uploadActiveRecordingToGrafana(recording.name)}
+          deleteFn={() => context.api.deleteRecording(recording.name)}
         />
       </Tr>
     );

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -818,20 +818,21 @@ const ActiveRecordingsToolbar: React.FC<ActiveRecordingsToolbarProps> = (props) 
               </OverflowMenuContent>
               <OverflowMenuControl>
                 <Dropdown
-                  isPlain
                   onSelect={() => setActionToggleOpen(false)}
                   toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                    <MenuToggle ref={toggleRef} onClick={() => handleActionToggle()}>
+                    <MenuToggle variant="plain" ref={toggleRef} onClick={() => handleActionToggle()}>
                       <EllipsisVIcon />
                     </MenuToggle>
                   )}
+                  onOpenChange={setActionToggleOpen}
+                  onOpenChangeKeys={['Escape']}
                   isOpen={actionToggleOpen}
                   popperProps={{
                     appendTo: document.body,
                     enableFlip: true,
                   }}
                 >
-                  <DropdownList>={buttons.map((b) => b.collapsed)}</DropdownList>
+                  <DropdownList>{buttons.map((b) => b.collapsed)}</DropdownList>
                 </Dropdown>
               </OverflowMenuControl>
             </OverflowMenu>

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -799,6 +799,7 @@ const ActiveRecordingsToolbar: React.FC<ActiveRecordingsToolbarProps> = (props) 
           updateFilters={props.updateFilters}
           breakpoint={'xl'}
         />
+        <ToolbarItem variant="separator" />
         <ToolbarGroup style={{ alignSelf: 'start' }} variant="button-group">
           <ToolbarItem variant="overflow-menu">
             <OverflowMenu

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -81,10 +81,12 @@ import {
   PanelHeader,
   PanelMain,
   PanelMainBody,
+  Tooltip,
 } from '@patternfly/react-core';
 import { EllipsisVIcon, RedoIcon } from '@patternfly/react-icons';
 import { ExpandableRowContent, SortByDirection, Tbody, Td, Tr } from '@patternfly/react-table';
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { combineLatest, forkJoin, merge, Observable } from 'rxjs';
@@ -865,6 +867,7 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
   handleRowCheck,
   updateFilters,
 }) => {
+  const { t } = useTranslation();
   const [dayjs, datetimeContext] = useDayjs();
   const context = React.useContext(ServiceContext);
   const [loadingAnalysis, setLoadingAnalysis] = React.useState(false);
@@ -1033,7 +1036,11 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
                     size="sm"
                     isDisabled={loadingAnalysis}
                     onClick={handleLoadAnalysis}
-                    icon={<RedoIcon />}
+                    icon={
+                      <Tooltip content={t('REFRESH', { ns: 'common' })}>
+                        <RedoIcon />
+                      </Tooltip>
+                    }
                   />
                 </Title>
               </PanelHeader>

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -1010,7 +1010,6 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
           index={index}
           recording={recording}
           uploadFn={() => context.api.uploadActiveRecordingToGrafana(recording.name)}
-          deleteFn={() => context.api.deleteRecording(recording.name)}
         />
       </Tr>
     );

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -1085,7 +1085,7 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
         </Td>
       </Tr>
     );
-  }, [index, isExpanded, handleLoadAnalysis, loadingAnalysis, analyses]);
+  }, [index, isExpanded, handleLoadAnalysis, loadingAnalysis, analyses, t]);
 
   return (
     <Tbody key={index} isExpanded={isExpanded}>

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -78,7 +78,7 @@ import { UploadIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { Tbody, Tr, Td, ExpandableRowContent, Table, SortByDirection } from '@patternfly/react-table';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Observable, forkJoin, merge, combineLatest } from 'rxjs';
+import { Observable, forkJoin, merge, combineLatest, of } from 'rxjs';
 import { concatMap, filter, first, map } from 'rxjs/operators';
 import { LabelCell } from '../RecordingMetadata/LabelCell';
 import { RecordingActions } from './RecordingActions';
@@ -905,12 +905,19 @@ export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
             recording={recording}
             index={index}
             uploadFn={() => context.api.uploadArchivedRecordingToGrafanaFromPath(propsDirectory.jvmId, recording.name)}
+            deleteFn={() => context.api.deleteArchivedRecordingFromPath(propsDirectory.jvmId, recording.name)}
           />
         ) : (
           <RecordingActions
             recording={recording}
             index={index}
             uploadFn={() => context.api.uploadArchivedRecordingToGrafana(sourceTarget, recording.name)}
+            deleteFn={() => {
+              context.reports.delete(recording);
+              return sourceTarget.pipe(
+                concatMap((t) => (t ? context.api.deleteArchivedRecording(t.connectUrl, recording.name) : of(false))),
+              );
+            }}
           />
         )}
       </Tr>

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -761,13 +761,14 @@ const ArchivedRecordingsToolbar: React.FC<ArchivedRecordingsToolbarProps> = (pro
               </OverflowMenuContent>
               <OverflowMenuControl>
                 <Dropdown
-                  isPlain
                   onSelect={() => setActionToggleOpen(false)}
                   toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                    <MenuToggle ref={toggleRef} onClick={() => handleActionToggle()}>
+                    <MenuToggle variant="plain" ref={toggleRef} onClick={() => handleActionToggle()}>
                       <EllipsisVIcon />
                     </MenuToggle>
                   )}
+                  onOpenChange={setActionToggleOpen}
+                  onOpenChangeKeys={['Escape']}
                   isOpen={actionToggleOpen}
                   popperProps={{
                     appendTo: portalRoot,

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -83,7 +83,7 @@ import { UploadIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { Tbody, Tr, Td, ExpandableRowContent, Table, SortByDirection } from '@patternfly/react-table';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Observable, forkJoin, merge, combineLatest, of } from 'rxjs';
+import { Observable, forkJoin, merge, combineLatest } from 'rxjs';
 import { concatMap, filter, first, map } from 'rxjs/operators';
 import { LabelCell } from '../RecordingMetadata/LabelCell';
 import { RecordingActions } from './RecordingActions';
@@ -912,19 +912,12 @@ export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
             recording={recording}
             index={index}
             uploadFn={() => context.api.uploadArchivedRecordingToGrafanaFromPath(propsDirectory.jvmId, recording.name)}
-            deleteFn={() => context.api.deleteArchivedRecordingFromPath(propsDirectory.jvmId, recording.name)}
           />
         ) : (
           <RecordingActions
             recording={recording}
             index={index}
             uploadFn={() => context.api.uploadArchivedRecordingToGrafana(sourceTarget, recording.name)}
-            deleteFn={() => {
-              context.reports.delete(recording);
-              return sourceTarget.pipe(
-                concatMap((t) => (t ? context.api.deleteArchivedRecording(t.connectUrl, recording.name) : of(false))),
-              );
-            }}
           />
         )}
       </Tr>
@@ -939,7 +932,6 @@ export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
     propsDirectory,
     recording,
     context.api,
-    context.reports,
     updateFilters,
     handleCheck,
     handleToggle,

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -742,6 +742,7 @@ const ArchivedRecordingsToolbar: React.FC<ArchivedRecordingsToolbarProps> = (pro
           updateFilters={props.updateFilters}
           breakpoint={'xl'}
         />
+        <ToolbarItem variant="separator" />
         <ToolbarGroup variant="button-group" style={{ alignSelf: 'start' }}>
           <ToolbarItem variant="overflow-menu">
             <OverflowMenu

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -937,6 +937,7 @@ export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
     propsDirectory,
     recording,
     context.api,
+    context.reports,
     updateFilters,
     handleCheck,
     handleToggle,

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -73,6 +73,11 @@ import {
   DropdownList,
   MenuToggle,
   MenuToggleElement,
+  PanelHeader,
+  Divider,
+  Panel,
+  PanelMain,
+  PanelMainBody,
 } from '@patternfly/react-core';
 import { UploadIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { Tbody, Tr, Td, ExpandableRowContent, Table, SortByDirection } from '@patternfly/react-table';
@@ -942,35 +947,47 @@ export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
       <Tr key={`${index}_child`} isExpanded={isExpanded}>
         <Td key={`archived-ex-expand-${index}`} dataLabel={'Content Details'} colSpan={tableColumns.length + 3}>
           <ExpandableRowContent>
-            <Title headingLevel={'h5'}>Automated analysis</Title>
-            <Grid>
-              {loadingAnalysis ? (
-                <Bullseye>
-                  <Spinner />
-                </Bullseye>
-              ) : (
-                analyses.map(([topic, evaluations]) => {
-                  return (
-                    <GridItem className="automated-analysis-grid-item" span={2} key={`gridItem-${topic}`}>
-                      <LabelGroup
-                        className="automated-analysis-topic-label-groups"
-                        categoryName={topic}
-                        isVertical
-                        numLabels={2}
-                        isCompact
-                        key={topic}
-                      >
-                        {evaluations.map((evaluation) => {
-                          return (
-                            <ClickableAutomatedAnalysisLabel result={evaluation} key={clickableAutomatedAnalysisKey} />
-                          );
-                        })}
-                      </LabelGroup>
-                    </GridItem>
-                  );
-                })
-              )}
-            </Grid>
+            <Panel>
+              <PanelHeader>
+                <Title headingLevel={'h5'}>Automated analysis</Title>
+              </PanelHeader>
+              <Divider />
+              <PanelMain>
+                <PanelMainBody>
+                  <Grid>
+                    {loadingAnalysis ? (
+                      <Bullseye>
+                        <Spinner />
+                      </Bullseye>
+                    ) : (
+                      analyses.map(([topic, evaluations]) => {
+                        return (
+                          <GridItem className="automated-analysis-grid-item" span={2} key={`gridItem-${topic}`}>
+                            <LabelGroup
+                              className="automated-analysis-topic-label-groups"
+                              categoryName={topic}
+                              isVertical
+                              numLabels={2}
+                              isCompact
+                              key={topic}
+                            >
+                              {evaluations.map((evaluation) => {
+                                return (
+                                  <ClickableAutomatedAnalysisLabel
+                                    result={evaluation}
+                                    key={clickableAutomatedAnalysisKey}
+                                  />
+                                );
+                              })}
+                            </LabelGroup>
+                          </GridItem>
+                        );
+                      })
+                    )}
+                  </Grid>
+                </PanelMainBody>
+              </PanelMain>
+            </Panel>
           </ExpandableRowContent>
         </Td>
       </Tr>

--- a/src/app/Recordings/Filters/DurationFilter.tsx
+++ b/src/app/Recordings/Filters/DurationFilter.tsx
@@ -61,8 +61,9 @@ export const DurationFilter: React.FC<DurationFilterProps> = ({
           onKeyDown={handleEnterKey}
         />
       </FlexItem>
-      <FlexItem>
+      <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
         <Checkbox
+          className="duration-filter__continuous-checkbox"
           label="Continuous"
           id="continuous-checkbox"
           isChecked={isContinuous}

--- a/src/app/Recordings/Filters/LabelFilter.tsx
+++ b/src/app/Recordings/Filters/LabelFilter.tsx
@@ -69,11 +69,17 @@ export const LabelFilter: React.FC<LabelFilterProps> = ({ recordings, filteredLa
     return !filterValue ? labelOptions : labelOptions.filter((l) => l.includes(filterValue.toLowerCase()));
   }, [filterValue, labelOptions]);
 
-  const selectOptionProps: SelectOptionProps[] = React.useMemo(() => {
+  const selectOptions = React.useMemo(() => {
     if (!filteredLabelOptions.length) {
-      return [{ isDisabled: true, children: `No results found for "${filterValue}"`, value: undefined }];
+      return <SelectOption isDisabled>No results found</SelectOption>;
     }
-    return filteredLabelOptions.map((l) => ({ children: l, value: l }));
+    return filteredLabelOptions.map((l, index) => (
+      <SelectOption key={index} value={l}>
+        <Label key={l} color="grey">
+          {l}
+        </Label>
+      </SelectOption>
+    ));
   }, [filteredLabelOptions, filterValue]);
 
   const toggle = React.useCallback(
@@ -119,15 +125,7 @@ export const LabelFilter: React.FC<LabelFilterProps> = ({ recordings, filteredLa
       onOpenChange={(isOpen) => setIsExpanded(isOpen)}
       onOpenChangeKeys={['Escape']}
     >
-      <SelectList id="typeahead-label-select">
-        {selectOptionProps.map(({ value, children }, index) => (
-          <SelectOption key={index} value={value}>
-            <Label key={value} color="grey">
-              {children}
-            </Label>
-          </SelectOption>
-        ))}
-      </SelectList>
+      <SelectList id="typeahead-label-select">{selectOptions}</SelectList>
     </Select>
   );
 };

--- a/src/app/Recordings/Filters/LabelFilter.tsx
+++ b/src/app/Recordings/Filters/LabelFilter.tsx
@@ -111,7 +111,14 @@ export const LabelFilter: React.FC<LabelFilterProps> = ({ recordings, filteredLa
   );
 
   return (
-    <Select toggle={toggle} onSelect={onSelect} isOpen={isExpanded} aria-label="Filter by label">
+    <Select
+      toggle={toggle}
+      onSelect={onSelect}
+      isOpen={isExpanded}
+      aria-label="Filter by label"
+      onOpenChange={(isOpen) => setIsExpanded(isOpen)}
+      onOpenChangeKeys={['Escape']}
+    >
       <SelectList id="typeahead-label-select">
         {selectOptionProps.map(({ value, children }, index) => (
           <SelectOption key={index} value={value}>

--- a/src/app/Recordings/Filters/LabelFilter.tsx
+++ b/src/app/Recordings/Filters/LabelFilter.tsx
@@ -22,7 +22,6 @@ import {
   Select,
   SelectList,
   SelectOption,
-  SelectOptionProps,
   TextInputGroup,
   TextInputGroupMain,
   TextInputGroupUtilities,
@@ -80,7 +79,7 @@ export const LabelFilter: React.FC<LabelFilterProps> = ({ recordings, filteredLa
         </Label>
       </SelectOption>
     ));
-  }, [filteredLabelOptions, filterValue]);
+  }, [filteredLabelOptions]);
 
   const toggle = React.useCallback(
     (toggleRef: React.Ref<MenuToggleElement>) => (

--- a/src/app/Recordings/Filters/NameFilter.tsx
+++ b/src/app/Recordings/Filters/NameFilter.tsx
@@ -104,7 +104,14 @@ export const NameFilter: React.FC<NameFilterProps> = ({ recordings, filteredName
   );
 
   return (
-    <Select toggle={toggle} onSelect={onSelect} isOpen={isExpanded} aria-label="Filter by name">
+    <Select
+      toggle={toggle}
+      onSelect={onSelect}
+      isOpen={isExpanded}
+      aria-label="Filter by name"
+      onOpenChange={(isOpen) => setIsExpanded(isOpen)}
+      onOpenChangeKeys={['Escape']}
+    >
       <SelectList>
         {selectOptionProps.map(({ value, children }, index) => (
           <SelectOption key={index} value={value}>

--- a/src/app/Recordings/Filters/NameFilter.tsx
+++ b/src/app/Recordings/Filters/NameFilter.tsx
@@ -22,7 +22,6 @@ import {
   Select,
   SelectList,
   SelectOption,
-  SelectOptionProps,
   TextInputGroup,
   TextInputGroupMain,
   TextInputGroupUtilities,
@@ -71,7 +70,7 @@ export const NameFilter: React.FC<NameFilterProps> = ({ recordings, filteredName
         {n}
       </SelectOption>
     ));
-  }, [filterValue, filteredNameOptions]);
+  }, [filteredNameOptions]);
 
   const toggle = React.useCallback(
     (toggleRef: React.Ref<MenuToggleElement>) => (

--- a/src/app/Recordings/Filters/NameFilter.tsx
+++ b/src/app/Recordings/Filters/NameFilter.tsx
@@ -62,11 +62,15 @@ export const NameFilter: React.FC<NameFilterProps> = ({ recordings, filteredName
     return !filterValue ? nameOptions : nameOptions.filter((n) => n.includes(filterValue.toLowerCase()));
   }, [filterValue, nameOptions]);
 
-  const selectOptionProps: SelectOptionProps[] = React.useMemo(() => {
+  const selectOptions = React.useMemo(() => {
     if (!filteredNameOptions.length) {
-      return [{ isDisabled: true, children: `No results found for "${filterValue}"`, value: undefined }];
+      return <SelectOption isDisabled>No results found</SelectOption>;
     }
-    return filteredNameOptions.map((n) => ({ children: n, value: n }));
+    return filteredNameOptions.map((n, index) => (
+      <SelectOption key={index} value={n}>
+        {n}
+      </SelectOption>
+    ));
   }, [filterValue, filteredNameOptions]);
 
   const toggle = React.useCallback(
@@ -112,13 +116,7 @@ export const NameFilter: React.FC<NameFilterProps> = ({ recordings, filteredName
       onOpenChange={(isOpen) => setIsExpanded(isOpen)}
       onOpenChangeKeys={['Escape']}
     >
-      <SelectList>
-        {selectOptionProps.map(({ value, children }, index) => (
-          <SelectOption key={index} value={value}>
-            {children}
-          </SelectOption>
-        ))}
-      </SelectList>
+      <SelectList>{selectOptions}</SelectList>
     </Select>
   );
 };

--- a/src/app/Recordings/Filters/RecordingStateFilter.tsx
+++ b/src/app/Recordings/Filters/RecordingStateFilter.tsx
@@ -38,12 +38,17 @@ export const RecordingStateFilter: React.FC<RecordingStateFilterProps> = ({ filt
     (toggleRef: React.Ref<MenuToggleElement>) => (
       <MenuToggle ref={toggleRef} onClick={() => setIsOpen((isOpen) => !isOpen)} isExpanded={isOpen}>
         Filter by state
-        {filteredStates?.length ? <Badge isRead>{filteredStates.length}</Badge> : null}
+        {filteredStates?.length ? (
+          <>
+            {' '}
+            <Badge isRead>{filteredStates.length}</Badge>
+          </>
+        ) : null}
       </MenuToggle>
     ),
     [filteredStates, setIsOpen, isOpen],
   );
-
+  console.log(filteredStates);
   return (
     <Select
       toggle={toggle}
@@ -55,7 +60,13 @@ export const RecordingStateFilter: React.FC<RecordingStateFilterProps> = ({ filt
       onOpenChangeKeys={['Escape']}
     >
       {Object.values(RecordingState).map((rs) => (
-        <SelectOption aria-label={`${rs} State`} key={rs} value={rs}>
+        <SelectOption
+          aria-label={`${rs} State`}
+          key={rs}
+          value={rs}
+          hasCheckbox
+          isSelected={filteredStates?.some((s) => s === rs)}
+        >
           {rs}
         </SelectOption>
       ))}

--- a/src/app/Recordings/Filters/RecordingStateFilter.tsx
+++ b/src/app/Recordings/Filters/RecordingStateFilter.tsx
@@ -45,7 +45,15 @@ export const RecordingStateFilter: React.FC<RecordingStateFilterProps> = ({ filt
   );
 
   return (
-    <Select toggle={toggle} onSelect={onSelect} selected={filteredStates} isOpen={isOpen} aria-label="Filter by state">
+    <Select
+      toggle={toggle}
+      onSelect={onSelect}
+      selected={filteredStates}
+      isOpen={isOpen}
+      aria-label="Filter by state"
+      onOpenChange={(isOpen) => setIsOpen(isOpen)}
+      onOpenChangeKeys={['Escape']}
+    >
       {Object.values(RecordingState).map((rs) => (
         <SelectOption aria-label={`${rs} State`} key={rs} value={rs}>
           {rs}

--- a/src/app/Recordings/Filters/RecordingStateFilter.tsx
+++ b/src/app/Recordings/Filters/RecordingStateFilter.tsx
@@ -36,14 +36,13 @@ export const RecordingStateFilter: React.FC<RecordingStateFilterProps> = ({ filt
 
   const toggle = React.useCallback(
     (toggleRef: React.Ref<MenuToggleElement>) => (
-      <MenuToggle ref={toggleRef} onClick={() => setIsOpen((isOpen) => !isOpen)} isExpanded={isOpen}>
+      <MenuToggle
+        ref={toggleRef}
+        badge={filteredStates?.length ? <Badge>{filteredStates.length}</Badge> : null}
+        onClick={() => setIsOpen((isOpen) => !isOpen)}
+        isExpanded={isOpen}
+      >
         Filter by state
-        {filteredStates?.length ? (
-          <>
-            {' '}
-            <Badge isRead>{filteredStates.length}</Badge>
-          </>
-        ) : null}
       </MenuToggle>
     ),
     [filteredStates, setIsOpen, isOpen],

--- a/src/app/Recordings/Filters/RecordingStateFilter.tsx
+++ b/src/app/Recordings/Filters/RecordingStateFilter.tsx
@@ -48,7 +48,7 @@ export const RecordingStateFilter: React.FC<RecordingStateFilterProps> = ({ filt
     ),
     [filteredStates, setIsOpen, isOpen],
   );
-  console.log(filteredStates);
+
   return (
     <Select
       toggle={toggle}

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -108,6 +108,7 @@ export const RecordingActions: React.FC<RecordingActionsProps> = (props) => {
         ref={toggleRef}
         onClick={() => setIsOpen((isOpen) => !isOpen)}
         isExpanded={isOpen}
+        variant="plain"
         data-quickstart-id="recording-kebab"
       >
         <EllipsisVIcon />
@@ -126,7 +127,6 @@ export const RecordingActions: React.FC<RecordingActionsProps> = (props) => {
           direction: 'down',
         }}
         aria-label={`${props.recording.name}-actions`}
-        isPlain
         isOpen={isOpen}
       >
         <DropdownList>

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -36,10 +36,9 @@ export interface RecordingActionsProps {
   recording: Recording;
   sourceTarget?: Observable<Target>;
   uploadFn: () => Observable<boolean>;
-  deleteFn: () => Observable<boolean>;
 }
 
-export const RecordingActions: React.FC<RecordingActionsProps> = ({ recording, uploadFn, deleteFn, ...props }) => {
+export const RecordingActions: React.FC<RecordingActionsProps> = ({ recording, uploadFn, ...props }) => {
   const context = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const [grafanaEnabled, setGrafanaEnabled] = React.useState(false);
@@ -77,11 +76,6 @@ export const RecordingActions: React.FC<RecordingActionsProps> = ({ recording, u
     context.api.downloadRecording(recording);
   }, [context.api, recording]);
 
-  const handleDeleteRecording = React.useCallback(
-    () => addSubscription(deleteFn().subscribe()),
-    [addSubscription, deleteFn],
-  );
-
   const actionItems = React.useMemo(() => {
     const actionItems = [
       {
@@ -98,19 +92,8 @@ export const RecordingActions: React.FC<RecordingActionsProps> = ({ recording, u
       });
     }
 
-    actionItems.push(
-      {
-        isSeparator: true,
-      },
-      {
-        title: 'Delete',
-        key: 'delete',
-        onClick: handleDeleteRecording,
-      },
-    );
-
     return actionItems;
-  }, [handleDownloadRecording, grafanaEnabled, grafanaUpload, handleDeleteRecording]);
+  }, [handleDownloadRecording, grafanaEnabled, grafanaUpload]);
 
   const onSelect = React.useCallback(
     (action: RowAction) => {

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -18,7 +18,7 @@ import { NotificationsContext } from '@app/Shared/Services/Notifications.service
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { Divider, Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
-import { DivideIcon, EllipsisVIcon } from '@patternfly/react-icons';
+import { EllipsisVIcon } from '@patternfly/react-icons';
 import { Td } from '@patternfly/react-table';
 import * as React from 'react';
 import { Observable } from 'rxjs';
@@ -39,14 +39,7 @@ export interface RecordingActionsProps {
   deleteFn: () => Observable<boolean>;
 }
 
-export const RecordingActions: React.FC<RecordingActionsProps> = ({
-  index,
-  recording,
-  sourceTarget,
-  uploadFn,
-  deleteFn,
-  ...props
-}) => {
+export const RecordingActions: React.FC<RecordingActionsProps> = ({ recording, uploadFn, deleteFn, ...props }) => {
   const context = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const [grafanaEnabled, setGrafanaEnabled] = React.useState(false);
@@ -78,7 +71,7 @@ export const RecordingActions: React.FC<RecordingActionsProps> = ({
           }
         }),
     );
-  }, [addSubscription, notifications, props, context.api]);
+  }, [addSubscription, notifications, context.api, recording, uploadFn]);
 
   const handleDownloadRecording = React.useCallback(() => {
     context.api.downloadRecording(recording);
@@ -86,7 +79,7 @@ export const RecordingActions: React.FC<RecordingActionsProps> = ({
 
   const handleDeleteRecording = React.useCallback(
     () => addSubscription(deleteFn().subscribe()),
-    [addSubscription, context.api, recording],
+    [addSubscription, deleteFn],
   );
 
   const actionItems = React.useMemo(() => {
@@ -117,7 +110,7 @@ export const RecordingActions: React.FC<RecordingActionsProps> = ({
     );
 
     return actionItems;
-  }, [handleDownloadRecording, grafanaEnabled, grafanaUpload]);
+  }, [handleDownloadRecording, grafanaEnabled, grafanaUpload, handleDeleteRecording]);
 
   const onSelect = React.useCallback(
     (action: RowAction) => {

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -161,6 +161,7 @@ export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
   const categoryDropdown = React.useMemo(() => {
     return (
       <Dropdown
+        selected={currentCategory}
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}
@@ -184,7 +185,12 @@ export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
       >
         <DropdownList>
           {(!isArchived ? allowedActiveRecordingFilters : allowedArchivedRecordingFilters).map((cat) => (
-            <DropdownItem aria-label={categoriesToDisplayNames[cat]} key={cat} onClick={() => onCategorySelect(cat)}>
+            <DropdownItem
+              aria-label={categoriesToDisplayNames[cat]}
+              key={cat}
+              onClick={() => onCategorySelect(cat)}
+              value={cat}
+            >
               {categoriesToDisplayNames[cat]}
             </DropdownItem>
           ))}

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -161,11 +161,17 @@ export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
     return (
       <Dropdown
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-          <MenuToggle ref={toggleRef} icon={<FilterIcon />} aria-label={currentCategory} onClick={() => onCategoryToggle()}>
-            
+          <MenuToggle
+            ref={toggleRef}
+            icon={<FilterIcon />}
+            aria-label={currentCategory}
+            onClick={() => onCategoryToggle()}
+          >
             {categoriesToDisplayNames[currentCategory]}
           </MenuToggle>
         )}
+        onOpenChange={(isOpen) => setIsCategoryDropdownOpen(isOpen)}
+        onOpenChangeKeys={['Escape']}
         isOpen={isCategoryDropdownOpen}
         popperProps={{
           position: 'left',

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -34,7 +34,7 @@ import {
   MenuToggle,
   MenuToggleElement,
 } from '@patternfly/react-core';
-import { FilterIcon, EllipsisVIcon } from '@patternfly/react-icons';
+import { FilterIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { DateTimeFilter } from './Filters/DatetimeFilter';

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -57,9 +57,9 @@ export const categoriesToDisplayNames = {
   Name: 'Name',
   Label: 'Label',
   State: 'Recording state',
-  StartedBeforeDate: 'Started before date',
-  StartedAfterDate: 'Started after date',
-  DurationSeconds: 'Duration (s)',
+  StartedBeforeDate: 'Start time before',
+  StartedAfterDate: 'Start time after',
+  DurationSeconds: 'Duration (seconds)',
 };
 
 export const categoryIsDate = (fieldKey: string) => /date/i.test(fieldKey);

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -33,6 +33,7 @@ import {
   DropdownList,
   MenuToggle,
   MenuToggleElement,
+  Icon,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 import * as React from 'react';
@@ -163,7 +164,11 @@ export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}
-            icon={<FilterIcon />}
+            icon={
+              <Icon>
+                <FilterIcon />
+              </Icon>
+            }
             aria-label={currentCategory}
             onClick={() => onCategoryToggle()}
           >
@@ -228,7 +233,14 @@ export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
   );
 
   return (
-    <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint={breakpoint}>
+    <ToolbarToggleGroup
+      toggleIcon={
+        <Icon>
+          <FilterIcon />
+        </Icon>
+      }
+      breakpoint={breakpoint}
+    >
       <ToolbarGroup variant="filter-group">
         <ToolbarItem style={{ alignSelf: 'start' }} key={'category-select'}>
           {categoryDropdown}

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -161,10 +161,9 @@ export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
     return (
       <Dropdown
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-          <MenuToggle ref={toggleRef} aria-label={currentCategory} onClick={() => onCategoryToggle()}>
-            <FilterIcon />
+          <MenuToggle ref={toggleRef} icon={<FilterIcon />} aria-label={currentCategory} onClick={() => onCategoryToggle()}>
+            
             {categoriesToDisplayNames[currentCategory]}
-            <EllipsisVIcon />
           </MenuToggle>
         )}
         isOpen={isCategoryDropdownOpen}

--- a/src/app/Recordings/RecordingLabelsPanel.tsx
+++ b/src/app/Recordings/RecordingLabelsPanel.tsx
@@ -53,6 +53,7 @@ export const RecordingLabelsPanel: React.FC<RecordingLabelsPanelProps> = (props)
           isUploadsTable={props.isUploadsTable}
           directory={props.directory}
           directoryRecordings={props.directoryRecordings}
+          closePanelFn={() => props.setShowPanel(false)}
         />
       </DrawerPanelBody>
     </DrawerPanelContent>

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -97,7 +97,7 @@ export const RecordingsTable: React.FC<RecordingsTableProps> = ({
       <Bullseye>
         <EmptyState>
           <EmptyStateHeader
-            titleText={<>No{tableTitle}</>}
+            titleText={<>No {tableTitle}</>}
             icon={<EmptyStateIcon icon={SearchIcon} />}
             headingLevel="h4"
           />
@@ -109,7 +109,7 @@ export const RecordingsTable: React.FC<RecordingsTableProps> = ({
       <Bullseye>
         <EmptyState>
           <EmptyStateHeader
-            titleText={<>No{tableTitle}found</>}
+            titleText={<>No {tableTitle}found</>}
             icon={<EmptyStateIcon icon={SearchIcon} />}
             headingLevel="h4"
           />

--- a/src/app/Recordings/RecordingsTable.tsx
+++ b/src/app/Recordings/RecordingsTable.tsx
@@ -109,7 +109,7 @@ export const RecordingsTable: React.FC<RecordingsTableProps> = ({
       <Bullseye>
         <EmptyState>
           <EmptyStateHeader
-            titleText={<>No {tableTitle}found</>}
+            titleText={<>No {tableTitle} found</>}
             icon={<EmptyStateIcon icon={SearchIcon} />}
             headingLevel="h4"
           />

--- a/src/app/Settings/Config/DatetimeControl.tsx
+++ b/src/app/Settings/Config/DatetimeControl.tsx
@@ -157,12 +157,7 @@ const Component = () => {
           <HelperText>
             <HelperTextItem>{t('SETTINGS.DATETIME_CONTROL.TIMEZONE_SELECT_DESCRIPTION')}</HelperTextItem>
           </HelperText>
-          <TimezonePicker
-            selected={datetimeFormat.timeZone}
-            menuAppendTo={portalRoot}
-            isFlipEnabled
-            onTimezoneChange={handleTimezoneSelect}
-          />
+          <TimezonePicker selected={datetimeFormat.timeZone} isFlipEnabled onTimezoneChange={handleTimezoneSelect} />
         </FormGroup>
       </StackItem>
     </Stack>

--- a/src/app/Shared/Components/SelectTemplateSelectorForm.tsx
+++ b/src/app/Shared/Components/SelectTemplateSelectorForm.tsx
@@ -96,12 +96,22 @@ export const SelectTemplateSelectorForm: React.FC<SelectTemplateSelectorFormProp
         id="recording-template"
         data-quickstart-id="template-selector"
       >
-        <FormSelectOption key="-1" value="" label="Select a Template" isPlaceholder />
+        <FormSelectOption key="placeholder" label="Select a Template" isPlaceholder isDisabled />
+
         {groups.map((group, index) => (
           <FormSelectOptionGroup isDisabled={group.disabled} key={index} label={group.groupLabel}>
-            {group.options.map((option, idx) => (
-              <FormSelectOption key={idx} label={option.label} value={option.value} isDisabled={option.disabled} />
-            ))}
+            {group.options.length > 0 ? (
+              group.options.map((option) => (
+                <FormSelectOption
+                  key={option.label}
+                  label={option.label}
+                  value={option.value}
+                  isDisabled={option.disabled}
+                />
+              ))
+            ) : (
+              <FormSelectOption key="no-template" label="No templates" isDisabled />
+            )}
           </FormSelectOptionGroup>
         ))}
       </FormSelect>

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -501,6 +501,11 @@ html, body, #root {
   z-index: 199;  /* Fix input border overlap */
 }
 
+.pf-v5-c-check__input {
+  --pf-v5-c-check__input--TranslateY--moz: 0;
+  --pf-v5-c-check__input--TranslateY: 0;
+}
+
 .settings__content {
   padding: 2ch;
 }

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -489,10 +489,6 @@ html, body, #root {
   color: var(--pf-v5-global--palette--black-300);
 }
 
-.datetime-picker__datetime-selected-display {
-  max-width: 14em !important;
-}
-
 .datetime-picker__calendar .pf-v5-c-calendar-month__header-year{
   min-width: 6em !important;
 }

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -710,3 +710,11 @@ svg.topology__node-decorator-icon.progress {
 .rules_form_select {
   min-width: 10ch;
 }
+
+.recording-create__form_select {
+  min-width: 10ch;
+}
+
+.duration-picker__form_select {
+  min-width: 10ch;
+}

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -76,6 +76,10 @@ html, body, #root {
   --pf-v5-c-chip__text--MaxWidth: 100ch;
 }
 
+.duration-filter__continuous-checkbox .pf-v5-c-check__label {
+  align-self: center;
+}
+
 .recording-table-outer-container {
   height: 67.3vh;
 }

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -118,10 +118,6 @@ html, body, #root {
   padding-left: 0.65em;
 }
 
-.automated-analysis-grid-item {
-  padding: 0.25em;
-}
-
 #automated-analysis-card {
   height: 100%;
 }
@@ -280,14 +276,18 @@ html, body, #root {
   color: var(--pf-v5-global--danger-color--100);
 }
 
-.automated-analysis-grid-item .pf-v5-c-label-group {
-  width: 100%;
-  height: 100%;
-  background-color: var(--pf-v5-global--BackgroundColor--light-300) !important;
+.automated-analysis-grid-item {
+  padding: 0.25em;
 }
 
-:is(.pf-v5-theme-dark) .automated-analysis-grid-item .pf-v5-c-label-group {
-  background-color: var(--pf-v5-global--BackgroundColor--light-300) !important;
+.automated-analysis-grid-item .automated-analysis-topic-label-groups.pf-v5-c-label-group {
+  width: 100%;
+  height: 100%;
+  background-color: var(--pf-v5-global--BackgroundColor--light-300);
+}
+
+:is(.pf-v5-theme-dark) .automated-analysis-grid-item .automated-analysis-topic-label-groups.pf-v5-c-label-group {
+  background-color: var(--pf-v5-global--BackgroundColor--light-300);
 }
 
 .automated-analysis-grid-item .pf-v5-c-label-group__main {
@@ -300,6 +300,14 @@ html, body, #root {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.automated-analysis-grid-item .pf-v5-c-label-group__list {
+  width: 100%;
+}
+
+.automated-analysis-grid-item .pf-v5-c-label-group__list-item {
+  width: 100%;
 }
 
 .stale-report-text {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -76,10 +76,6 @@ html, body, #root {
   --pf-v5-c-chip__text--MaxWidth: 100ch;
 }
 
-.duration-filter__continuous-checkbox .pf-v5-c-check__label {
-  align-self: center;
-}
-
 .recording-table-outer-container {
   height: 67.3vh;
 }
@@ -230,16 +226,6 @@ html, body, #root {
   --pf-v5-c-label--BackgroundColor: var(--pf-v5-global--BackgroundColor--400);
 }
 
-.pf-v5-c-label-group.pf-v5-m-vertical.pf-v5-c-label-group {
-  height: 100%;
-  width: 100%;
-  background-color: var(--pf-v5-global--BackgroundColor--light-300);
-  border-color: var(--pf-v5-global--BorderColor--light-100);
-  border-style: solid;
-  border-width: 0.1em;
-  border-radius: 0.5em;
-}
-
 .automated-analysis-score-filter-slider .pf-v5-c-slider__step-label {
   font-size: 0.85em;
 }
@@ -282,6 +268,16 @@ html, body, #root {
 
 .automated-analysis-grid-item {
   padding: 0.25em;
+}
+
+.automated-analysis-grid-item .pf-v5-c-label-group.pf-m-vertical.pf-v5-c-label-group {
+  height: 100%;
+  width: 100%;
+  background-color: var(--pf-v5-global--BackgroundColor--light-300);
+  border-color: var(--pf-v5-global--BorderColor--light-100);
+  border-style: solid;
+  border-width: 0.1em;
+  border-radius: 0.5em;
 }
 
 .automated-analysis-grid-item .automated-analysis-topic-label-groups.pf-v5-c-label-group {
@@ -513,8 +509,8 @@ html, body, #root {
   padding-left: 0 !important;
 }
 
-.expandable-form__accordion-toggle-block.pf-v5-c-accordion__toggle.pf-v5-m-expanded {
-  --pf-v5-c-accordion__toggle--before--BackgroundColor: transparent;
+.expandable-form__accordion-toggle-block.pf-v5-c-accordion__toggle.pf-m-expanded {
+  --pf-v5-c-accordion__toggle--after--BackgroundColor: transparent;
 }
 
 .expandable-form__title {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -438,13 +438,13 @@ html, body, #root {
 }
 
 /* Chrome, Safari, Edge, Opera */
-input.datetime-picker__number-input::-webkit-outer-spin-button,
-input.datetime-picker__number-input::-webkit-inner-spin-button {
+.datetime-picker__number-input input::-webkit-outer-spin-button,
+.datetime-picker__number-input input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-input[type=number].datetime-picker__number-input {
+.datetime-picker__number-input input[type=number] {
   -moz-appearance: textfield; /* Firefox */
   width: 3.6rem;
   height: 3.6em;
@@ -453,7 +453,7 @@ input[type=number].datetime-picker__number-input {
   font-weight: 600;
 }
 
-:where(.pf-v5-theme-dark) input[type=number].datetime-picker__number-input {
+:where(.pf-v5-theme-dark) .datetime-picker__number-input input[type=number] {
   background-color: var(--pf-v5-global--palette--black-500);
 }
 
@@ -462,7 +462,7 @@ input[type=number].datetime-picker__number-input {
 }
 
 .datetime-picker__time-spin-box {
-  width: 3.6rem;
+  width: 100%;
   height: 2.2rem;
 }
 
@@ -471,7 +471,7 @@ input[type=number].datetime-picker__number-input {
 }
 
 .datetime-picker__time-spin-box.down {
-  border-radius: 0 0 0.5rem 0.5rem ;
+  border-radius: 0 0 0.5rem 0.5rem;
 }
 
 .datetime-picker__colon-divider {
@@ -482,7 +482,7 @@ input[type=number].datetime-picker__number-input {
 .datetime-picker__time-text-top-label {
   text-align: center;
   color: var(--pf-v5-global--palette--black-600);
-  margin: 0 0 0.5em 0 !important;
+  margin: 0 0 0.5em 0;
 }
 
 :where(.pf-v5-theme-dark) .datetime-picker__time-text-top-label {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -280,24 +280,18 @@ html, body, #root {
   color: var(--pf-v5-global--danger-color--100);
 }
 
+.automated-analysis-grid-item .pf-v5-c-label-group {
+  width: 100%;
+  height: 100%;
+  background-color: var(--pf-v5-global--BackgroundColor--light-300) !important;
+}
+
+:is(.pf-v5-theme-dark) .automated-analysis-grid-item .pf-v5-c-label-group {
+  background-color: var(--pf-v5-global--BackgroundColor--light-300) !important;
+}
+
 .automated-analysis-grid-item .pf-v5-c-label-group__main {
   width: 100%;
-}
-
-.automated-analysis-grid-item .pf-v5-c-label-group__list {
-  width: 100%;
-}
-
-.automated-analysis-grid-item .pf-v5-c-label-group__list-item {
-  width: 100%;
-}
-
-.automated-analysis-grid-item .pf-v5-c-label.pf-v5-m-compact {
-  max-width: 100%;
-}
-
-:is(.pf-v5-theme-dark) .automated-analysis-grid-item .pf-v5-c-label {
-  --pf-v5-c-label--BackgroundColor: var(--pf-v5-global--BackgroundColor--dark-100);
 }
 
 .automated-analysis-grid-item .pf-v5-c-label-group__label {

--- a/src/test/DateTimePicker/TimezonePicker.test.tsx
+++ b/src/test/DateTimePicker/TimezonePicker.test.tsx
@@ -89,9 +89,7 @@ describe('<TimezonePicker/>', () => {
         routes: [
           {
             path: '/recordings',
-            element: (
-              <TimezonePicker isCompact selected={supportedTimezones()[0]} onTimezoneChange={onTimezoneChange} />
-            ),
+            element: <TimezonePicker selected={supportedTimezones()[0]} onTimezoneChange={onTimezoneChange} />,
           },
         ],
       },
@@ -108,9 +106,7 @@ describe('<TimezonePicker/>', () => {
         routes: [
           {
             path: '/recordings',
-            element: (
-              <TimezonePicker isCompact selected={supportedTimezones()[0]} onTimezoneChange={onTimezoneChange} />
-            ),
+            element: <TimezonePicker selected={supportedTimezones()[0]} onTimezoneChange={onTimezoneChange} />,
           },
         ],
       },


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1303 

## Description of the change:

Other upgrading the components to be compatible with PF5. Here some major and minor revamps.

### Major changes


| Changes | Description | Screenshot |
|--------------|-------------------|------------------|
| New label editor for bulk editting | Label editor is now following PF5 [guideline](https://www.patternfly.org/components/label/react-demos/) and closer to that of [OpenShift](http://openshift.github.io/openshift-origin-design/designs/administrator/4.0/labels/). The user can define labels with `key=value`.  The same editor is used for Recording Form and Archive Upload. |  ![image](https://github.com/user-attachments/assets/fbc3bce8-9b56-4394-9f54-2408856c52a4) |

### Minor changes

| Changes | Description | Screenshot |
|--------------|-------------------|------------------|
| Use a different color for advanced option labels | Previously, a blue label can be confused as a selected label for filtering. |  ![image](https://github.com/user-attachments/assets/4f64ff2e-6a98-4419-9bbd-4bc801f6968e) |
| Spacious AA content with refresh button now follows title | A blue stripe on the left-end was removed in PF5, and action buttons should follow title instead. |  ![image](https://github.com/user-attachments/assets/6b8d52a4-3c45-4855-a481-613ce5bf5336) |
| A vertical separator is added to separate filters and action buttons | It is nicer look, especially when rendered with a checkbox (i.e. Continuous duration filter). |  ![image](https://github.com/user-attachments/assets/d6d62683-6fa9-4afd-abbc-aca3c8778186)
| Better wording and selected filter category should be indicated |Selected item is now showed with a check mark. Duration unit is made clear.  Redundant words are removed (i.e. "date"). |  ![image](https://github.com/user-attachments/assets/e71490cb-7a60-4168-9c18-bb806b43303b)
| Overflow menu item `Stop` is disabled if recording is already stopped | Previously, this `Stop` button is not disabled and cause silently failed API call. | ![image](https://github.com/user-attachments/assets/e7878444-da33-427f-88d3-dd8871435b19)|
| Timezone picker now has its own section | Timezone picker was given very limited space so menu toggle is significantly truncated. | ![image](https://github.com/user-attachments/assets/4d3be153-0970-4e61-8cf2-90db4bbeda70)|
| Use new icon button for label uploads | This ensures the same upload button is used consistently across UI. | ![image](https://github.com/user-attachments/assets/b15abb86-4c98-4be7-8afb-b5c8bf164b02) |


