### PR TITLE
chore(discovery): use target.agent field for determining connection type

### DIFF
--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -173,6 +173,7 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
           `query AllTargetsArchives {
             targetNodes {
               target {
+                agent
                 id
                 connectUrl
                 alias

--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -133,6 +133,7 @@ export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecor
       setArchivesForTargets(
         targetNodes.map((node) => {
           const target: Target = {
+            agent: node.target.agent,
             id: node.target.id,
             jvmId: node.target.jvmId,
             connectUrl: node.target.connectUrl,

--- a/src/app/Archives/Archives.tsx
+++ b/src/app/Archives/Archives.tsx
@@ -34,6 +34,7 @@ import { AllTargetsArchivedRecordingsTable } from './AllTargetsArchivedRecording
   notification handling in the ArchivedRecordingsTable.
 */
 export const uploadAsTarget: Target = {
+  agent: false,
   connectUrl: UPLOADS_SUBDIRECTORY,
   alias: '',
   labels: [],

--- a/src/app/Archives/utils.tsx
+++ b/src/app/Archives/utils.tsx
@@ -32,6 +32,7 @@ export const indexOfDirectory = (arr: RecordingDirectory[], dir: RecordingDirect
 
 export const getTargetFromDirectory = (dir: RecordingDirectory): Target => {
   return {
+    agent: dir.connectUrl.startsWith('http'),
     connectUrl: dir.connectUrl,
     alias: dir.jvmId,
     labels: [],

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -26,7 +26,6 @@ import {
   Target,
   KeyValue,
 } from '@app/Shared/Services/api.types';
-import { isTargetAgentHttp } from '@app/Shared/Services/api.utils';
 import { NotificationsContext } from '@app/Shared/Services/Notifications.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
@@ -286,7 +285,7 @@ export const CustomRecordingForm: React.FC = () => {
             setAdvancedRecordingOptions(recordingOptions);
           },
           error: (error) => {
-            setErrorMessage(isTargetAgentHttp(target) ? 'Unsupported operation: Create Recordings' : error.message);
+            setErrorMessage(error.message);
             setTemplates([]);
             setFormData((old) => ({ ...old, template: undefined }));
             setAdvancedRecordingOptions({});

--- a/src/app/Shared/Services/api.types.ts
+++ b/src/app/Shared/Services/api.types.ts
@@ -473,6 +473,7 @@ export const TEMPLATE_UNSUPPORTED_MESSAGE = 'The template type used in this Reco
 export interface Target {
   id?: number; // present in responses but we must not include it in requests to create targets
   jvmId?: string; // present in responses, but we do not need to provide it in requests
+  agent: boolean;
   connectUrl: string;
   alias: string;
   labels: KeyValue[];

--- a/src/app/Shared/Services/api.types.ts
+++ b/src/app/Shared/Services/api.types.ts
@@ -107,7 +107,7 @@ export class XMLHttpError extends Error {
   }
 }
 
-export type TargetStub = Omit<Target, 'jvmId' | 'labels' | 'annotations'>;
+export type TargetStub = Omit<Target, 'agent' | 'jvmId' | 'labels' | 'annotations'>;
 
 export type TargetForTest = Pick<Target, 'alias' | 'connectUrl'> & {
   labels: object;

--- a/src/app/Shared/Services/api.utils.ts
+++ b/src/app/Shared/Services/api.utils.ts
@@ -152,8 +152,6 @@ export const indexOfTarget = (arr: Target[], target: Target): number => {
 export const getTargetRepresentation = (t: Target) =>
   !t.alias || t.alias === t.connectUrl ? `${t.connectUrl}` : `${t.alias} (${t.connectUrl})`;
 
-export const isTargetAgentHttp = (t: Target) => t.connectUrl.startsWith('http');
-
 export const isTargetNode = (node: EnvironmentNode | TargetNode): node is TargetNode => {
   return node['target'] !== undefined;
 };

--- a/src/app/Topology/Actions/CreateTarget.tsx
+++ b/src/app/Topology/Actions/CreateTarget.tsx
@@ -429,7 +429,7 @@ export const CreateTarget: React.FC<CreateTargetProps> = ({ prefilled }) => {
 };
 
 export interface SampleNodeDonutProps {
-  target: Target;
+  target: Omit<Target, 'agent'>;
   testing?: boolean;
   validation: {
     option: ValidatedOptions;

--- a/src/app/Topology/GraphView/CustomNode.tsx
+++ b/src/app/Topology/GraphView/CustomNode.tsx
@@ -95,7 +95,7 @@ const CustomNode: React.FC<CustomNodeProps> = ({
 
   const data: TargetNode = element.getData();
 
-  const graphic = React.useMemo(() => (data.target.connectUrl.startsWith('http') ? cryostatSvg : openjdkSvg), [data]);
+  const graphic = React.useMemo(() => (data.target.agent ? cryostatSvg : openjdkSvg), [data]);
 
   const [nodeStatus] = getStatusTargetNode(data);
 

--- a/src/app/utils/fakeData.ts
+++ b/src/app/utils/fakeData.ts
@@ -46,6 +46,7 @@ import { TargetService } from '@app/Shared/Services/Target.service';
 import { Observable, of } from 'rxjs';
 
 export const fakeTarget: Target = {
+  agent: false,
   jvmId: 'rpZeYNB9wM_TEnXoJvAFuR0jdcUBXZgvkXiKhjQGFvY=',
   connectUrl: 'service:jmx:rmi:///jndi/rmi://10-128-2-25.my-namespace.pod:9097/jmxrmi',
   alias: 'quarkus-test-77f556586c-25bkv',

--- a/src/mirage/factories.ts
+++ b/src/mirage/factories.ts
@@ -18,6 +18,7 @@ import { FactoryDefinition } from 'miragejs/-types';
 import { Resource } from './typings';
 
 export const targetFactory: FactoryDefinition<any> = Factory.extend({
+  agent: true,
   alias: 'Fake Target',
   connectUrl: 'http://fake-target.local:1234',
   jvmId: '1234',

--- a/src/test/Agent/AgentLiveProbes.test.tsx
+++ b/src/test/Agent/AgentLiveProbes.test.tsx
@@ -31,6 +31,7 @@ import { render, renderSnapshot } from '../utils';
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockJvmId = 'id';
 const mockTarget = {
+  agent: false,
   connectUrl: mockConnectUrl,
   alias: 'fooTarget',
   jvmId: mockJvmId,

--- a/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
+++ b/src/test/Archives/AllTargetsArchivedRecordingsTable.test.tsx
@@ -24,6 +24,7 @@ import { render, renderSnapshot } from '../utils';
 const mockConnectUrl1 = 'service:jmx:rmi://someUrl1';
 const mockAlias1 = 'fooTarget1';
 const mockTarget1: Target = {
+  agent: false,
   jvmId: 'target1',
   connectUrl: mockConnectUrl1,
   alias: mockAlias1,
@@ -36,6 +37,7 @@ const mockTarget1: Target = {
 const mockConnectUrl2 = 'service:jmx:rmi://someUrl2';
 const mockAlias2 = 'fooTarget2';
 const mockTarget2: Target = {
+  agent: false,
   jvmId: 'target2',
   connectUrl: mockConnectUrl2,
   alias: mockAlias2,
@@ -48,6 +50,7 @@ const mockTarget2: Target = {
 const mockConnectUrl3 = 'service:jmx:rmi://someUrl3';
 const mockAlias3 = 'fooTarget3';
 const mockTarget3: Target = {
+  agent: false,
   jvmId: 'target3',
   connectUrl: mockConnectUrl3,
   alias: mockAlias3,
@@ -60,6 +63,7 @@ const mockTarget3: Target = {
 const mockNewConnectUrl = 'service:jmx:rmi://someNewUrl';
 const mockNewAlias = 'newTarget';
 const mockNewTarget: Target = {
+  agent: false,
   jvmId: 'target4',
   connectUrl: mockNewConnectUrl,
   alias: mockNewAlias,

--- a/src/test/CreateRecording/CustomRecordingForm.test.tsx
+++ b/src/test/CreateRecording/CustomRecordingForm.test.tsx
@@ -37,6 +37,7 @@ jest.mock('react-router-dom', () => ({
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = {
+  agent: false,
   connectUrl: mockConnectUrl,
   alias: 'fooTarget',
   jvmId: 'foo',

--- a/src/test/CreateRecording/SnapshotRecordingForm.test.tsx
+++ b/src/test/CreateRecording/SnapshotRecordingForm.test.tsx
@@ -24,6 +24,7 @@ import { render, renderSnapshot } from '../utils';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = {
+  agent: false,
   connectUrl: mockConnectUrl,
   alias: 'fooTarget',
   jvmId: 'foo',

--- a/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.test.tsx
@@ -41,6 +41,7 @@ jest.mock('@app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCardList', () => {
 });
 
 const mockTarget = {
+  agent: false,
   connectUrl: 'service:jmx:rmi://someUrl',
   alias: 'fooTarget',
   jvmId: 'foo',

--- a/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.test.tsx
@@ -23,6 +23,7 @@ import { of } from 'rxjs';
 import { render, testT } from '../../utils';
 
 const mockTarget = {
+  agent: false,
   connectUrl: 'service:jmx:rmi://someUrl',
   alias: 'fooTarget',
   jvmId: 'foo',

--- a/src/test/Dashboard/Charts/jfr/JFRMetricsChartCard.test.tsx
+++ b/src/test/Dashboard/Charts/jfr/JFRMetricsChartCard.test.tsx
@@ -30,6 +30,7 @@ const mockDashboardUrl = 'http://localhost:3000';
 jest.spyOn(defaultServices.api, 'grafanaDashboardUrl').mockReturnValue(of(mockDashboardUrl));
 
 const mockTarget = {
+  agent: false,
   connectUrl: 'service:jmx:rmi://someUrl',
   alias: 'fooTarget',
   jvmId: 'foo',

--- a/src/test/Dashboard/Charts/mbean/MBeanMetricsChartCard.test.tsx
+++ b/src/test/Dashboard/Charts/mbean/MBeanMetricsChartCard.test.tsx
@@ -38,6 +38,7 @@ jest.spyOn(defaultServices.target, 'authRetry').mockReturnValue(of());
 jest.spyOn(defaultServices.target, 'sslFailure').mockReturnValue(of());
 
 const mockTarget = {
+  agent: false,
   connectUrl: 'service:jmx:rmi://someUrl',
   alias: 'fooTarget',
   jvmId: 'foo',

--- a/src/test/Dashboard/Dashboard.test.tsx
+++ b/src/test/Dashboard/Dashboard.test.tsx
@@ -28,6 +28,7 @@ import { of } from 'rxjs';
 const mockFooConnectUrl = 'service:jmx:rmi://someFooUrl';
 
 const mockFooTarget: Target = {
+  agent: false,
   connectUrl: mockFooConnectUrl,
   alias: 'fooTarget',
   labels: [],

--- a/src/test/Events/EventTemplates.test.tsx
+++ b/src/test/Events/EventTemplates.test.tsx
@@ -26,6 +26,7 @@ import { render, renderSnapshot } from '../utils';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = {
+  agent: false,
   connectUrl: mockConnectUrl,
   alias: 'fooTarget',
   jvmId: 'foo',

--- a/src/test/Events/EventTypes.test.tsx
+++ b/src/test/Events/EventTypes.test.tsx
@@ -25,6 +25,7 @@ import { render, renderSnapshot } from '../utils';
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget = {
+  agent: false,
   connectUrl: mockConnectUrl,
   alias: 'fooTarget',
   jvmId: 'foo',

--- a/src/test/RecordingMetadata/BulkEditLabels.test.tsx
+++ b/src/test/RecordingMetadata/BulkEditLabels.test.tsx
@@ -35,6 +35,7 @@ jest.mock('@patternfly/react-core', () => ({
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockJvmId = 'id';
 const mockTarget: Target = {
+  agent: false,
   connectUrl: mockConnectUrl,
   alias: 'fooTarget',
   jvmId: mockJvmId,

--- a/src/test/RecordingMetadata/LabelCell.test.tsx
+++ b/src/test/RecordingMetadata/LabelCell.test.tsx
@@ -23,6 +23,7 @@ import userEvent from '@testing-library/user-event';
 import { render, renderSnapshot } from '../utils';
 
 const mockFooTarget: Target = {
+  agent: false,
   connectUrl: 'service:jmx:rmi://someFooUrl',
   alias: 'fooTarget',
   labels: [],

--- a/src/test/Recordings/ActiveRecordingsTable.test.tsx
+++ b/src/test/Recordings/ActiveRecordingsTable.test.tsx
@@ -34,6 +34,7 @@ import { basePreloadedState, DEFAULT_DIMENSIONS, render, resize } from '../utils
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockJvmId = 'id';
 const mockTarget = {
+  agent: false,
   connectUrl: mockConnectUrl,
   alias: 'fooTarget',
   jvmId: mockJvmId,

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -39,6 +39,7 @@ import { basePreloadedState, DEFAULT_DIMENSIONS, render, resize } from '../utils
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockJvmId = 'id';
 const mockTarget: Target = {
+  agent: false,
   connectUrl: mockConnectUrl,
   alias: 'fooTarget',
   jvmId: mockJvmId,
@@ -46,6 +47,7 @@ const mockTarget: Target = {
   annotations: { cryostat: [], platform: [] },
 };
 const mockUploadsTarget = {
+  agent: false,
   connectUrl: UPLOADS_SUBDIRECTORY,
   alias: '',
   labels: [],

--- a/src/test/Recordings/RecordingFilters.test.tsx
+++ b/src/test/Recordings/RecordingFilters.test.tsx
@@ -35,6 +35,7 @@ import { of } from 'rxjs';
 import { basePreloadedState, render } from '../utils';
 
 const mockFooTarget: Target = {
+  agent: false,
   connectUrl: 'service:jmx:rmi://someFooUrl',
   alias: 'fooTarget',
   labels: [],

--- a/src/test/Recordings/Recordings.test.tsx
+++ b/src/test/Recordings/Recordings.test.tsx
@@ -51,6 +51,7 @@ jest.mock('@app/TargetView/TargetView', () => {
 });
 
 const mockFooTarget: Target = {
+  agent: false,
   connectUrl: 'service:jmx:rmi://someFooUrl',
   alias: 'fooTarget',
   labels: [],

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -28,6 +28,7 @@ jest.mock('@app/Shared/Components/MatchExpression/MatchExpressionVisualizer', ()
 
 const mockConnectUrl = 'service:jmx:rmi://someUrl';
 const mockTarget: Target = {
+  agent: false,
   connectUrl: mockConnectUrl,
   alias: 'io.cryostat.Cryostat',
   labels: [],

--- a/src/test/TargetView/TargetSelect.test.tsx
+++ b/src/test/TargetView/TargetSelect.test.tsx
@@ -33,6 +33,7 @@ const cryostatAnnotation = [
   },
 ];
 const mockFooTarget: Target = {
+  agent: false,
   jvmId: 'abcd',
   connectUrl: mockFooConnectUrl,
   alias: 'fooTarget',


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-web/issues/1320
See https://github.com/cryostatio/cryostat/pull/598

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
