### PR TITLE
fix(labels): fix broken label file parsing in archive upload modal

### DIFF
--- a/src/app/RecordingMetadata/utils.ts
+++ b/src/app/RecordingMetadata/utils.ts
@@ -33,8 +33,8 @@ export const parseLabelsFromFile = (file: File): Observable<KeyValue[]> => {
       .then(JSON.parse)
       .then((obj) => {
         const labels: KeyValue[] = [];
-        const labelObj: KeyValue[] = obj['labels'];
-        if (labelObj) {
+        const labelObj = obj['labels'];
+        if (labelObj && Array.isArray(labelObj)) {
           Object.values(labelObj).forEach((keyValue) => {
             labels.push({
               key: keyValue.key,

--- a/src/app/RecordingMetadata/utils.ts
+++ b/src/app/RecordingMetadata/utils.ts
@@ -33,12 +33,12 @@ export const parseLabelsFromFile = (file: File): Observable<KeyValue[]> => {
       .then(JSON.parse)
       .then((obj) => {
         const labels: KeyValue[] = [];
-        const labelObj = obj['labels'];
+        const labelObj: KeyValue[] = obj['labels'];
         if (labelObj) {
-          Object.keys(labelObj).forEach((key) => {
+          Object.values(labelObj).forEach((keyValue) => {
             labels.push({
-              key: key,
-              value: labelObj[key],
+              key: keyValue.key,
+              value: keyValue.value,
             });
           });
           return labels;
@@ -47,7 +47,6 @@ export const parseLabelsFromFile = (file: File): Observable<KeyValue[]> => {
       }),
   );
 };
-
 export const LabelPattern = /^\S+$/;
 
 export const getValidatedOption = (isValid: boolean) => {

--- a/src/test/RecordingMetadata/RecordingLabelFields.test.tsx
+++ b/src/test/RecordingMetadata/RecordingLabelFields.test.tsx
@@ -21,17 +21,18 @@ import * as tlr from '@testing-library/react';
 import { cleanup, screen } from '@testing-library/react';
 import { render, renderSnapshot } from '../utils';
 
-const mockUploadedRecordingLabels = {
-  someUploaded: 'someUploadedValue',
+const mockUploadedRecordingLabels: KeyValue = {
+  key: 'someUploaded',
+  value: 'someUploadedValue',
 };
 const mockMetadataFileName = 'mock.metadata.json';
 const mockMetadataFile = new File(
-  [JSON.stringify({ labels: { ...mockUploadedRecordingLabels } })],
+  [JSON.stringify({ labels: [{ ...mockUploadedRecordingLabels }] })],
   mockMetadataFileName,
   { type: 'json' },
 );
 mockMetadataFile.text = jest.fn(
-  () => new Promise((resolve, _) => resolve(JSON.stringify({ labels: { ...mockUploadedRecordingLabels } }))),
+  () => new Promise((resolve, _) => resolve(JSON.stringify({ labels: [{ ...mockUploadedRecordingLabels }] }))),
 );
 
 describe('<RecordingLabelFields />', () => {
@@ -387,10 +388,6 @@ describe('<RecordingLabelFields />', () => {
     expect(labelUploadInput.files?.item(0)).toStrictEqual(mockMetadataFile);
 
     expect(mockProps.setLabels).toHaveBeenCalledTimes(1);
-    expect(mockProps.setLabels).toHaveBeenCalledWith([
-      mockLabel1,
-      mockLabel2,
-      { key: 'someUploaded', value: 'someUploadedValue' },
-    ]);
+    expect(mockProps.setLabels).toHaveBeenCalledWith([mockLabel1, mockLabel2, mockUploadedRecordingLabels]);
   });
 });

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -51,13 +51,13 @@ const mockUploadsTarget = {
   labels: [],
   annotations: { cryostat: [], platform: [] },
 };
-const mockRecordingLabels = [
+const mockRecordingLabels: KeyValue[] = [
   {
     key: 'someLabel',
     value: 'someValue',
   },
 ];
-const mockUploadedRecordingLabels = [
+const mockUploadedRecordingLabels: KeyValue[] = [
   {
     key: 'someUploaded',
     value: 'someUpdatedValue',
@@ -71,14 +71,10 @@ export const convertLabels = (kv: KeyValue[]): object => {
   return out;
 };
 const mockMetadataFileName = 'mock.metadata.json';
-const mockMetadataFile = new File(
-  [JSON.stringify({ labels: convertLabels(mockUploadedRecordingLabels) })],
-  mockMetadataFileName,
-  { type: 'json' },
-);
-mockMetadataFile.text = jest.fn(() =>
-  Promise.resolve(JSON.stringify({ labels: convertLabels(mockUploadedRecordingLabels) })),
-);
+const mockMetadataFile = new File([JSON.stringify({ labels: mockUploadedRecordingLabels })], mockMetadataFileName, {
+  type: 'json',
+});
+mockMetadataFile.text = jest.fn(() => Promise.resolve(JSON.stringify({ labels: mockUploadedRecordingLabels })));
 
 const mockRecording: ArchivedRecording = {
   name: 'someRecording',


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes #1322 

## Description of the change:

Fixed the incorrect label parsing utility. The labels should be rendered correctly now.

## Motivation for the change:

See #1322 

![image](https://github.com/user-attachments/assets/f0531af0-87fd-4747-9102-ad5c829af9ed)
