### PR TITLE
fix(recordings): maxSize should be displayed correctly

### DIFF
--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -911,7 +911,7 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
       options.push({ key: 'maxAge', value: `${recording.maxAge / 1000}s` });
     }
     if (recording.maxSize) {
-      options.push({ key: 'maxSize', value: formatBytes(recording.maxAge) });
+      options.push({ key: 'maxSize', value: formatBytes(recording.maxSize) });
     }
     return options;
   };


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1313 

## Description of the change:

Correctly use `recording.maxSize` to render. Previously, `recording.maxAge` was mistakenly used.

## Motivation for the change:

Recording's max size should be displayed correctly. Only affected `main` and `pf5` (i.e. after #1313).

## Others

### Before

![image](https://github.com/user-attachments/assets/d93e0212-4983-40c0-a1eb-1a24ed68cd19)

### After

![image](https://github.com/user-attachments/assets/52b660b6-2dbc-47a6-98d4-3e8d9aa0a0df)