### PR TITLE
fix(topology): fix Cola layout failing due to pending outdated graph elements

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -453,6 +453,12 @@
       "TITLE": "Target JVM"
     }
   },
+  "ThemeToggle": {
+    "ARIA_LABELS": {
+      "DARK_THEME": "dark-theme",
+      "LIGHT_THEME": "light-theme"
+    }
+  },
   "TimePicker": {
     "24HOUR": "24-hour",
     "USE_24HR_TIME": "Use 24-hour time"

--- a/src/app/AppLayout/ThemeToggle.tsx
+++ b/src/app/AppLayout/ThemeToggle.tsx
@@ -20,12 +20,14 @@ import { useTheme } from '@app/utils/hooks/useTheme';
 import { Icon, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import { SunIcon, MoonIcon } from '@patternfly/react-icons';
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export interface ThemeToggleProps {}
 
 export const ThemeToggle: React.FC<ThemeToggleProps> = () => {
   const context = React.useContext(ServiceContext);
   const [_theme] = useTheme();
+  const { t } = useTranslation();
 
   const handleThemeSelect = React.useCallback(
     (_, setting: ThemeSetting) => {
@@ -37,6 +39,7 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = () => {
   return (
     <ToggleGroup className="theme__toggle-group">
       <ToggleGroupItem
+        aria-label={t('ThemeToggle.ARIA_LABELS.LIGHT_THEME')}
         icon={
           <Icon>
             <SunIcon />
@@ -47,6 +50,7 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = () => {
         onClick={(e) => handleThemeSelect(e, ThemeSetting.LIGHT)}
       />
       <ToggleGroupItem
+        aria-label={t('ThemeToggle.ARIA_LABELS.DARK_THEME')}
         icon={
           <Icon>
             <MoonIcon />

--- a/src/app/Topology/Actions/WarningResolver.tsx
+++ b/src/app/Topology/Actions/WarningResolver.tsx
@@ -81,7 +81,7 @@ export const WarningResolverAsCredModal: React.FC<WarningResolverAsCredModalProp
         onPropsSave={handleAuthModalClose}
         {...props}
       />
-      <div onClick={handleAuthModalOpen}>{children}</div>
+      <span onClick={handleAuthModalOpen}>{children}</span>
     </>
   );
 };

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -681,7 +681,7 @@ export const EntityDetailHeader: React.FC<EntityDetailHeaderProps> = ({
               <>
                 <StackItem key={'alert-description'}>{extra?.description}</StackItem>
                 <StackItem key={'alert-call-for-action'}>
-                  <Flex>
+                  <Flex direction={{ default: 'column' }}>
                     {extra.callForAction.map((action, index) => (
                       <FlexItem key={index}>{action}</FlexItem>
                     ))}

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -36,6 +36,8 @@ import {
   ExpandableSection,
   Flex,
   FlexItem,
+  List,
+  ListItem,
   Stack,
   StackItem,
   Tab,
@@ -681,11 +683,11 @@ export const EntityDetailHeader: React.FC<EntityDetailHeaderProps> = ({
               <>
                 <StackItem key={'alert-description'}>{extra?.description}</StackItem>
                 <StackItem key={'alert-call-for-action'}>
-                  <Flex direction={{ default: 'column' }}>
+                  <List>
                     {extra.callForAction.map((action, index) => (
-                      <FlexItem key={index}>{action}</FlexItem>
+                      <ListItem key={index}>{action} </ListItem>
                     ))}
-                  </Flex>
+                  </List>
                 </StackItem>
               </>
             ) : null}

--- a/src/app/Topology/GraphView/TopologyControlBar.tsx
+++ b/src/app/Topology/GraphView/TopologyControlBar.tsx
@@ -49,6 +49,12 @@ export const TopologyControlBar: React.FC<TopologyControlBarProps> = ({ visualiz
         visualization.getGraph().reset();
         // Reset layout
         visualization.getGraph().layout();
+
+        // Open collapsed groups
+        visualization
+          .getGraph()
+          .getNodes()
+          .forEach((n) => n.setCollapsed(false));
       }),
       legend: false,
     });
@@ -59,7 +65,7 @@ export const TopologyControlBar: React.FC<TopologyControlBarProps> = ({ visualiz
         icon: <CollapseIcon />,
         tooltip: 'Collapse all groups',
         callback: action(() => {
-          // Close top-level groups
+          // Close groups
           visualization
             .getGraph()
             .getNodes()

--- a/src/app/Topology/GraphView/TopologyGraphView.tsx
+++ b/src/app/Topology/GraphView/TopologyGraphView.tsx
@@ -183,6 +183,11 @@ export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({ transformC
       },
     };
 
+    // Destroy old graph if any
+    if (visualization.hasGraph()) {
+      visualization.getGraph().destroy();
+    }
+
     // Initialize the controller with model to create nodes
     visualization.fromModel(model, false);
   }, [_transformData, visualization, discoveryTree]);

--- a/src/app/Topology/GraphView/utils.tsx
+++ b/src/app/Topology/GraphView/utils.tsx
@@ -205,7 +205,6 @@ export const getNodeById = (nodes: NodeModel[], id?: string) => {
 };
 
 // This method sets the layout of your topology view (e.g. Force, Dagre, Cola, etc.).
-// OCP is supporting only Cola
 export const layoutFactory: LayoutFactory = (type: string, graph: Graph): Layout | undefined => {
   switch (type) {
     case 'Cola':

--- a/src/app/Topology/Toolbar/TopologyFilters.tsx
+++ b/src/app/Topology/Toolbar/TopologyFilters.tsx
@@ -91,9 +91,10 @@ export const TopologyFilterCategorySelect: React.FC<TopologyFilterCategorySelect
     (_, category: string) => {
       if (category) {
         dispatch(topologyUpdateCategoryIntent(isGroup, category));
+        setIsOpen(false);
       }
     },
-    [dispatch, isGroup],
+    [dispatch, isGroup, setIsOpen],
   );
 
   const handleCategoryTypeChange = React.useCallback(

--- a/src/app/Topology/Toolbar/TopologyFilters.tsx
+++ b/src/app/Topology/Toolbar/TopologyFilters.tsx
@@ -399,6 +399,8 @@ export const TopologyFilterSelect: React.FC<TopologyFilterSelectProps> = ({
       }}
       onOpenChange={setIsExpanded}
       onOpenChangeKeys={['Escape']}
+      maxMenuHeight={'40vh'}
+      isScrollable
     >
       <SelectList>
         {selectOptions.length > 0 ? selectOptions : <SelectOption isDisabled>No results found</SelectOption>}

--- a/src/app/Topology/Topology.tsx
+++ b/src/app/Topology/Topology.tsx
@@ -26,6 +26,7 @@ import { SearchExprServiceContext } from '@app/Shared/Services/service.utils';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { Bullseye, Card, CardBody } from '@patternfly/react-core';
+import _ from 'lodash';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { TopologyGraphView } from './GraphView/TopologyGraphView';
@@ -80,7 +81,7 @@ export const Topology: React.FC<TopologyProps> = ({ ..._props }) => {
       // Credentials will trigger modifed target event if any
       context.notificationChannel
         .messages(NotificationCategory.TargetJvmDiscovery)
-        .subscribe((_) => _refreshDiscoveryTree()),
+        .subscribe(() => _.debounce(_refreshDiscoveryTree, 100)),
     );
   }, [addSubscription, context.notificationChannel, _refreshDiscoveryTree]);
 

--- a/src/app/Topology/Topology.tsx
+++ b/src/app/Topology/Topology.tsx
@@ -26,9 +26,9 @@ import { SearchExprServiceContext } from '@app/Shared/Services/service.utils';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { Bullseye, Card, CardBody } from '@patternfly/react-core';
-import _ from 'lodash';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
+import { debounceTime } from 'rxjs';
 import { TopologyGraphView } from './GraphView/TopologyGraphView';
 import { TopologyListView } from './ListView/TopologyListView';
 import { DiscoveryTreeContext } from './Shared/utils';
@@ -81,7 +81,8 @@ export const Topology: React.FC<TopologyProps> = ({ ..._props }) => {
       // Credentials will trigger modifed target event if any
       context.notificationChannel
         .messages(NotificationCategory.TargetJvmDiscovery)
-        .subscribe(() => _.debounce(_refreshDiscoveryTree, 100)),
+        .pipe(debounceTime(100))
+        .subscribe(() => _refreshDiscoveryTree()),
     );
   }, [addSubscription, context.notificationChannel, _refreshDiscoveryTree]);
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1303 

## Description of the change:

Graph Layout was previously failing due to `undefined` Controller (i.e. via `getController` func). My speculation is that as new `Model` (i.e. on discovery tree refresh)  is set on the controller, old graph elements are still animating, thus causing the issue. The combination of the following changes seem to fix:

- Debounce (100ms)  discovery tree refresh when new target events are emitted. Optional but nice to have.
- Destroy graph layout before setting new model.


## Minor changes

| Changes | Description | Screenshot |
|--------------|-------------------|------------------|
| Reset view should expand all collapsed groups | A quick way to re-expand all collapsed groups. Previously, manual unpacking for each group is required | N/A |
| Alert and resolver for nodes should be rendered as a vertical list and action button is now inline with sentence | Previously, `Flex` renders them inline (horizontally) if enough width is available |  ![image](https://github.com/user-attachments/assets/3a4479b8-64eb-4b21-ac7a-95f9b0af48ca) |
| Destroy old graph before initializing new model | Previously, stale elements are causing a recursive fails on graph layouts | N/A |
| Set Menu Max Height for filter select menus | Previously, the menu can become very long and overflow the view |  ![image](https://github.com/user-attachments/assets/a26dbf08-c3a0-45c7-a2b7-c06cc2241c90) |



