### PR TITLE
chore(pf5): upgrade Dashboard view to Patternfly 5

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -80,7 +80,6 @@
   "TEST": "Test",
   "TIME": "Time",
   "UNKNOWN_ERROR": "Unknown error",
-  "UPLOAD": "Upload",
   "USER_SUBMITTED": "User-submitted",
   "VIEW": "View",
   "VIEW_MORE": "View more",

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -77,6 +77,10 @@
       "TOOLTIP": "Report data is stale. Click the Create Recording button and choose an option to start an active Recording to source automated reports from."
     },
     "TOOLBAR": {
+      "ARIA_LABELS": {
+        "GRID_VIEW": "grid-view",
+        "LIST_VIEW": "list-view"
+      },
       "CHECKBOX": {
         "SHOW_NA": {
           "LABEL": "Show N/A scores"
@@ -88,12 +92,11 @@
       "LABEL": "Automated analysis toolbar",
       "REFRESH": {
         "LABEL": "Refresh automated analysis"
-      },
-      "SWITCH": {
-        "LIST_VIEW": {
-          "LABEL": "List view"
-        }
       }
+    },
+    "TOOLTIP": {
+      "CLEAR_ANALYSIS": "Clear analysis",
+      "REFRESH_ANALYSIS": "Refresh analysis"
     },
     "WARNING_RESULTS_one": "{{count}} warning result",
     "WARNING_RESULTS_other": "{{count}} warning results"

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -95,8 +95,8 @@
         }
       }
     },
-    "WARNING_RESULTS_one": "{{count}} Warning Result",
-    "WARNING_RESULTS_other": "{{count}} Warning Results"
+   "WARNING_RESULTS_one": "{{count}} warning result",
+    "WARNING_RESULTS_other": "{{count}} warning results"
   },
   "AutomatedAnalysisConfigDrawer": {
     "INPUT_GROUP": {

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -235,7 +235,7 @@
   },
   "Dashboard": {
     "ADD_CARD_HELPER_TEXT": "Choose a card type to add to your Dashboard. Some cards require additional configuration.",
-    "CARD_CATALOG_DESCRIPTION": "Cards added to this Dashboard Layout present information at a glance about the selected target. The layout is preserved for all targets viewed on this client.",
+    "CARD_CATALOG_DESCRIPTION": "Cards added to this Dashboard Layout present information at a glance about the selected target. The layout is preserved locally for all targets viewed only on this client.",
     "CARD_CATALOG_TITLE": "Dashboard Card catalog",
     "INVALID_CARD_CONFIGURATIONS": "Invalid card configurations",
     "PAGE_TITLE": "Dashboard"

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -350,6 +350,7 @@
   },
   "LayoutTemplatePicker": {
     "CARD_COUNT": "Card count",
+    "SEARCH_PLACEHOLDER": "Find by name...",
     "SORT_BY": {
       "CARD_COUNT": "Sort by: Card count",
       "NAME": "Sort by: Name"

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -54,7 +54,7 @@
       }
     },
     "USER_MENU": {
-      "LANGUAGE_PREFERENCE": "<Icon/> Language preference",
+      "LANGUAGE_PREFERENCE": "Language preference",
       "LOGOUT": "Log out"
     }
   },

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -349,10 +349,10 @@
     "ITEMS_other": "{{count}} items"
   },
   "LayoutTemplatePicker": {
+    "CARD_COUNT": "Card count",
     "SORT_BY": {
       "CARD_COUNT": "Sort by: Card count",
-      "NAME": "Sort by: Name",
-      "PLACEHOLDER": "Sort by..."
+      "NAME": "Sort by: Name"
     }
   },
   "LayoutTemplateUploadModal": {

--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -95,7 +95,7 @@
         }
       }
     },
-   "WARNING_RESULTS_one": "{{count}} warning result",
+    "WARNING_RESULTS_one": "{{count}} warning result",
     "WARNING_RESULTS_other": "{{count}} warning results"
   },
   "AutomatedAnalysisConfigDrawer": {
@@ -139,6 +139,7 @@
       "POPOUT": {
         "LABEL": "Pop out {{chartKind}} chart"
       },
+      "REFRESH_TOOLTIP": "Refresh chart data",
       "SYNC": {
         "LABEL": "Synchronize {{chartKind}} chart"
       }

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -288,7 +288,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
           <Trans t={t} i18nKey="AppLayout.USER_MENU.LANGUAGE_PREFERENCE" />
         </DropdownItem>
       </FeatureFlag>,
-      <DropdownItem key={'log-out'} onClick={handleLogout} icon={<LogoutIcon></LogoutIcon>}>
+      <DropdownItem key={'log-out'} onClick={handleLogout} icon={<LogoutIcon />}>
         {t('AppLayout.USER_MENU.LOGOUT')}
       </DropdownItem>,
     ],

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -68,7 +68,6 @@ import {
   Dropdown,
 } from '@patternfly/react-core';
 import {
-  ArrowRightIcon,
   BarsIcon,
   BellIcon,
   CogIcon,
@@ -78,7 +77,6 @@ import {
   QuestionCircleIcon,
   UserIcon,
 } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import _ from 'lodash';
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -68,19 +68,23 @@ import {
   Dropdown,
 } from '@patternfly/react-core';
 import {
+  ArrowRightIcon,
   BarsIcon,
   BellIcon,
   CogIcon,
   ExternalLinkAltIcon,
+  LanguageIcon,
   PlusCircleIcon,
   QuestionCircleIcon,
   UserIcon,
 } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
 import _ from 'lodash';
 import * as React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link, matchPath, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { map } from 'rxjs/operators';
+import { LogoutIcon } from './LogoutIcon';
 import { ThemeToggle } from './ThemeToggle';
 
 export interface AppLayoutProps {
@@ -282,11 +286,11 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const userInfoItems = React.useMemo(
     () => [
       <FeatureFlag level={FeatureLevel.BETA} key={'language-preferences-feature-flag'}>
-        <DropdownItem key={'language-preferences'} onClick={handleLanguagePref}>
+        <DropdownItem key={'language-preferences'} onClick={handleLanguagePref} icon={<LanguageIcon />}>
           <Trans t={t} i18nKey="AppLayout.USER_MENU.LANGUAGE_PREFERENCE" />
         </DropdownItem>
       </FeatureFlag>,
-      <DropdownItem key={'log-out'} onClick={handleLogout}>
+      <DropdownItem key={'log-out'} onClick={handleLogout} icon={<LogoutIcon></LogoutIcon>}>
         {t('AppLayout.USER_MENU.LOGOUT')}
       </DropdownItem>,
     ],

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -72,7 +72,6 @@ import {
   BellIcon,
   CogIcon,
   ExternalLinkAltIcon,
-  LanguageIcon,
   PlusCircleIcon,
   QuestionCircleIcon,
   UserIcon,

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -284,7 +284,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
     () => [
       <FeatureFlag level={FeatureLevel.BETA} key={'language-preferences-feature-flag'}>
         <DropdownItem key={'language-preferences'} onClick={handleLanguagePref}>
-          <Trans t={t} components={{ Icon: <LanguageIcon /> }} i18nKey="AppLayout.USER_MENU.LANGUAGE_PREFERENCE" />
+          <Trans t={t} i18nKey="AppLayout.USER_MENU.LANGUAGE_PREFERENCE" />
         </DropdownItem>
       </FeatureFlag>,
       <DropdownItem key={'log-out'} onClick={handleLogout}>

--- a/src/app/AppLayout/LogoutIcon.tsx
+++ b/src/app/AppLayout/LogoutIcon.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as React from 'react';
+
+export const LogoutIcon: React.FC<React.HTMLProps<SVGElement>> = ({ style }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="1em"
+      width="1em"
+      viewBox="0 0 512 512"
+      fill="currentColor"
+      style={{ verticalAlign: '-0.125em', ...style }}
+    >
+      <path d="M502.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-128-128c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L402.7 224 192 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l210.7 0-73.4 73.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l128-128zM160 96c17.7 0 32-14.3 32-32s-14.3-32-32-32L96 32C43 32 0 75 0 128L0 384c0 53 43 96 96 96l64 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-64 0c-17.7 0-32-14.3-32-32l0-256c0-17.7 14.3-32 32-32l64 0z" />
+    </svg>
+  );
+};

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -320,7 +320,6 @@ export const CardGallery: React.FC<CardGalleryProps> = ({ selection, onSelect })
       const { icon, labels, title, description } = card;
       return (
         <CatalogTile
-          style={{ height: '100%' }}
           featured={selection === t(title)}
           id={title}
           key={title}
@@ -421,7 +420,7 @@ export const CardGallery: React.FC<CardGalleryProps> = ({ selection, onSelect })
     <Drawer isExpanded={!!toViewCard} isInline>
       <DrawerContent panelContent={panelContent}>
         <DrawerContentBody>
-          <Grid hasGutter style={{ alignItems: 'stretch', marginTop: '1em', marginRight: !toViewCard ? 0 : '1em' }}>
+          <Grid hasGutter className="dashboard-card-picker" style={{ marginRight: !toViewCard ? 0 : '1em' }}>
             {items.map((item) => (
               <GridItem span={4} key={item.key}>
                 {item}

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -223,6 +223,7 @@ export const AddCard: React.FC<AddCardProps> = ({ variant }) => {
         hasNoBodyWrapper
         showClose={false}
         appendTo={portalRoot}
+        onClose={() => setShowWizard(false)}
       >
         <Wizard
           id={'card-catalog-wizard'}

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -21,13 +21,12 @@ import { fakeChartContext, fakeServices } from '@app/utils/fakeData';
 import { useFeatureLevel } from '@app/utils/hooks/useFeatureLevel';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot } from '@app/utils/utils';
+import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
 import {
   Bullseye,
   Button,
   Card,
   CardBody,
-  CardHeader,
-  CardTitle,
   Drawer,
   DrawerActions,
   DrawerCloseButton,
@@ -320,14 +319,13 @@ export const CardGallery: React.FC<CardGalleryProps> = ({ selection, onSelect })
     return availableCards.map((card) => {
       const { icon, labels, title, description } = card;
       return (
-        <Card
+        <CatalogTile
+          style={{ height: '100%' }}
+          featured={selection === t(title)}
           id={title}
           key={title}
-          isSelectable
-          isFullHeight
-          isFlat
-          isSelected={selection === t(title)}
-          tabIndex={0}
+          icon={icon}
+          title={t(title)}
           onClick={(_event) => {
             if (selection === t(title)) {
               setToViewCard(availableCards.find((card) => t(card.title) === selection));
@@ -335,35 +333,22 @@ export const CardGallery: React.FC<CardGalleryProps> = ({ selection, onSelect })
               onSelect(_event, t(title));
             }
           }}
+          badges={
+            labels && [
+              <CatalogTileBadge>
+                <LabelGroup>
+                  {labels.map(({ content, icon, color }) => (
+                    <Label key={content} color={color} icon={icon} isCompact>
+                      {content}
+                    </Label>
+                  ))}
+                </LabelGroup>
+              </CatalogTileBadge>,
+            ]
+          }
         >
-          <CardHeader
-            selectableActions={{
-              selectableActionId: title,
-              selectableActionAriaLabelledby: title,
-              variant: 'single',
-              name: t(title),
-            }}
-          >
-            <Flex spacer={{ default: 'spacerSm' }}>
-              {icon ? <FlexItem>{icon}</FlexItem> : null}
-              <FlexItem>
-                <CardTitle>{t(title)}</CardTitle>
-              </FlexItem>
-              <FlexItem>
-                {labels ? (
-                  <LabelGroup>
-                    {labels.map(({ content, icon, color }) => (
-                      <Label key={content} color={color} icon={icon} isCompact>
-                        {content}
-                      </Label>
-                    ))}
-                  </LabelGroup>
-                ) : null}
-              </FlexItem>
-            </Flex>
-          </CardHeader>
-          <CardBody>{t(description)}</CardBody>
-        </Card>
+          {t(description)}
+        </CatalogTile>
       );
     });
   }, [t, availableCards, selection, onSelect]);

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -544,12 +544,12 @@ const PropsConfigForm: React.FC<PropsConfigFormProps> = ({ onChange, ...props })
       }
       return (
         <FormGroup key={`${ctrl.key}`} label={t(ctrl.name)} isInline isStack>
+          {input}
           <FormHelperText>
             <HelperText>
               <HelperTextItem>{t(ctrl.description)}</HelperTextItem>
             </HelperText>
           </FormHelperText>
-          {input}
         </FormGroup>
       );
     },

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -223,7 +223,6 @@ export const AddCard: React.FC<AddCardProps> = ({ variant }) => {
         hasNoBodyWrapper
         showClose={false}
         appendTo={portalRoot}
-        onClose={() => setShowWizard(false)}
       >
         <Wizard
           id={'card-catalog-wizard'}

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -48,8 +48,6 @@ import {
   GridItem,
   Label,
   LabelGroup,
-  Level,
-  LevelItem,
   Modal,
   NumberInput,
   Stack,
@@ -641,7 +639,10 @@ const SelectControl: React.FC<SelectControlProps> = ({ handleChange, control, se
         enableFlip: true,
         appendTo: portalRoot,
       }}
-      shouldFocusToggleOnSelect
+      isScrollable
+      maxMenuHeight={'30vh'}
+      onOpenChange={setSelectOpen}
+      onOpenChangeKeys={['Escape']}
     >
       <SelectList>
         {errored

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -325,31 +325,33 @@ export const CardGallery: React.FC<CardGalleryProps> = ({ selection, onSelect })
         <Card
           id={title}
           key={title}
-          isClickable
           isSelectable
           isFullHeight
           isFlat
           isSelected={selection === t(title)}
           tabIndex={0}
+          onClick={(_event) => {
+            if (selection === t(title)) {
+              setToViewCard(availableCards.find((card) => t(card.title) === selection));
+            } else {
+              onSelect(_event, t(title));
+            }
+          }}
         >
           <CardHeader
             selectableActions={{
-              onClickAction: (event) => {
-                if (selection === t(title)) {
-                  setToViewCard(availableCards.find((card) => t(card.title) === selection));
-                } else {
-                  onSelect(event, t(title));
-                }
-              },
               selectableActionId: title,
+              selectableActionAriaLabelledby: title,
+              variant: 'single',
+              name: t(title),
             }}
           >
-            <Level hasGutter>
-              {icon ? <LevelItem>{icon}</LevelItem> : null}
-              <LevelItem>
+            <Flex spacer={{ default: 'spacerSm' }}>
+              {icon ? <FlexItem>{icon}</FlexItem> : null}
+              <FlexItem>
                 <CardTitle>{t(title)}</CardTitle>
-              </LevelItem>
-              <LevelItem>
+              </FlexItem>
+              <FlexItem>
                 {labels ? (
                   <LabelGroup>
                     {labels.map(({ content, icon, color }) => (
@@ -359,8 +361,8 @@ export const CardGallery: React.FC<CardGalleryProps> = ({ selection, onSelect })
                     ))}
                   </LabelGroup>
                 ) : null}
-              </LevelItem>
-            </Level>
+              </FlexItem>
+            </Flex>
           </CardHeader>
           <CardBody>{t(description)}</CardBody>
         </Card>
@@ -392,18 +394,18 @@ export const CardGallery: React.FC<CardGalleryProps> = ({ selection, onSelect })
                 <FlexItem>
                   <Title headingLevel={'h3'}>{t(title)}</Title>
                 </FlexItem>
+                <FlexItem>
+                  {labels && labels.length ? (
+                    <LabelGroup>
+                      {labels.map(({ content, icon, color }) => (
+                        <Label key={content} color={color} icon={icon}>
+                          {content}
+                        </Label>
+                      ))}
+                    </LabelGroup>
+                  ) : null}
+                </FlexItem>
               </Flex>
-            </StackItem>
-            <StackItem>
-              {labels && labels.length ? (
-                <LabelGroup>
-                  {labels.map(({ content, icon, color }) => (
-                    <Label key={content} color={color} icon={icon}>
-                      {content}
-                    </Label>
-                  ))}
-                </LabelGroup>
-              ) : null}
             </StackItem>
             <StackItem>{getFullDescription(t(title), t)}</StackItem>
             <StackItem isFilled>

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -65,11 +65,8 @@ import {
   GridItem,
   Label,
   LabelGroup,
-  Level,
-  LevelItem,
   Stack,
   StackItem,
-  Switch,
   Text,
   TextContent,
   TextVariants,
@@ -81,6 +78,10 @@ import {
   EmptyStateActions,
   EmptyStateHeader,
   EmptyStateFooter,
+  Flex,
+  FlexItem,
+  ToggleGroup,
+  ToggleGroupItem,
 } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
@@ -673,45 +674,61 @@ export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> 
             filters={targetAutomatedAnalysisFilters}
             updateFilters={updateFilters}
           />
-          <ToolbarGroup style={{ margin: '0.5em 0 0.5em 0' }}>
+          <ToolbarItem>
+            <Checkbox
+              label={t('AutomatedAnalysisCard.TOOLBAR.CHECKBOX.SHOW_NA.LABEL')}
+              isChecked={showNAScores}
+              onChange={(_, checked: boolean) => setShowNAScores(checked)}
+              id="show-na-scores"
+              name="show-na-scores"
+              style={{ alignSelf: 'center' }}
+            />
+          </ToolbarItem>
+          <ToolbarItem variant="separator" />
+          <ToolbarGroup variant="icon-button-group">
             <ToolbarItem>
-              <Button
-                size="sm"
-                isDisabled={isLoading || usingCachedReport || usingArchivedReport}
-                isAriaDisabled={isLoading || usingCachedReport || usingArchivedReport}
-                aria-label={t('AutomatedAnalysisCard.TOOLBAR.REFRESH.LABEL')}
-                onClick={generateReport}
-                variant="control"
-                icon={<Spinner2Icon />}
-              />
-              <Button
-                size="sm"
-                isDisabled={isLoading}
-                isAriaDisabled={isLoading}
-                aria-label={t('AutomatedAnalysisCard.TOOLBAR.DELETE.LABEL')}
-                onClick={clearAnalysis}
-                variant="control"
-                icon={<TrashIcon />}
-              />
-            </ToolbarItem>
-            <ToolbarItem>
-              <Checkbox
-                label={t('AutomatedAnalysisCard.TOOLBAR.CHECKBOX.SHOW_NA.LABEL')}
-                isChecked={showNAScores}
-                onChange={(_, checked: boolean) => setShowNAScores(checked)}
-                id="show-na-scores"
-                name="show-na-scores"
-              />
-            </ToolbarItem>
-            <ToolbarItem>
-              <Switch
-                label={t('AutomatedAnalysisCard.TOOLBAR.SWITCH.LIST_VIEW.LABEL')}
-                isChecked={showListView}
-                onChange={(_, checked: boolean) => setShowListView(checked)}
-                id="show-list-view"
-              />
+              <Tooltip content={t('AutomatedAnalysisCard.TOOLTIP.REFRESH_ANALYSIS')}>
+                <Button
+                  size="sm"
+                  isDisabled={isLoading || usingCachedReport || usingArchivedReport}
+                  isAriaDisabled={isLoading || usingCachedReport || usingArchivedReport}
+                  aria-label={t('AutomatedAnalysisCard.TOOLBAR.REFRESH.LABEL')}
+                  onClick={generateReport}
+                  variant="control"
+                  icon={<Spinner2Icon />}
+                />
+              </Tooltip>
+              <Tooltip content={t('AutomatedAnalysisCard.TOOLTIP.CLEAR_ANALYSIS')}>
+                <Button
+                  size="sm"
+                  isDisabled={isLoading}
+                  isAriaDisabled={isLoading}
+                  aria-label={t('AutomatedAnalysisCard.TOOLBAR.DELETE.LABEL')}
+                  onClick={clearAnalysis}
+                  variant="control"
+                  icon={<TrashIcon />}
+                />
+              </Tooltip>
             </ToolbarItem>
           </ToolbarGroup>
+          <ToolbarItem>
+            <ToggleGroup>
+              <ToggleGroupItem
+                aria-label={t('AutomatedAnalysisCard.TOOLBAR.ARIA_LABELS.GRID_VIEW')}
+                text="Grid view"
+                buttonId="grid-view-btn"
+                isSelected={!showListView}
+                onClick={() => setShowListView(false)}
+              />
+              <ToggleGroupItem
+                aria-label={t('AutomatedAnalysisCard.TOOLBAR.ARIA_LABELS.LIST_VIEW')}
+                text="List view"
+                buttonId="list-view-btn"
+                isSelected={showListView}
+                onClick={() => setShowListView(true)}
+              />
+            </ToggleGroup>
+          </ToolbarItem>
         </ToolbarContent>
       </Toolbar>
     );
@@ -830,12 +847,12 @@ export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> 
           'aria-expanded': isCardExpanded,
         }}
       >
-        <Level hasGutter>
-          <LevelItem>
+        <Flex>
+          <FlexItem>
             <CardTitle component="h4">{t('AutomatedAnalysisCard.CARD_TITLE')}</CardTitle>
-          </LevelItem>
-          <LevelItem>{headerLabels}</LevelItem>
-        </Level>
+          </FlexItem>
+          <FlexItem>{headerLabels}</FlexItem>
+        </Flex>
       </CardHeader>
     );
   }, [t, onCardExpand, isCardExpanded, headerLabels, props.actions]);

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCardList.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCardList.tsx
@@ -50,19 +50,19 @@ export const AutomatedAnalysisCardList: React.FC<AutomatedAnalysisCardListProps>
 
   const icon = React.useCallback((score: number): JSX.Element => {
     return score == AutomatedAnalysisScore.NA_SCORE ? (
-      <span className={css('pf-m-grey', 'pf-c-label__icon')}>
+      <span className={css('pf-m-grey', 'pf-v5-c-label__icon')}>
         <InfoCircleIcon />
       </span>
     ) : score < AutomatedAnalysisScore.ORANGE_SCORE_THRESHOLD ? (
-      <span className={css('pf-m-green', 'pf-c-label__icon')}>
+      <span className={css('pf-m-green', 'pf-v5-c-label__icon')}>
         <CheckCircleIcon />
       </span>
     ) : score < AutomatedAnalysisScore.RED_SCORE_THRESHOLD ? (
-      <span className={css('pf-m-orange', 'pf-c-label__icon')}>
+      <span className={css('pf-m-orange', 'pf-v5-c-label__icon')}>
         <ExclamationTriangleIcon />
       </span>
     ) : (
-      <span className={css('pf-m-red', 'pf-c-label__icon')}>
+      <span className={css('pf-m-red', 'pf-v5-c-label__icon')}>
         <ExclamationCircleIcon />
       </span>
     );

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigDrawer.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigDrawer.tsx
@@ -125,25 +125,23 @@ export const AutomatedAnalysisConfigDrawer: React.FC<AutomatedAnalysisConfigDraw
   const inputGroup = React.useMemo(() => {
     return (
       <InputGroup>
-        <InputGroupItem>
-          <div style={{ margin: 'auto' }}>
-            <Button
-              aria-label={t('AutomatedAnalysisConfigDrawer.INPUT_GROUP.OPEN_SETTINGS.LABEL')}
-              variant="control"
-              onClick={onCogSelect}
-              icon={<CogIcon />}
-            />
-            <Button
-              id={'automated-analysis-config-drawer-create-recording-button'}
-              aria-label={t('AutomatedAnalysisConfigDrawer.INPUT_GROUP.CREATE_RECORDING.LABEL')}
-              variant="control"
-              onClick={onDefaultRecordingStart}
-            >
-              <span style={{ marginRight: '0.2em' }}>
-                {t('AutomatedAnalysisConfigDrawer.INPUT_GROUP.CREATE_RECORDING.LABEL')}
-              </span>
-            </Button>
-          </div>
+        <InputGroupItem style={{ margin: 'auto' }}>
+          <Button
+            aria-label={t('AutomatedAnalysisConfigDrawer.INPUT_GROUP.OPEN_SETTINGS.LABEL')}
+            variant="control"
+            onClick={onCogSelect}
+            icon={<CogIcon />}
+          />
+          <Button
+            id={'automated-analysis-config-drawer-create-recording-button'}
+            aria-label={t('AutomatedAnalysisConfigDrawer.INPUT_GROUP.CREATE_RECORDING.LABEL')}
+            variant="control"
+            onClick={onDefaultRecordingStart}
+          >
+            <span style={{ marginRight: '0.2em' }}>
+              {t('AutomatedAnalysisConfigDrawer.INPUT_GROUP.CREATE_RECORDING.LABEL')}
+            </span>
+          </Button>
         </InputGroupItem>
       </InputGroup>
     );

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters.tsx
@@ -29,7 +29,7 @@ import {
   MenuToggle,
   MenuToggleElement,
 } from '@patternfly/react-core';
-import { EllipsisVIcon, FilterIcon } from '@patternfly/react-icons';
+import { FilterIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -128,13 +128,13 @@ export const AutomatedAnalysisFilters: React.FC<AutomatedAnalysisFiltersProps> =
     return (
       <Dropdown
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-          <MenuToggle ref={toggleRef} aria-label={currentCategory} onClick={() => onCategoryToggle()}>
-            <FilterIcon />
+          <MenuToggle ref={toggleRef} aria-label={currentCategory} onClick={onCategoryToggle} icon={<FilterIcon />}>
             {getCategoryDisplay(currentCategory)}
-            <EllipsisVIcon />
           </MenuToggle>
         )}
         isOpen={isCategoryDropdownOpen}
+        onOpenChange={setIsCategoryDropdownOpen}
+        onOpenChangeKeys={['Escape']}
         popperProps={{
           position: 'left',
         }}

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.tsx
@@ -29,6 +29,7 @@ import {
   TextInputGroupUtilities,
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
+import _ from 'lodash';
 import * as React from 'react';
 
 export interface AutomatedAnalysisNameFilterProps {
@@ -70,7 +71,8 @@ export const AutomatedAnalysisNameFilter: React.FC<AutomatedAnalysisNameFilterPr
   }, [evaluations, filteredNames]);
 
   const filteredNameOptions = React.useMemo(() => {
-    return !filterValue ? nameOptions : nameOptions.filter((n) => n.includes(filterValue.toLowerCase()));
+    const reg = new RegExp(_.escapeRegExp(filterValue), 'i');
+    return !filterValue ? nameOptions : nameOptions.filter((n) => reg.test(n));
   }, [filterValue, nameOptions]);
 
   const selectOptionProps: SelectOptionProps[] = React.useMemo(() => {
@@ -124,6 +126,11 @@ export const AutomatedAnalysisNameFilter: React.FC<AutomatedAnalysisNameFilterPr
         enableFlip: true,
         appendTo: () => document.getElementById('dashboard-grid') || portalRoot,
       }}
+      onOpenChange={setIsExpanded}
+      onOpenChangeKeys={['Escape']}
+      shouldFocusFirstItemOnOpen={false}
+      isScrollable
+      maxMenuHeight={'30vh'}
     >
       <SelectList id="typeahead-filter-select">
         {selectOptionProps.map(({ value, children }, index) => (

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.tsx
@@ -29,6 +29,7 @@ import {
   TextInputGroupUtilities,
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
+import _ from 'lodash';
 import * as React from 'react';
 
 export interface AutomatedAnalysisTopicFilterProps {
@@ -60,7 +61,8 @@ export const AutomatedAnalysisTopicFilter: React.FC<AutomatedAnalysisTopicFilter
   }, [props.evaluations, props.filteredTopics]);
 
   const filteredTopicOptions = React.useMemo(() => {
-    return !filterValue ? topicOptions : topicOptions.filter((topic) => topic.includes(filterValue.toLowerCase()));
+    const reg = new RegExp(_.escapeRegExp(filterValue), 'i');
+    return !filterValue ? topicOptions : topicOptions.filter((topic) => reg.test(topic));
   }, [filterValue, topicOptions]);
 
   const selectOptionProps: SelectOptionProps[] = React.useMemo(() => {
@@ -113,6 +115,11 @@ export const AutomatedAnalysisTopicFilter: React.FC<AutomatedAnalysisTopicFilter
       popperProps={{
         appendTo: () => document.getElementById('dashboard-grid') || portalRoot,
       }}
+      onOpenChange={setIsExpanded}
+      onOpenChangeKeys={['Escape']}
+      shouldFocusFirstItemOnOpen={false}
+      isScrollable
+      maxMenuHeight={'30vh'}
     >
       <SelectList id="typeahead-topic-filter">
         {selectOptionProps.map(({ value, children }, index) => (

--- a/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
@@ -338,7 +338,7 @@ export const JFRMetricsChartCardDescriptor: DashboardCardDescriptor = {
   labels: [
     {
       content: 'Beta',
-      color: 'green',
+      color: 'cyan',
     },
     {
       content: 'Metrics',

--- a/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
@@ -56,30 +56,34 @@ export interface JFRMetricsChartCardProps extends DashboardCardTypeProps {
 
 // TODO these need to be localized
 export enum JFRMetricsChartKind {
-  'Core Count' = 1,
-  'Thread Count' = 2,
-  'CPU Load' = 3,
-  'Heap Usage' = 4,
-  'Memory Usage' = 5,
-  'Total Memory' = 6,
-  'Recording Start Time' = 7,
-  'Recording Duration' = 8,
-  'Classloading Statistics' = 9,
-  'Metaspace Summary' = 10,
-  'Network Utilization' = 11,
-  'Metaspace GC Threshold' = 12,
-  'Thread Statistics' = 13,
-  'Exception Statistics' = 14,
-  'Thread Context Switch Rate' = 15,
-  'Compiler Statistics' = 16,
+  'Recording Duration' = 2,
+  'Recording Start Time' = 3,
 
-  'Safepoint Duration' = 18,
-  'File I/O' = 19,
-  'Compiler Total Time' = 20,
+  'Core Count' = 5,
+  'Thread Count' = 6,
+  'Total Memory' = 7,
+  'CPU Load' = 8,
+  'Memory Usage' = 9,
+
+  'Network Utilization' = 11,
+
+  'File I/O' = 13,
+
+  'Thread Statistics' = 15,
+  'Thread Context Switch Rate' = 16,
+
+  'Heap Usage' = 18,
+  'Object Allocation Sample' = 19,
+  'Safepoint Duration' = 20,
+  'Metaspace Summary' = 21,
+  'Metaspace GC Threshold' = 22,
 
   'Compiler Peak Time' = 24,
+  'Compiler Total Time' = 25,
+  'Compiler Statistics' = 26,
 
-  'Object Allocation Sample' = 38,
+  'Classloading Statistics' = 28,
+  'Exception Statistics' = 29,
 }
 
 export function kindToId(kind: string): number {

--- a/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
@@ -124,8 +124,8 @@ const SimpleChart: React.FC<{
               style={{
                 fill:
                   cryostatTheme === ThemeSetting.DARK
-                    ? 'var(--pf-global--palette--black-200)'
-                    : 'var(--pf-chart-global--label--Fill, #151515)',
+                    ? 'var(--pf-v5-global--palette--black-200)'
+                    : 'var(--pf-v5-chart-global--label--Fill, #151515)',
               }}
             />
           }
@@ -151,8 +151,8 @@ const SimpleChart: React.FC<{
             style={{
               fill:
                 cryostatTheme === ThemeSetting.DARK
-                  ? 'var(--pf-global--palette--black-200)'
-                  : 'var(--pf-chart-global--label--Fill, #151515)',
+                  ? 'var(--pf-v5-global--palette--black-200)'
+                  : 'var(--pf-v5-chart-global--label--Fill, #151515)',
             }}
           />
         }
@@ -297,8 +297,8 @@ const chartKinds: MBeanMetricsChartKind[] = [
               style={{
                 fill:
                   cryostatTheme === ThemeSetting.DARK
-                    ? 'var(--pf-global--palette--black-200)'
-                    : 'var(--pf-chart-donut--label--title--Fill, #151515)',
+                    ? 'var(--pf-v5-global--palette--black-200)'
+                    : 'var(--pf-v5-chart-donut--label--title--Fill, #151515)',
                 fontSize: '24px',
               }}
             />

--- a/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
@@ -375,7 +375,7 @@ export const MBeanMetricsChartCard: DashboardCardFC<MBeanMetricsChartCardProps> 
   const isError = React.useMemo(() => errorMessage != '', [errorMessage]);
 
   const resizeObserver = React.useRef((): void => undefined);
-  const [cardWidth, setCardWidth] = React.useState(0);
+  const [cardWidth, setCardWidth] = React.useState(1); // Use non-zero as 0 means Infinity (invalid)
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const containerRef: React.Ref<any> = React.createRef();
 
@@ -459,9 +459,8 @@ export const MBeanMetricsChartCard: DashboardCardFC<MBeanMetricsChartCardProps> 
 
   const refreshButton = React.useMemo(
     () => (
-      <Tooltip content={t('CHART_CARD.BUTTONS.REFRESH_TOOLTIP')}>
+      <Tooltip key={0} content={t('CHART_CARD.BUTTONS.REFRESH_TOOLTIP')}>
         <Button
-          key={0}
           aria-label={t('CHART_CARD.BUTTONS.SYNC.LABEL', { chartKind: props.chartKind })}
           onClick={refresh}
           variant="plain"

--- a/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
@@ -40,7 +40,7 @@ import {
   ChartLine,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
-import { getResizeObserver, Button, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import { getResizeObserver, Button, CardBody, CardHeader, CardTitle, Tooltip } from '@patternfly/react-core';
 import { MonitoringIcon, SyncAltIcon } from '@patternfly/react-icons';
 import _ from 'lodash';
 import * as React from 'react';
@@ -459,14 +459,16 @@ export const MBeanMetricsChartCard: DashboardCardFC<MBeanMetricsChartCardProps> 
 
   const refreshButton = React.useMemo(
     () => (
-      <Button
-        key={0}
-        aria-label={t('CHART_CARD.BUTTONS.SYNC.LABEL', { chartKind: props.chartKind })}
-        onClick={refresh}
-        variant="plain"
-        icon={<SyncAltIcon />}
-        isDisabled={isLoading}
-      />
+      <Tooltip content={t('CHART_CARD.BUTTONS.REFRESH_TOOLTIP')}>
+        <Button
+          key={0}
+          aria-label={t('CHART_CARD.BUTTONS.SYNC.LABEL', { chartKind: props.chartKind })}
+          onClick={refresh}
+          variant="plain"
+          icon={<SyncAltIcon />}
+          isDisabled={isLoading}
+        />
+      </Tooltip>
     ),
     [t, props.chartKind, refresh, isLoading],
   );

--- a/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
@@ -402,7 +402,7 @@ export const MBeanMetricsChartCard: DashboardCardFC<MBeanMetricsChartCardProps> 
   }, [containerRef, setCardWidth]);
 
   React.useEffect(() => {
-    resizeObserver.current = getResizeObserver(containerRef.current, handleResize);
+    resizeObserver.current = getResizeObserver(containerRef.current, handleResize, true);
     handleResize();
     return resizeObserver.current;
   }, [resizeObserver, containerRef, handleResize]);

--- a/src/app/Dashboard/DashboardCardActionMenu.tsx
+++ b/src/app/Dashboard/DashboardCardActionMenu.tsx
@@ -51,7 +51,6 @@ export const DashboardCardActionMenu: React.FC<DashboardCardActionProps> = ({ on
 
   return (
     <Dropdown
-      isPlain
       popperProps={{
         enableFlip: true,
         appendTo: () => document.getElementById('dashboard-grid') || portalRoot,
@@ -60,19 +59,16 @@ export const DashboardCardActionMenu: React.FC<DashboardCardActionProps> = ({ on
       isOpen={isOpen}
       onSelect={onSelect}
       toggle={toggle}
-      onOpenChange={(isOpen) => {
-        setIsOpen(isOpen);
-      }}
+      onOpenChange={setIsOpen}
+      onOpenChangeKeys={['Escape']}
     >
       <DropdownList>
         <DropdownItem key="View" onClick={onView}>
           {t('VIEW', { ns: 'common' })}
         </DropdownItem>
-        ,
         <DropdownItem key="Remove" onClick={onRemove}>
           {t('REMOVE', { ns: 'common' })}
         </DropdownItem>
-        ,
         <DropdownItem key="Reset Size" onClick={onResetSize}>
           {t('DashboardCardActionMenu.RESET_SIZE')}
         </DropdownItem>

--- a/src/app/Dashboard/DashboardLayoutCreateModal.tsx
+++ b/src/app/Dashboard/DashboardLayoutCreateModal.tsx
@@ -207,7 +207,7 @@ export const DashboardLayoutCreateModal: React.FC<DashboardLayoutCreateModalProp
       width={isCreateModal ? '80%' : '40%'}
       appendTo={portalRoot}
       isOpen={props.visible}
-      showClose={true}
+      showClose={false}
       header={header}
     >
       <Form onSubmit={(e) => e.preventDefault()}>

--- a/src/app/Dashboard/DashboardLayoutCreateModal.tsx
+++ b/src/app/Dashboard/DashboardLayoutCreateModal.tsx
@@ -145,22 +145,13 @@ export const DashboardLayoutCreateModal: React.FC<DashboardLayoutCreateModalProp
     return (
       <FormSection>
         {isCreateModal && (
-          <FormGroup label={'Template'} fieldId="template" isRequired height="35em">
-            <div style={{ border: '1px solid var(--pf-global--BorderColor--100)', height: '33em' }}>
+          <FormGroup label={'Template'} fieldId="template" isRequired>
+            <div style={{ border: '1px solid var(--pf-v5-global--BorderColor--100)', height: '50vh' }}>
               <LayoutTemplatePicker onTemplateSelect={onTemplateSelect} />
             </div>
           </FormGroup>
         )}
         <FormGroup label={t('DashboardLayoutCreateModal.NAME.LABEL')} fieldId="name" isRequired>
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem variant={nameValidated}>
-                {nameValidated === ValidatedOptions.error
-                  ? errorMessage
-                  : t('DashboardLayoutCreateModal.NAME.HELPER_TEXT')}
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
           <TextInput
             isRequired
             type="text"
@@ -174,6 +165,15 @@ export const DashboardLayoutCreateModal: React.FC<DashboardLayoutCreateModalProp
             autoComplete="on"
             validated={nameValidated}
           />
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem variant={nameValidated}>
+                {nameValidated === ValidatedOptions.error
+                  ? errorMessage
+                  : t('DashboardLayoutCreateModal.NAME.HELPER_TEXT')}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
         </FormGroup>
       </FormSection>
     );
@@ -204,8 +204,7 @@ export const DashboardLayoutCreateModal: React.FC<DashboardLayoutCreateModalProp
   return (
     <Modal
       aria-label={t('DashboardLayoutCreateModal.LABEL')}
-      width={isCreateModal ? '110em' : '40%'}
-      height={isCreateModal ? '90%' : 'auto'}
+      width={isCreateModal ? '80%' : '40%'}
       appendTo={portalRoot}
       isOpen={props.visible}
       showClose={true}

--- a/src/app/Dashboard/DashboardLayoutCreateModal.tsx
+++ b/src/app/Dashboard/DashboardLayoutCreateModal.tsx
@@ -208,7 +208,6 @@ export const DashboardLayoutCreateModal: React.FC<DashboardLayoutCreateModalProp
       appendTo={portalRoot}
       isOpen={props.visible}
       showClose={true}
-      onClose={handleClose}
       header={header}
     >
       <Form onSubmit={(e) => e.preventDefault()}>

--- a/src/app/Dashboard/DashboardLayoutToolbar.tsx
+++ b/src/app/Dashboard/DashboardLayoutToolbar.tsx
@@ -44,8 +44,7 @@ import {
   DropdownItem,
   DropdownList,
   MenuToggleElement,
-  Dropdown as PF5Dropdown,
-  DropdownItem as PF5DropdownItem,
+  MenuToggleAction,
 } from '@patternfly/react-core';
 import {
   EllipsisVIcon,
@@ -263,54 +262,52 @@ export const DashboardLayoutToolbar: React.FC<DashboardLayoutToolbarProps> = (_p
 
   const createTemplateDropdownItems = React.useMemo(
     () => [
-      <PF5DropdownItem key="action" onClick={createBlankLayout} autoFocus icon={<FileIcon />}>
+      <DropdownItem key="action" onClick={createBlankLayout} autoFocus icon={<FileIcon />}>
         Blank Layout
-      </PF5DropdownItem>,
-      <PF5DropdownItem key="template" onClick={handleCreateModalOpen} icon={<PficonTemplateIcon />}>
+      </DropdownItem>,
+      <DropdownItem key="template" onClick={handleCreateModalOpen} icon={<PficonTemplateIcon />}>
         Choose Template
-      </PF5DropdownItem>,
-      <PF5DropdownItem key="upload" onClick={handleUploadModalOpen} icon={<UploadIcon />}>
+      </DropdownItem>,
+      <DropdownItem key="upload" onClick={handleUploadModalOpen} icon={<UploadIcon />}>
         Upload Template
-      </PF5DropdownItem>,
+      </DropdownItem>,
     ],
     [createBlankLayout, handleCreateModalOpen, handleUploadModalOpen],
   );
 
   const createTemplateButton = React.useMemo(
     () => (
-      <PF5Dropdown
+      <Dropdown
+        isOpen={isCreateDropdownOpen}
         onSelect={onCreateDropdownSelect}
-        onOpenChange={(open) => setIsCreateDropdownOpen(open)}
+        onOpenChange={setIsCreateDropdownOpen}
+        onOpenChangeKeys={['Escape']}
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}
             className="dashboard-layout-create-dropdown-toggle"
+            onClick={() => setIsCreateDropdownOpen((open) => !open)}
             splitButtonOptions={{
+              variant: 'action',
               items: [
-                <DropdownItem
-                  key="action"
+                <MenuToggleAction
                   onClick={(_e) => {
                     createBlankLayout();
                     setIsSelectorOpen(false);
                   }}
+                  key="action"
                 >
-                  <span style={{ display: 'flex', alignItems: 'center' }}>
-                    <PlusCircleIcon style={{ marginRight: 'var(--pf-global--spacer--sm)' }} />
-                    {t('DashboardLayoutToolbar.NEW_LAYOUT')}
-                  </span>
-                </DropdownItem>,
+                  <PlusCircleIcon style={{ marginRight: 'var(--pf-v5-global--spacer--sm)' }} />
+                  {t('DashboardLayoutToolbar.NEW_LAYOUT')}
+                </MenuToggleAction>,
               ],
             }}
             variant="primary"
-            //splitButtonVariant="action"
-          >
-            <EllipsisVIcon />
-          </MenuToggle>
+          />
         )}
       >
-        isOpen={isCreateDropdownOpen}
         <DropdownList>{createTemplateDropdownItems}</DropdownList>
-      </PF5Dropdown>
+      </Dropdown>
     ),
     [
       t,
@@ -358,7 +355,7 @@ export const DashboardLayoutToolbar: React.FC<DashboardLayoutToolbarProps> = (_p
 
   const dropdownItems = React.useMemo(() => {
     return (
-      <DropdownList>
+      <>
         <DropdownItem key="template" value={'template'}>
           {t('DashboardLayoutToolbar.SET_AS_TEMPLATE')}
         </DropdownItem>
@@ -368,7 +365,7 @@ export const DashboardLayoutToolbar: React.FC<DashboardLayoutToolbarProps> = (_p
         <DropdownItem key="clearAll" value={'clearAll'} isDisabled={currLayout.cards.length < 1}>
           {t('DashboardLayoutToolbar.CLEAR_LAYOUT')}
         </DropdownItem>
-      </DropdownList>
+      </>
     );
   }, [t, currLayout.cards.length]);
 
@@ -411,12 +408,8 @@ export const DashboardLayoutToolbar: React.FC<DashboardLayoutToolbarProps> = (_p
       <Dropdown
         isOpen={isKebabOpen}
         onSelect={onKebabSelect}
-        popperProps={{
-          minWidth: '12em',
-        }}
-        onOpenChange={(isOpen) => {
-          setIsKebabOpen(isOpen);
-        }}
+        onOpenChange={setIsKebabOpen}
+        onOpenChangeKeys={['Escape']}
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}
@@ -493,6 +486,7 @@ export const DashboardLayoutToolbar: React.FC<DashboardLayoutToolbarProps> = (_p
       <Dropdown
         isOpen={isSelectorOpen}
         onOpenChange={onOpenChange}
+        onOpenChangeKeys={['Escape']}
         toggle={(toggleRef) => (
           <MenuToggle
             ref={toggleRef}

--- a/src/app/Dashboard/LayoutTemplateGroup.tsx
+++ b/src/app/Dashboard/LayoutTemplateGroup.tsx
@@ -16,7 +16,6 @@
 import { dashboardConfigTemplateHistoryClearIntent } from '@app/Shared/Redux/ReduxStore';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { portalRoot } from '@app/utils/utils';
 import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
 import {
   Button,

--- a/src/app/Dashboard/LayoutTemplateGroup.tsx
+++ b/src/app/Dashboard/LayoutTemplateGroup.tsx
@@ -17,7 +17,7 @@ import { dashboardConfigTemplateHistoryClearIntent } from '@app/Shared/Redux/Red
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { portalRoot } from '@app/utils/utils';
-import { CatalogTile } from '@patternfly/react-catalog-view-extension';
+import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
 import {
   Button,
   Gallery,
@@ -107,51 +107,32 @@ export const LayoutTemplateGroup: React.FC<LayoutTemplateGroupProps> = ({
         {props.templates.map((template) => {
           const level = smallestFeatureLevel(template.cards);
           return (
-            <div
-              key={template.name}
-              className={
-                // make sure the selected template that is **clicked** is highlighted and not any copies that may be in other categories (i.e. suggested)
+            <CatalogTile
+              featured={
                 selectedTemplate &&
                 selectedTemplate.template.name === template.name &&
                 selectedTemplate.template.vendor == template.vendor &&
                 selectedTemplate.category == props.title
-                  ? 'layout-template-card__featured'
-                  : undefined
               }
-            >
-              <CatalogTile
-                featured={
-                  selectedTemplate &&
-                  selectedTemplate.template.name === template.name &&
-                  selectedTemplate.template.vendor == template.vendor &&
-                  selectedTemplate.category == props.title
-                }
-                id={template.name}
-                key={template.name}
-                icon={iconify(template.vendor)}
-                title={template.name}
-                vendor={template.vendor}
-                onClick={() => handleTemplateSelect(template)}
-                badges={[
-                  level !== FeatureLevel.PRODUCTION && (
-                    <Label
-                      key={template.name}
-                      isCompact
-                      style={{
-                        textTransform: 'capitalize',
-                        marginTop: '1.1ch',
-                      }}
-                      color={level === FeatureLevel.BETA ? 'green' : 'red'}
-                    >
-                      {FeatureLevel[level].toLowerCase()}
+              id={template.name}
+              key={template.name}
+              icon={iconify(template.vendor)}
+              title={template.name}
+              vendor={template.vendor}
+              onClick={() => handleTemplateSelect(template)}
+              badges={[
+                level !== FeatureLevel.PRODUCTION && (
+                  <CatalogTileBadge>
+                    <Label key={template.name} isCompact color={level === FeatureLevel.BETA ? 'green' : 'red'}>
+                      {t(FeatureLevel[level])}
                     </Label>
-                  ),
-                  <KebabCatalogTileBadge template={template} onTemplateDelete={onTemplateDelete} key={template.name} />,
-                ]}
-              >
-                {template.description}
-              </CatalogTile>
-            </div>
+                  </CatalogTileBadge>
+                ),
+                <KebabCatalogTileBadge template={template} onTemplateDelete={onTemplateDelete} key={template.name} />,
+              ]}
+            >
+              {template.description}
+            </CatalogTile>
           );
         })}
       </Gallery>
@@ -173,14 +154,6 @@ export const KebabCatalogTileBadge: React.FC<KebabCatalogTileBadgeProps> = ({ te
   const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, _value: string | number | undefined) => {
     setIsOpen(false);
   };
-
-  const openKebab = React.useCallback(
-    (value, e) => {
-      e.stopPropagation();
-      setIsOpen(value);
-    },
-    [setIsOpen],
-  );
 
   const handleTemplateDownload = React.useCallback(
     (e: React.MouseEvent) => {
@@ -210,26 +183,32 @@ export const KebabCatalogTileBadge: React.FC<KebabCatalogTileBadgeProps> = ({ te
   }, [t, handleTemplateDownload, handleTemplateDelete]);
 
   return (
-    <Dropdown
-      //menuAppendTo={portalRoot}
-      onSelect={onSelect}
-      //toggle={<KebabToggle isDisabled={template.vendor !== LayoutTemplateVendor.USER} onToggle={openKebab} />}
-      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-        <MenuToggle
-          ref={toggleRef}
-          variant="plain"
-          isDisabled={template.vendor !== LayoutTemplateVendor.USER}
-          onClick={(event: React.MouseEvent) => openKebab(isOpen, event)}
-          isExpanded={isOpen}
-        >
-          <EllipsisVIcon />
-        </MenuToggle>
-      )}
-      popperProps={{
-        appendTo: portalRoot,
-      }}
-    >
-      <DropdownList>{dropdownItems}</DropdownList>
-    </Dropdown>
+    <CatalogTileBadge>
+      <Dropdown
+        popperProps={{
+          appendTo: portalRoot,
+        }}
+        onSelect={onSelect}
+        onOpenChange={setIsOpen}
+        isOpen={isOpen}
+        onOpenChangeKeys={['Escape']}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            className={'layout-template-card__action-toggle'}
+            variant="plain"
+            isDisabled={template.vendor !== LayoutTemplateVendor.USER}
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsOpen((open) => !open);
+            }}
+          >
+            <EllipsisVIcon />
+          </MenuToggle>
+        )}
+      >
+        <DropdownList>{dropdownItems}</DropdownList>
+      </Dropdown>
+    </CatalogTileBadge>
   );
 };

--- a/src/app/Dashboard/LayoutTemplateGroup.tsx
+++ b/src/app/Dashboard/LayoutTemplateGroup.tsx
@@ -185,9 +185,6 @@ export const KebabCatalogTileBadge: React.FC<KebabCatalogTileBadgeProps> = ({ te
   return (
     <CatalogTileBadge>
       <Dropdown
-        popperProps={{
-          appendTo: portalRoot,
-        }}
         onSelect={onSelect}
         onOpenChange={setIsOpen}
         isOpen={isOpen}

--- a/src/app/Dashboard/LayoutTemplatePicker.tsx
+++ b/src/app/Dashboard/LayoutTemplatePicker.tsx
@@ -75,6 +75,7 @@ import {
 } from '@patternfly/react-icons';
 import { InnerScrollContainer } from '@patternfly/react-table';
 import { TFunction } from 'i18next';
+import _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -145,7 +146,8 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
       if (!searchFilter) {
         return templates;
       }
-      return templates.filter((t) => t.name.toLowerCase().includes(searchFilter.toLowerCase()));
+      const reg = new RegExp(_.escapeRegExp(searchFilter), 'i');
+      return templates.filter((t) => reg.test(t.name));
     },
     [searchFilter],
   );
@@ -522,7 +524,11 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
               <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint={'md'}>
                 <ToolbarGroup variant="filter-group">
                   <ToolbarItem variant="search-filter">
-                    <SearchAutocomplete values={allTemplates.map((t) => t.name)} onChange={onSearchChange} />
+                    <SearchAutocomplete
+                      values={allTemplates.map((t) => t.name)}
+                      onChange={onSearchChange}
+                      placeholder={t('LayoutTemplatePicker.SEARCH_PLACEHOLDER')}
+                    />
                   </ToolbarItem>
                   <ToolbarFilter chips={selectedFilters} deleteChip={onDeleteChip} categoryName="Category">
                     <Select

--- a/src/app/Dashboard/LayoutTemplatePicker.tsx
+++ b/src/app/Dashboard/LayoutTemplatePicker.tsx
@@ -74,7 +74,7 @@ import {
   SortAmountUpAltIcon,
   UploadIcon,
 } from '@patternfly/react-icons';
-import { InnerScrollContainer, OuterScrollContainer } from '@patternfly/react-table';
+import { InnerScrollContainer } from '@patternfly/react-table';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -208,10 +208,9 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
         variant="secondary"
         aria-label={t('DashboardLayoutToolbar.UPLOAD.LABEL')}
         onClick={handleUploadButton}
-        icon={<UploadIcon />}
         data-quickstart-id="dashboard-upload-btn"
       >
-        {t('UPLOAD', { ns: 'common' })}
+        <UploadIcon />
       </Button>
     ),
     [t, handleUploadButton],
@@ -429,9 +428,9 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
   }, [t, onDrawerCloseClick, selectedTemplate]);
 
   const sortedFilteredFeatureLeveledTemplateLayoutGroup = React.useCallback(
-    (title: LayoutTemplateFilter, templates: LayoutTemplate[]) => {
-      const featuredLevelled = templates.filter((t) => smallestFeatureLevel(t.cards) >= activeLevel);
-      const sortedSearchFilteredTemplates = searchFilteredTemplates(featuredLevelled).sort((a, b) => {
+    (title: LayoutTemplateFilter, templates: LayoutTemplate[], divider: boolean = true) => {
+      const featuredLevelledTemplates = templates.filter((t) => smallestFeatureLevel(t.cards) >= activeLevel);
+      const sortedSearchFilteredTemplates = searchFilteredTemplates(featuredLevelledTemplates).sort((a, b) => {
         switch (selectedSort) {
           case 'Name':
             if (sortDirection === 'asc') {
@@ -465,13 +464,13 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
               onTemplateDelete={onInnerTemplateDelete}
             />
           </StackItem>
-          <StackItem>
-            <Divider />
-          </StackItem>
+          {divider && (
+            <StackItem>
+              <Divider />
+            </StackItem>
+          )}
         </>
-      ) : (
-        <></>
-      );
+      ) : null;
     },
     [
       activeLevel,
@@ -510,120 +509,121 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
     <Drawer isExpanded={isDrawerExpanded} isInline>
       <DrawerContent panelContent={panelContent}>
         <DrawerContentBody>
-          <OuterScrollContainer>
-            <InnerScrollContainer>
-              <Toolbar isSticky clearAllFilters={onClearAllFilters}>
-                <ToolbarContent>
-                  <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint={'md'}>
-                    <ToolbarGroup variant="filter-group">
-                      <ToolbarItem variant="search-filter">
-                        <SearchAutocomplete values={allTemplates.map((t) => t.name)} onChange={onSearchChange} />
-                      </ToolbarItem>
-                      <ToolbarFilter chips={selectedFilters} deleteChip={onDeleteChip} categoryName="Category">
-                        <Select
-                          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                            <MenuToggle ref={toggleRef} onClick={onFilterSelectToggle} isExpanded={isFilterSelectOpen}>
-                              Template Type
-                              {selectedFilters.length ? <Badge isRead>{selectedFilters.length}</Badge> : null}
-                            </MenuToggle>
-                          )}
-                          popperProps={{
-                            appendTo: portalRoot,
-                          }}
-                          aria-label="Select template category"
-                          onSelect={onFilterSelect}
-                          selected={selectedFilters}
-                          isOpen={isFilterSelectOpen}
-                        >
-                          <SelectList>
-                            <SelectOption key="suggested" value={t('SUGGESTED', { ns: 'common' })} hasCheckbox>
-                              {t('SUGGESTED', { ns: 'common' })}
-                            </SelectOption>
-                            <SelectOption key="cryostat" value="Cryostat" hasCheckbox>
-                              Cryostat
-                            </SelectOption>
-                            <SelectOption
-                              key="user-submitted"
-                              value={t('USER_SUBMITTED', { ns: 'common' })}
-                              hasCheckbox
-                            >
-                              {t('USER_SUBMITTED', { ns: 'common' })}
-                            </SelectOption>
-                          </SelectList>
-                        </Select>
-                      </ToolbarFilter>
-                    </ToolbarGroup>
-                  </ToolbarToggleGroup>
-                  <ToolbarGroup variant="icon-button-group">
-                    <ToolbarItem>
-                      <Select
-                        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                          <MenuToggle ref={toggleRef} onClick={onSortSelectToggle} isExpanded={isSortSelectOpen}>
-                            {selectedSort ?? t('LayoutTemplatePicker.SORT_BY.PLACEHOLDER')}
-                          </MenuToggle>
-                        )}
-                        popperProps={{
-                          appendTo: portalRoot,
-                        }}
-                        aria-label="Select sorting category"
-                        onSelect={onSortSelect}
-                        selected={selectedSort}
-                        isOpen={isSortSelectOpen}
-                      >
-                        <SelectList>
-                          <SelectOption key={LayoutTemplateSort.NAME} value={LayoutTemplateSort.NAME}>
-                            {t('LayoutTemplatePicker.SORT_BY.NAME')}
-                          </SelectOption>
-                          <SelectOption key={LayoutTemplateSort.CARD_COUNT} value={LayoutTemplateSort.CARD_COUNT}>
-                            {t('LayoutTemplatePicker.SORT_BY.CARD_COUNT')}
-                          </SelectOption>
-                        </SelectList>
-                      </Select>
-                    </ToolbarItem>
-                    <ToolbarItem>
-                      <Button
-                        variant="plain"
-                        aria-label="Sort"
-                        onClick={onSortDirectionChange}
-                        isAriaDisabled={!selectedSort}
-                      >
-                        {sortArrowIcon}
-                      </Button>
-                    </ToolbarItem>
-                  </ToolbarGroup>
-                  <ToolbarGroup>
-                    <ToolbarItem>{uploadButton}</ToolbarItem>
-                  </ToolbarGroup>
-                </ToolbarContent>
-              </Toolbar>
-              <Stack>
-                {allSearchableTemplateNames.length !== 0 ? (
-                  <>
-                    {sortedFilteredFeatureLeveledTemplateLayoutGroup(t('SUGGESTED', { ns: 'common' }), [
-                      BlankLayout,
-                      ...RecentTemplates,
-                    ])}
-                    {sortedFilteredFeatureLeveledTemplateLayoutGroup('Cryostat', CryostatLayoutTemplates)}
-                    {sortedFilteredFeatureLeveledTemplateLayoutGroup(
-                      t('USER_SUBMITTED', { ns: 'common' }),
-                      userSubmittedTemplates,
+          <Toolbar isSticky clearAllFilters={onClearAllFilters}>
+            <ToolbarContent>
+              <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint={'md'}>
+                <ToolbarGroup variant="filter-group">
+                  <ToolbarItem variant="search-filter">
+                    <SearchAutocomplete values={allTemplates.map((t) => t.name)} onChange={onSearchChange} />
+                  </ToolbarItem>
+                  <ToolbarFilter chips={selectedFilters} deleteChip={onDeleteChip} categoryName="Category">
+                    <Select
+                      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                        <MenuToggle ref={toggleRef} onClick={onFilterSelectToggle} isExpanded={isFilterSelectOpen}>
+                          Template Type
+                          {selectedFilters.length ? <Badge isRead>{selectedFilters.length}</Badge> : null}
+                        </MenuToggle>
+                      )}
+                      popperProps={{
+                        appendTo: portalRoot,
+                      }}
+                      aria-label="Select template category"
+                      onSelect={onFilterSelect}
+                      selected={selectedFilters}
+                      isOpen={isFilterSelectOpen}
+                    >
+                      <SelectList>
+                        <SelectOption key="suggested" value={t('SUGGESTED', { ns: 'common' })} hasCheckbox>
+                          {t('SUGGESTED', { ns: 'common' })}
+                        </SelectOption>
+                        <SelectOption key="cryostat" value="Cryostat" hasCheckbox>
+                          Cryostat
+                        </SelectOption>
+                        <SelectOption key="user-submitted" value={t('USER_SUBMITTED', { ns: 'common' })} hasCheckbox>
+                          {t('USER_SUBMITTED', { ns: 'common' })}
+                        </SelectOption>
+                      </SelectList>
+                    </Select>
+                  </ToolbarFilter>
+                </ToolbarGroup>
+              </ToolbarToggleGroup>
+              <ToolbarItem variant="separator" />
+              <ToolbarGroup variant="icon-button-group">
+                <ToolbarItem>
+                  <Select
+                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                      <MenuToggle ref={toggleRef} onClick={onSortSelectToggle} isExpanded={isSortSelectOpen}>
+                        {selectedSort ?? t('LayoutTemplatePicker.SORT_BY.PLACEHOLDER')}
+                      </MenuToggle>
                     )}
-                  </>
-                ) : (
-                  <StackItem>
-                    <EmptyState>
-                      <EmptyStateHeader
-                        titleText="No templates found"
-                        icon={<EmptyStateIcon icon={PficonTemplateIcon} />}
-                        headingLevel="h4"
-                      />
-                      <EmptyStateBody>Upload a template and try again.</EmptyStateBody>
-                    </EmptyState>
-                  </StackItem>
-                )}
-              </Stack>
-            </InnerScrollContainer>
-          </OuterScrollContainer>
+                    popperProps={{
+                      appendTo: portalRoot,
+                    }}
+                    aria-label="Select sorting category"
+                    onSelect={onSortSelect}
+                    selected={selectedSort}
+                    isOpen={isSortSelectOpen}
+                  >
+                    <SelectList>
+                      <SelectOption key={LayoutTemplateSort.NAME} value={LayoutTemplateSort.NAME}>
+                        {t('LayoutTemplatePicker.SORT_BY.NAME')}
+                      </SelectOption>
+                      <SelectOption key={LayoutTemplateSort.CARD_COUNT} value={LayoutTemplateSort.CARD_COUNT}>
+                        {t('LayoutTemplatePicker.SORT_BY.CARD_COUNT')}
+                      </SelectOption>
+                    </SelectList>
+                  </Select>
+                </ToolbarItem>
+                <ToolbarItem>
+                  <Button
+                    variant="plain"
+                    aria-label="Sort"
+                    onClick={onSortDirectionChange}
+                    isAriaDisabled={!selectedSort}
+                  >
+                    {sortArrowIcon}
+                  </Button>
+                </ToolbarItem>
+              </ToolbarGroup>
+              <ToolbarItem variant="separator" />
+              <ToolbarGroup>
+                <ToolbarItem>{uploadButton}</ToolbarItem>
+              </ToolbarGroup>
+            </ToolbarContent>
+          </Toolbar>
+          <InnerScrollContainer>
+            <Stack>
+              {allSearchableTemplateNames.length > 0 ? (
+                <>
+                  {sortedFilteredFeatureLeveledTemplateLayoutGroup(t('SUGGESTED', { ns: 'common' }), [
+                    BlankLayout,
+                    ...RecentTemplates,
+                  ])}
+                  {sortedFilteredFeatureLeveledTemplateLayoutGroup(
+                    'Cryostat',
+                    CryostatLayoutTemplates,
+                    userSubmittedTemplates.length > 0,
+                  )}
+                  {sortedFilteredFeatureLeveledTemplateLayoutGroup(
+                    t('USER_SUBMITTED', { ns: 'common' }),
+                    userSubmittedTemplates,
+                    false,
+                  )}
+                </>
+              ) : (
+                <StackItem>
+                  <EmptyState>
+                    <EmptyStateHeader
+                      titleText="No templates found"
+                      icon={<EmptyStateIcon icon={PficonTemplateIcon} />}
+                      headingLevel="h4"
+                    />
+                    <EmptyStateBody>Upload a template and try again.</EmptyStateBody>
+                  </EmptyState>
+                </StackItem>
+              )}
+            </Stack>
+          </InnerScrollContainer>
         </DrawerContentBody>
       </DrawerContent>
       {deleteWarningModal}

--- a/src/app/Dashboard/LayoutTemplatePicker.tsx
+++ b/src/app/Dashboard/LayoutTemplatePicker.tsx
@@ -19,7 +19,6 @@ import { RootState, dashboardConfigDeleteTemplateIntent } from '@app/Shared/Redu
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { fakeChartContext, fakeServices } from '@app/utils/fakeData';
 import { useFeatureLevel } from '@app/utils/hooks/useFeatureLevel';
-import { portalRoot } from '@app/utils/utils';
 import {
   Bullseye,
   Button,
@@ -75,6 +74,7 @@ import {
   UploadIcon,
 } from '@patternfly/react-icons';
 import { InnerScrollContainer } from '@patternfly/react-table';
+import { TFunction } from 'i18next';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
@@ -96,6 +96,17 @@ export enum LayoutTemplateSort {
   // TODO: add 'Version' after more version are released
 }
 
+export const getSortToggleDisplay = (sort: LayoutTemplateSort, t: TFunction): string => {
+  switch (sort) {
+    case LayoutTemplateSort.NAME:
+      return t('LayoutTemplatePicker.SORT_BY.NAME');
+    case LayoutTemplateSort.CARD_COUNT:
+      return t('LayoutTemplatePicker.SORT_BY.CARD_COUNT');
+    default:
+      return `${sort}`;
+  }
+};
+
 const CARD_PREVIEW_LIMIT = 16;
 
 export interface LayoutTemplatePickerProps {
@@ -113,7 +124,7 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
   const [selectedFilters, setSelectedFilters] = React.useState<LayoutTemplateFilter[]>([]);
 
   const [isSortSelectOpen, setIsSortSelectOpen] = React.useState(false);
-  const [selectedSort, setSelectedSort] = React.useState<LayoutTemplateSort | undefined>(undefined);
+  const [selectedSort, setSelectedSort] = React.useState<LayoutTemplateSort>(LayoutTemplateSort.NAME);
   const [sortDirection, setSortDirection] = React.useState<'asc' | 'desc'>('asc');
 
   const [isDrawerExpanded, setIsDrawerExpanded] = React.useState(false);
@@ -233,9 +244,6 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
   const onFilterSelect = React.useCallback(
     (_ev: React.MouseEvent<Element, MouseEvent>, selected: LayoutTemplateFilter) => {
       setSelectedFilters((prev) => {
-        if (selected) {
-          return [];
-        }
         if (prev.includes(selected)) {
           return prev.filter((item) => item !== selected);
         }
@@ -519,27 +527,45 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
                   <ToolbarFilter chips={selectedFilters} deleteChip={onDeleteChip} categoryName="Category">
                     <Select
                       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                        <MenuToggle ref={toggleRef} onClick={onFilterSelectToggle} isExpanded={isFilterSelectOpen}>
+                        <MenuToggle
+                          ref={toggleRef}
+                          onClick={onFilterSelectToggle}
+                          isExpanded={isFilterSelectOpen}
+                          badge={selectedFilters.length ? <Badge isRead>{selectedFilters.length}</Badge> : null}
+                        >
                           Template Type
-                          {selectedFilters.length ? <Badge isRead>{selectedFilters.length}</Badge> : null}
                         </MenuToggle>
                       )}
-                      popperProps={{
-                        appendTo: portalRoot,
-                      }}
                       aria-label="Select template category"
                       onSelect={onFilterSelect}
                       selected={selectedFilters}
                       isOpen={isFilterSelectOpen}
+                      onOpenChangeKeys={['Escape']}
+                      onOpenChange={setIsFilterSelectOpen}
                     >
                       <SelectList>
-                        <SelectOption key="suggested" value={t('SUGGESTED', { ns: 'common' })} hasCheckbox>
+                        <SelectOption
+                          key="suggested"
+                          value={'Suggested'}
+                          hasCheckbox
+                          isSelected={selectedFilters.includes('Suggested')}
+                        >
                           {t('SUGGESTED', { ns: 'common' })}
                         </SelectOption>
-                        <SelectOption key="cryostat" value="Cryostat" hasCheckbox>
+                        <SelectOption
+                          key="cryostat"
+                          value="Cryostat"
+                          hasCheckbox
+                          isSelected={selectedFilters.includes('Cryostat')}
+                        >
                           Cryostat
                         </SelectOption>
-                        <SelectOption key="user-submitted" value={t('USER_SUBMITTED', { ns: 'common' })} hasCheckbox>
+                        <SelectOption
+                          key="user-submitted"
+                          value={'User-submitted'}
+                          hasCheckbox
+                          isSelected={selectedFilters.includes('User-submitted')}
+                        >
                           {t('USER_SUBMITTED', { ns: 'common' })}
                         </SelectOption>
                       </SelectList>
@@ -548,28 +574,27 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
                 </ToolbarGroup>
               </ToolbarToggleGroup>
               <ToolbarItem variant="separator" />
-              <ToolbarGroup variant="icon-button-group">
+              <ToolbarGroup>
                 <ToolbarItem>
                   <Select
                     toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
                       <MenuToggle ref={toggleRef} onClick={onSortSelectToggle} isExpanded={isSortSelectOpen}>
-                        {selectedSort ?? t('LayoutTemplatePicker.SORT_BY.PLACEHOLDER')}
+                        {getSortToggleDisplay(selectedSort, t)}
                       </MenuToggle>
                     )}
-                    popperProps={{
-                      appendTo: portalRoot,
-                    }}
                     aria-label="Select sorting category"
                     onSelect={onSortSelect}
                     selected={selectedSort}
                     isOpen={isSortSelectOpen}
+                    onOpenChange={setIsSortSelectOpen}
+                    onOpenChangeKeys={['Escape']}
                   >
                     <SelectList>
                       <SelectOption key={LayoutTemplateSort.NAME} value={LayoutTemplateSort.NAME}>
-                        {t('LayoutTemplatePicker.SORT_BY.NAME')}
+                        {t('NAME', { ns: 'common' })}
                       </SelectOption>
                       <SelectOption key={LayoutTemplateSort.CARD_COUNT} value={LayoutTemplateSort.CARD_COUNT}>
-                        {t('LayoutTemplatePicker.SORT_BY.CARD_COUNT')}
+                        {t('LayoutTemplatePicker.CARD_COUNT')}
                       </SelectOption>
                     </SelectList>
                   </Select>
@@ -586,7 +611,7 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
                 </ToolbarItem>
               </ToolbarGroup>
               <ToolbarItem variant="separator" />
-              <ToolbarGroup>
+              <ToolbarGroup variant="icon-button-group">
                 <ToolbarItem>{uploadButton}</ToolbarItem>
               </ToolbarGroup>
             </ToolbarContent>

--- a/src/app/Dashboard/SearchAutocomplete.tsx
+++ b/src/app/Dashboard/SearchAutocomplete.tsx
@@ -20,10 +20,11 @@ import * as React from 'react';
 export interface SearchAutocompleteProps {
   values: string[];
   onChange: (value: string) => void;
+  placeholder?: string;
 }
 
-export const SearchAutocomplete: React.FC<SearchAutocompleteProps> = ({ onChange, ...props }) => {
-  const [value, setValue] = React.useState('');
+export const SearchAutocomplete: React.FC<SearchAutocompleteProps> = ({ onChange, placeholder, ...props }) => {
+  const [searchTerm, setSearchTerm] = React.useState('');
   const [hint, setHint] = React.useState('');
   const [autocompleteOptions, setAutocompleteOptions] = React.useState<JSX.Element[]>([]);
 
@@ -33,9 +34,9 @@ export const SearchAutocomplete: React.FC<SearchAutocompleteProps> = ({ onChange
   const autocompleteRef = React.useRef<HTMLDivElement>(null);
 
   const onClear = React.useCallback(() => {
-    setValue('');
+    setSearchTerm('');
     onChange('');
-  }, [setValue, onChange]);
+  }, [setSearchTerm, onChange]);
 
   const onSearchChange = React.useCallback(
     (newValue) => {
@@ -61,10 +62,10 @@ export const SearchAutocomplete: React.FC<SearchAutocompleteProps> = ({ onChange
         setAutocompleteOptions([]);
         setHint('');
       }
-      setValue(newValue);
+      setSearchTerm(newValue);
       onChange(newValue);
     },
-    [setValue, setHint, setIsAutocompleteOpen, setAutocompleteOptions, onChange, props.values],
+    [setSearchTerm, setHint, setIsAutocompleteOpen, setAutocompleteOptions, onChange, props.values],
   );
 
   // Whenever an autocomplete option is selected, set the search input value, close the menu, and put the browser
@@ -72,12 +73,12 @@ export const SearchAutocomplete: React.FC<SearchAutocompleteProps> = ({ onChange
   const onSelect = React.useCallback(
     (e, itemId) => {
       e.stopPropagation();
-      setValue(itemId);
+      setSearchTerm(itemId);
       setHint('');
       setIsAutocompleteOpen(false);
       searchInputRef.current && searchInputRef.current.focus();
     },
-    [setValue, setHint, setIsAutocompleteOpen],
+    [setSearchTerm, setHint, setIsAutocompleteOpen],
   );
 
   const handleMenuKeys = React.useCallback(
@@ -85,7 +86,7 @@ export const SearchAutocomplete: React.FC<SearchAutocompleteProps> = ({ onChange
       // If there is a hint while the browser focus is on the search input, tab or right arrow will 'accept' the hint value
       // and set it as the search input value
       if (hint && (event.key === 'Tab' || event.key === 'ArrowRight') && searchInputRef.current === event.target) {
-        setValue(hint);
+        setSearchTerm(hint);
         setHint('');
         setIsAutocompleteOpen(false);
         if (event.key === 'ArrowRight') {
@@ -150,15 +151,16 @@ export const SearchAutocomplete: React.FC<SearchAutocompleteProps> = ({ onChange
   const searchInput = React.useMemo(
     () => (
       <SearchInput
-        value={value}
+        value={searchTerm}
         onChange={onSearchChange}
         onClear={onClear}
         ref={searchInputRef}
         hint={hint}
+        placeholder={placeholder}
         id="cryostat-autocomplete-search"
       />
     ),
-    [value, onSearchChange, onClear, hint],
+    [searchTerm, onSearchChange, onClear, hint, placeholder],
   );
 
   const autocomplete = React.useMemo(

--- a/src/app/Dashboard/cryostat-dashboard-templates.tsx
+++ b/src/app/Dashboard/cryostat-dashboard-templates.tsx
@@ -15,7 +15,7 @@
  */
 import { LayoutTemplate, LayoutTemplateVendor, LayoutTemplateVersion } from './types';
 
-const CURR_VERSION: LayoutTemplateVersion = LayoutTemplateVersion['v2.4'];
+const CURR_VERSION: LayoutTemplateVersion = LayoutTemplateVersion['v3.0'];
 
 export const BlankLayout: LayoutTemplate = {
   name: 'Blank',

--- a/src/app/Dashboard/types.ts
+++ b/src/app/Dashboard/types.ts
@@ -121,6 +121,8 @@ export type LayoutTemplateRecord = Pick<LayoutTemplate, 'name' | 'vendor'>;
 export enum LayoutTemplateVersion {
   'v2.3' = 'v2.3',
   'v2.4' = 'v2.4',
+  'v3.0' = 'v3.0',
+  'v4.0' = 'v4.0',
 }
 
 export enum LayoutTemplateVendor {

--- a/src/app/QuickStarts/QuickStartDrawer.tsx
+++ b/src/app/QuickStarts/QuickStartDrawer.tsx
@@ -78,7 +78,7 @@ export const GlobalQuickStartDrawer: React.FC<GlobalQuickStartDrawerProps> = ({ 
             regex: HIGHLIGHT_REGEXP,
             replace: (text: string, linkLabel: string, linkType: string, linkId: string): string => {
               if (!linkLabel || !linkType || !linkId) return text;
-              return `<button class="pf-c-button pf-m-inline pf-m-link" data-highlight="${linkId}">${linkLabel}</button>`;
+              return `<button class="pf-v5-c-button pf-m-inline pf-m-link" data-highlight="${linkId}">${linkLabel}</button>`;
             },
           },
           {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -118,6 +118,11 @@ body,
   padding: 0 1em 1em 1em;
 }
 
+.catalog-tile-pf-icon {
+  /* Catalog icon style is only applied if display is inline-block */
+  display: inline-block;
+}
+
 .layout-template-picker .catalog-tile-pf {
   height: 100%;
   border-top: 1.5px solid var(--pf-v5-global--palette--black-300);

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -120,7 +120,6 @@ body,
 
 .layout-template-picker .catalog-tile-pf {
   height: 100%;
-  color: var(--pf-v5-global--Color--100);
   border-top: 1.5px solid var(--pf-v5-global--palette--black-300);
 }
 
@@ -132,6 +131,10 @@ body,
 }
 
 .layout-template-card__featured {
+  z-index: 1;
+}
+
+.layout-template-card__action-toggle {
   z-index: 1;
 }
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -114,6 +114,18 @@ body,
   overflow-y: auto;
 }
 
+.dashboard-card-picker {
+  align-items: stretch;
+  margin-top: 1em;
+  /* Ensure left border is visible*/
+  margin-left: 1px;
+}
+
+.dashboard-card-picker  .catalog-tile-pf {
+  height: 100%;
+  border-top: 1.5px solid var(--pf-v5-global--palette--black-300);
+}
+
 .layout-template-picker {
   padding: 0 1em 1em 1em;
 }

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -15,6 +15,8 @@
  */
 
 import '@patternfly/react-core/dist/styles/base.css';
+import '@patternfly/quickstarts/dist/quickstarts.css';
+import '@patternfly/react-catalog-view-extension/dist/css/react-catalog-view-extension.css';
 import '@app/app.css';
 import '@app/Topology/styles/base.css';
 import '@i18n/config';

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -15,8 +15,8 @@
  */
 
 import '@patternfly/react-core/dist/styles/base.css';
-import '@patternfly/quickstarts/dist/quickstarts.css';
 import '@patternfly/react-catalog-view-extension/dist/css/react-catalog-view-extension.css';
+import '@patternfly/quickstarts/dist/quickstarts.min.css';
 import '@app/app.css';
 import '@app/Topology/styles/base.css';
 import '@i18n/config';

--- a/stylePaths.js
+++ b/stylePaths.js
@@ -14,6 +14,6 @@ module.exports = {
     path.resolve(__dirname, "node_modules/@patternfly/react-topology/node_modules/@patternfly/react-styles/css"),
     path.resolve(__dirname, "node_modules/@patternfly/react-catalog-view-extension/dist/css/react-catalog-view-extension.css"),
     path.resolve(__dirname, "node_modules/@patternfly/react-catalog-view-extension/node_modules/@patternfly/react-styles/css"),
-    path.resolve(__dirname, 'node_modules/@patternfly/quickstarts/dist/quickstarts.css') 
+    path.resolve(__dirname, 'node_modules/@patternfly/quickstarts/dist/quickstarts.min.css'),
   ]
 }

--- a/stylePaths.js
+++ b/stylePaths.js
@@ -1,0 +1,19 @@
+const path = require('path');
+module.exports = {
+  stylePaths: [
+    path.resolve(__dirname, 'src'),
+    path.resolve(__dirname, 'node_modules/patternfly'),
+    path.resolve(__dirname, 'node_modules/@patternfly/patternfly'),
+    path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css'),
+    path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/base.css'),
+    path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/esm/@patternfly/patternfly'),
+    path.resolve(__dirname, 'node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles/css'),
+    path.resolve(__dirname, 'node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles/css'),
+    path.resolve(__dirname, 'node_modules/@patternfly/quickstarts/dist/quickstarts.css'),
+    path.resolve(__dirname, 'node_modules/@patternfly/react-topology/dist/esm/css'),
+    path.resolve(__dirname, "node_modules/@patternfly/react-topology/node_modules/@patternfly/react-styles/css"),
+    path.resolve(__dirname, "node_modules/@patternfly/react-catalog-view-extension/dist/css/react-catalog-view-extension.css"),
+    path.resolve(__dirname, "node_modules/@patternfly/react-catalog-view-extension/node_modules/@patternfly/react-styles/css"),
+    path.resolve(__dirname, 'node_modules/@patternfly/quickstarts/dist/quickstarts.css') 
+  ]
+}

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -3,6 +3,7 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 const ESLintPlugin = require('eslint-webpack-plugin');
 const { EnvironmentPlugin } = require('webpack');
+const { stylePaths } = require('./stylePaths');
 
 const HOST = process.env.HOST || "localhost";
 const PORT = process.env.PORT || "9000";
@@ -41,20 +42,7 @@ module.exports = merge(common('development'), {
     rules: [
       {
         test: /\.css$/,
-        include: [
-          path.resolve(__dirname, 'src'),
-          path.resolve(__dirname, 'node_modules/patternfly'),
-          path.resolve(__dirname, 'node_modules/@patternfly/patternfly'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/base.css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/esm/@patternfly/patternfly'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles/css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles/css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/quickstarts/dist/quickstarts.css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-topology/dist/esm/css'),
-          path.resolve(__dirname, "node_modules/@patternfly/react-topology/node_modules/@patternfly/react-styles/css"),
-          path.resolve(__dirname, "node_modules/@patternfly/react-catalog-view-extension/node_modules/@patternfly/react-styles/css")
-        ],
+        include: [...stylePaths],
         use: ['style-loader', 'css-loader']
       }
     ]

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -5,6 +5,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const TerserJSPlugin = require('terser-webpack-plugin');
 const { EnvironmentPlugin } = require('webpack');
+const { stylePaths } = require('./stylePaths');
 
 module.exports = merge(common('production'), {
   mode: 'production',
@@ -50,20 +51,7 @@ module.exports = merge(common('production'), {
     rules: [
       {
         test: /\.css$/,
-        include: [
-          path.resolve(__dirname, 'src'),
-          path.resolve(__dirname, 'node_modules/patternfly'),
-          path.resolve(__dirname, 'node_modules/@patternfly/patternfly'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-styles/css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/base.css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/esm/@patternfly/patternfly'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles/css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles/css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/quickstarts/dist/quickstarts.css'),
-          path.resolve(__dirname, 'node_modules/@patternfly/react-topology/dist/esm/css'),
-          path.resolve(__dirname, "node_modules/@patternfly/react-topology/node_modules/@patternfly/react-styles/css"),
-          path.resolve(__dirname, "node_modules/@patternfly/react-catalog-view-extension/node_modules/@patternfly/react-styles/css")
-        ],
+        include: [...stylePaths],
         use: [MiniCssExtractPlugin.loader, 'css-loader']
       }
     ]


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1303 

## Description of the change:

- Upgrade Dashboard view to Patternfly 5.
- Upgraded QuickStart to Patternfly 5
  - Only need to add missing imported css module for quickstart package.
  - Still there is a small bug with TIP admonition styling.
- Moved common css style paths to a JS module to avoid having to change both places in webpack configs.
- Updated Grafana dashboard panel's id. I organized the enum in order of increasing id (top down), similar to what being displayed on Grafana.

## Minor changes

| Changes | Description | Screenshot |
|--------------|-------------------|------------------|
| Newly organized toolbar for Automatic Analysis Card | Filter items are brought together. View mode is displayed as a toggle group (similar to theme toggle). Buttons also have tooltips now |  ![image](https://github.com/user-attachments/assets/cf5925ea-b2f6-47c1-b850-9dbf05c99f04) |
| Sort is defaulted to `Name` | There is no options to "unsort" (after selecting sort option) so it makes sense to just default to one. Template picker modal is now a bit large to allow spaces for previews | ![image](https://github.com/user-attachments/assets/a554fde6-3c4c-4a2d-9b54-962db21241e8) |
| Use `CatalogTile` component for dashboard selection | This helps bring consistency with the template picker | ![image](https://github.com/user-attachments/assets/e4d27536-9dab-4b16-b320-a2befbf6b26e) |

