### PR TITLE
chore(pf5): upgrade 404 page to Patternfly 5

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -391,6 +391,11 @@
       "LISTBOX": "Select AM or PM"
     }
   },
+  "NotFound": {
+    "DESCRIPTION": "The page you're trying to find was either removed, moved or maybe the URL isn't quite right. Try returning home or visit one of the following pages below.",
+    "HOME_REDIRECT_BUTTON_CONTENT": "Return to home page",
+    "TITLE": "404: We couldn't find that page"
+  },
   "QuickStarts": {
     "CATALOG_PAGE": {
       "HINT": "Quick start tutorials to get started with Cryostat.",

--- a/src/app/NotFound/NotFound.tsx
+++ b/src/app/NotFound/NotFound.tsx
@@ -26,15 +26,19 @@ import {
   EmptyStateActions,
   EmptyStateHeader,
   EmptyStateFooter,
+  Gallery,
+  GalleryItem,
 } from '@patternfly/react-core';
 import { MapMarkedAltIcon } from '@patternfly/react-icons';
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { NotFoundCard } from './NotFoundCard';
 
 export interface NotFoundProps {}
 
 export const NotFound: React.FC<NotFoundProps> = (_) => {
+  const { t } = useTranslation();
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [activeLevel, setActiveLevel] = React.useState(FeatureLevel.PRODUCTION);
@@ -59,18 +63,26 @@ export const NotFound: React.FC<NotFoundProps> = (_) => {
 
   return (
     <>
-      <EmptyState className="pf-c-empty-state-not-found">
+      <EmptyState>
         <EmptyStateHeader
-          titleText="404: We couldn't find that page"
+          titleText={t('NotFound.TITLE')}
           icon={<EmptyStateIcon icon={MapMarkedAltIcon} />}
           headingLevel="h4"
         />
-        <EmptyStateBody>One of the following pages might have what you&apos;re looking for.</EmptyStateBody>
+        <EmptyStateBody>{t('NotFound.DESCRIPTION')}</EmptyStateBody>
         <EmptyStateFooter>
-          <EmptyStateActions>{cards}</EmptyStateActions>
-          <Button variant="primary" component={(props) => <Link {...props} to="/" />}>
-            Take me home
-          </Button>
+          <EmptyStateActions>
+            <Button variant="primary" component={(props) => <Link {...props} to="/" />}>
+              {t('NotFound.HOME_REDIRECT_BUTTON_CONTENT')}
+            </Button>
+          </EmptyStateActions>
+          <EmptyStateActions>
+            <Gallery hasGutter style={{ marginTop: '1rem' }}>
+              {cards.map((card, idx) => (
+                <GalleryItem key={idx}>{card}</GalleryItem>
+              ))}
+            </Gallery>
+          </EmptyStateActions>
         </EmptyStateFooter>
       </EmptyState>
     </>

--- a/src/app/NotFound/NotFoundCard.tsx
+++ b/src/app/NotFound/NotFoundCard.tsx
@@ -27,14 +27,12 @@ export interface NotFoundCardProps {
 
 export const NotFoundCard: React.FC<NotFoundCardProps> = ({ title, bodyText, linkText, linkPath }) => {
   return (
-    <>
-      <Card className="pf-c-card-not-found">
-        <CardTitle>{title}</CardTitle>
-        <CardBody>{bodyText}</CardBody>
-        <CardFooter className="pf-c-card-not-found__footer">
-          <Link to={linkPath}>{linkText}</Link>
-        </CardFooter>
-      </Card>
-    </>
+    <Card isFullHeight isCompact isFlat isRounded>
+      <CardTitle>{title}</CardTitle>
+      <CardBody isFilled>{bodyText}</CardBody>
+      <CardFooter>
+        <Link to={linkPath}>{linkText}</Link>
+      </CardFooter>
+    </Card>
   );
 };


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1303

## Description of the change:

Upgraded 404 page to Patternfly 5. Looks like the styling from EmptyState is also centering the texts.

![image](https://github.com/user-attachments/assets/c423973f-c5aa-441d-8a2a-5fe95ca0f7e4)
