### PR TITLE
fix(about): add missing buildInfo in mocked health response

### DIFF
--- a/src/app/Recordings/Filters/DatetimeFilter.tsx
+++ b/src/app/Recordings/Filters/DatetimeFilter.tsx
@@ -55,7 +55,7 @@ export interface DateTimeRange {
   to?: Date;
 }
 
-export const filterRecordingByDatetime = (recordings?: ActiveRecording[], filters?: DateTimeRange[]) => {
+export const filterRecordingByDatetime = (recordings: ActiveRecording[], filters?: DateTimeRange[]) => {
   if (!recordings?.length || !filters?.length) {
     return recordings;
   }

--- a/src/app/Recordings/Filters/DurationFilter.tsx
+++ b/src/app/Recordings/Filters/DurationFilter.tsx
@@ -38,7 +38,7 @@ import { DURATION_INPUT_MAXLENGTH } from './const';
 
 export const CONTINUOUS_INDICATOR = 'continuous';
 
-export const filterRecordingByDuration = (recordings?: ActiveRecording[], filters?: DurationRange[]) => {
+export const filterRecordingByDuration = (recordings: ActiveRecording[], filters?: DurationRange[]) => {
   if (!recordings?.length || !filters?.length) {
     return recordings;
   }

--- a/src/mirage/index.ts
+++ b/src/mirage/index.ts
@@ -68,8 +68,8 @@ export const startMirage = ({ environment = 'development' } = {}) => {
       this.get('health', () => ({
         build: {
           git: {
-            hash: "775aee4cdd61f5b8d91aa38f4601933c9750d54e"
-          }
+            hash: '775aee4cdd61f5b8d91aa38f4601933c9750d54e',
+          },
         },
         cryostatVersion: `${build.version.replace(/(-\w+)*$/g, '')}-0-preview`,
         dashboardAvailable: false,
@@ -102,6 +102,11 @@ export const startMirage = ({ environment = 'development' } = {}) => {
         () => new Response(400, {}, 'Resource downloads are not supported in this demo'),
       );
       this.post('api/v2/targets', (schema, request) => {
+        const params = request.queryParams;
+        if (params['dryrun']) {
+          return new Response(200);
+        }
+
         const attrs = request.requestBody as any;
         const target = schema.create(Resource.TARGET, {
           jvmId: `${Date.now().toString(16)}`,

--- a/src/mirage/index.ts
+++ b/src/mirage/index.ts
@@ -66,6 +66,11 @@ export const startMirage = ({ environment = 'development' } = {}) => {
       this.logging = environment === 'development';
 
       this.get('health', () => ({
+        build: {
+          git: {
+            hash: "775aee4cdd61f5b8d91aa38f4601933c9750d54e"
+          }
+        },
         cryostatVersion: `${build.version.replace(/(-\w+)*$/g, '')}-0-preview`,
         dashboardAvailable: false,
         dashboardConfigured: false,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1303 #1315 

## Description of the change:


- Updated Mirage API mocks to include git commit hash.
- Fixed Mirage `/api/v2/targets` API route to consider `dryrun` query parameter.
- Fixed some remaining type-check issues.

## Motivations

Previously, About page is throwing error in preview mode.

![image](https://github.com/user-attachments/assets/373b499f-d15f-4c7e-bb2e-644c08581c56)
