### PR TITLE
fix(topology): filter options should show unique value only

### DIFF
--- a/src/app/Topology/Toolbar/TopologyFilters.tsx
+++ b/src/app/Topology/Toolbar/TopologyFilters.tsx
@@ -209,20 +209,19 @@ export const TopologyFilter: React.FC<TopologyFilterProps> = ({ isDisabled }) =>
                     return !criteria || !criteria.includes(val);
                   }
                   return true;
-                })
-                .map<TopologyFilterSelectOption>((val) => ({
-                  value: val,
-                  render: () =>
-                    isLabelOrAnnotation(cat) ? (
-                      <Label color="grey" textMaxWidth={LABEL_TEXT_MAXWIDTH}>
-                        {val}
-                      </Label>
-                    ) : (
-                      val
-                    ),
-                })),
+                }),
             ),
-          ),
+          ).map<TopologyFilterSelectOption>((val) => ({
+            value: val,
+            render: () =>
+              isLabelOrAnnotation(cat) ? (
+                <Label color="grey" textMaxWidth={LABEL_TEXT_MAXWIDTH}>
+                  {val}
+                </Label>
+              ) : (
+                val
+              ),
+          })),
         }))
         .filter((group) => group.options && group.options.length); // Do show show empty groups
 
@@ -267,20 +266,19 @@ export const TopologyFilter: React.FC<TopologyFilterProps> = ({ isDisabled }) =>
                 .filter((val) => {
                   const criteria: string[] = targetFilters.filters[cat];
                   return !criteria || !criteria.includes(val);
-                })
-                .map<TopologyFilterSelectOption>((val) => ({
-                  value: val,
-                  render: () =>
-                    isLabelOrAnnotation(cat) ? (
-                      <Label color="grey" textMaxWidth={LABEL_TEXT_MAXWIDTH}>
-                        {val}
-                      </Label>
-                    ) : (
-                      val
-                    ),
-                })),
+                }),
             ),
-          ),
+          ).map<TopologyFilterSelectOption>((val) => ({
+            value: val,
+            render: () =>
+              isLabelOrAnnotation(cat) ? (
+                <Label color="grey" textMaxWidth={LABEL_TEXT_MAXWIDTH}>
+                  {val}
+                </Label>
+              ) : (
+                val
+              ),
+          })),
         },
       ];
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1339 

## Description of the change:

Fixed the topology filter menu list to include only unique options. The `new Set` should be called on the array of strings before transforming to `ReactNode`.

## Motivation for the change:

| Previous | Now |
|:--:|:--:|
| ![image](https://github.com/user-attachments/assets/058042ce-3ee8-4279-8142-5744b15abb0a) | ![image](https://github.com/user-attachments/assets/1d4f0c5a-34be-4fdf-a904-a366ac7fd036)|


