### PR TITLE
fix(credentials): number of matched targets should be updated corretly on notification

### DIFF
--- a/src/app/SecurityPanel/Credentials/StoredCredentials.tsx
+++ b/src/app/SecurityPanel/Credentials/StoredCredentials.tsx
@@ -244,15 +244,21 @@ export const StoredCredentials = () => {
         .messages(NotificationCategory.CredentialsStored)
         .pipe(
           concatMap(({ message }) => {
-            // FiXME: This is a workaround to correct the numMatchingTargets (i.e. notification always return 0)
-            return context.api.getCredential(message.id).pipe(map((cred) => [message.id, cred]));
+            // FIXME: This is a workaround to correct the numMatchingTargets (i.e. notification always return 0)
+            return context.api.getCredential(message.id).pipe(
+              map((cred) => ({
+                id: message.id,
+                matchExpression: cred.matchExpression,
+                numMatchingTargets: cred.targets.length,
+              })),
+            );
           }),
         )
-        .subscribe(([id, cred]) => {
+        .subscribe((cred) => {
           dispatch({
             type: Actions.HANDLE_CREDENTIALS_STORED_NOTIFICATION,
             payload: {
-              credential: { id: id, matchExpression: cred.matchExpression, numMatchingTargets: cred.targets.length },
+              credential: cred,
             },
           });
         }),

--- a/src/app/SecurityPanel/Credentials/StoredCredentials.tsx
+++ b/src/app/SecurityPanel/Credentials/StoredCredentials.tsx
@@ -63,7 +63,7 @@ import { TFunction } from 'i18next';
 import _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { forkJoin } from 'rxjs';
+import { concatMap, forkJoin, map } from 'rxjs';
 import { SecurityCard } from '../types';
 import { CreateCredentialModal } from './CreateCredentialModal';
 import { MatchedTargetsTable } from './MatchedTargetsTable';
@@ -240,9 +240,22 @@ export const StoredCredentials = () => {
 
   React.useEffect(() => {
     addSubscription(
-      context.notificationChannel.messages(NotificationCategory.CredentialsStored).subscribe((v) => {
-        dispatch({ type: Actions.HANDLE_CREDENTIALS_STORED_NOTIFICATION, payload: { credential: v.message } });
-      }),
+      context.notificationChannel
+        .messages(NotificationCategory.CredentialsStored)
+        .pipe(
+          concatMap(({ message }) => {
+            // FiXME: This is a workaround to correct the numMatchingTargets (i.e. notification always return 0)
+            return context.api.getCredential(message.id).pipe(map((cred) => [message.id, cred]));
+          }),
+        )
+        .subscribe(([id, cred]) => {
+          dispatch({
+            type: Actions.HANDLE_CREDENTIALS_STORED_NOTIFICATION,
+            payload: {
+              credential: { id: id, matchExpression: cred.matchExpression, numMatchingTargets: cred.targets.length },
+            },
+          });
+        }),
     );
   }, [addSubscription, context, context.notificationChannel]);
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1303 

## Description of the change:

Added an additional API fetch to obtain the up-to-date number of matched targets for a credential since the notification message always returns 0.

There is a small side effect: there is a gap between the time when the notification message is received and the table is updated. I think this is still better than the potential confusion when the number of matched targets is 0 (when it should not be).

## Motivation for the change:

See https://github.com/cryostatio/cryostat-web/pull/1303#issuecomment-2349295493
