### PR TITLE
fix(custom-target): validation icons should have correct color

### DIFF
--- a/src/app/Topology/Actions/CreateTarget.tsx
+++ b/src/app/Topology/Actions/CreateTarget.tsx
@@ -457,12 +457,12 @@ export const SampleNodeDonut: React.FC<SampleNodeDonutProps> = ({
     }
     return validation.option === ValidatedOptions.success
       ? {
-          icon: <CheckCircleIcon color="var(--pf-global--success-color--100)" />,
+          icon: <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />,
           message: 'Target definition is valid.',
         }
       : validation.option === ValidatedOptions.error
         ? {
-            icon: <ExclamationCircleIcon color="var(--pf-global--danger-color--100)" />,
+            icon: <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />,
             message: validation.errorMessage,
           }
         : { icon: <PendingIcon />, message: '' };


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1303 

## Description of the change:

Updated the css class to use prefix `pf-v5-` such that the correct color is applied. This was missed during upgrades.

| Before | After |
|:---:|:---:|
| ![image](https://github.com/user-attachments/assets/14daeb42-a4b6-438e-a638-cdbd72a3c24a) | ![image](https://github.com/user-attachments/assets/7aae94d0-e6c5-420b-a475-41d57d6884bb) |
|  ![image](https://github.com/user-attachments/assets/cb82b05f-9454-4b51-a67d-970fd7e04011) | ![image](https://github.com/user-attachments/assets/0ea16a14-4364-4d27-93fe-b31d829e7f1a)|