### PR TITLE
fix(webpack): set publicPath to / in dev mode

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -46,6 +46,9 @@ module.exports = merge(common('development'), {
         use: ['style-loader', 'css-loader']
       }
     ]
+  },
+  output: {
+    publicPath: "/"
   }
 });
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1175 

## Description of the change:

Set the `publicPath` in `webpack.dev` to `/`, which configures the web assets path to `/<asset-path>` when using with hot-reload server.

This way, directly accessing sub-path such as `/rules/create` should work. It makes workflow easier when we are working on sub views (i.e. create rules, recordings, etc).