### PR TITLE
feat(eventtemplates): enable custom event template UI to display when no target is selected

### DIFF
--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -165,9 +165,10 @@ export const EventTemplates: React.FC<EventTemplatesProps> = () => {
       context.target
         .target()
         .pipe(
-          filter((target) => !!target),
           first(),
-          concatMap((target: Target) => context.api.getTargetEventTemplates(target)),
+          concatMap((target: Target) =>
+            target ? context.api.getTargetEventTemplates(target) : context.api.getEventTemplates(),
+          ),
         )
         .subscribe({
           next: handleTemplates,

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -62,7 +62,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { forkJoin, Observable, of } from 'rxjs';
-import { catchError, concatMap, defaultIfEmpty, filter, first, tap } from 'rxjs/operators';
+import { catchError, concatMap, defaultIfEmpty, first, tap } from 'rxjs/operators';
 
 const tableColumns: TableColumn[] = [
   {

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -86,11 +86,9 @@ export const EventTabs: React.FC<TabsProps> = ({ targetSelected }) => {
       <Tab eventKey={EventTab.EVENT_TEMPLATE} title="Event Templates">
         <EventTemplates />
       </Tab>
-      {targetSelected && (
-        <Tab eventKey={EventTab.EVENT_TYPE} title="Event types">
-          <EventTypes />
-        </Tab>
-      )}
+      <Tab isAriaDisabled={!targetSelected} eventKey={EventTab.EVENT_TYPE} title="Event types">
+        <EventTypes />
+      </Tab>
     </Tabs>
   );
 };
@@ -136,20 +134,18 @@ export const AgentTabs: React.FC<TabsProps> = ({ targetSelected }) => {
       <Tab eventKey={AgentTab.AGENT_TEMPLATE} title="Probe Templates">
         <AgentProbeTemplates agentDetected={agentDetected} />
       </Tab>
-      {targetSelected && (
-        <Tab
-          eventKey={AgentTab.AGENT_PROBE}
-          title="Live Configuration"
-          isAriaDisabled={!agentDetected}
-          tooltip={
-            agentDetected ? undefined : (
-              <Tooltip content="JMC ByteCode Instrumentation Agent not detected for the selected Target JVM" />
-            )
-          }
-        >
-          <AgentLiveProbes />
-        </Tab>
-      )}
+      <Tab
+        eventKey={AgentTab.AGENT_PROBE}
+        title="Live Configuration"
+        isAriaDisabled={!targetSelected || !agentDetected}
+        tooltip={
+          agentDetected ? undefined : (
+            <Tooltip content="JMC ByteCode Instrumentation Agent not detected for the selected Target JVM" />
+          )
+        }
+      >
+        <AgentLiveProbes />
+      </Tab>
     </Tabs>
   );
 };

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -16,7 +16,6 @@
 import { AgentLiveProbes } from '@app/Agent/AgentLiveProbes';
 import { AgentProbeTemplates } from '@app/Agent/AgentProbeTemplates';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { TargetView } from '@app/TargetView/TargetView';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { getActiveTab, switchTab } from '@app/utils/utils';
 import { Card, CardBody, Tab, Tabs, Tooltip } from '@patternfly/react-core';
@@ -31,26 +30,18 @@ import { TargetContextSelector } from '@app/TargetView/TargetContextSelector';
 export interface EventsProps {}
 
 export const Events: React.FC<EventsProps> = ({ ...props }) => {
-  const context = React.useContext(ServiceContext);
-  const addSubscription = useSubscriptions();
-  const [targetSelected, setTargetSelected] = React.useState(false);
-
-  React.useEffect(() => {
-    addSubscription(context.target.target().subscribe((t) => setTargetSelected(!!t)));
-  }, [context, context.target, setTargetSelected]);
-
   return (
     <>
       <TargetContextSelector />
       <BreadcrumbPage {...props} pageTitle="Events">
-        <Card>
+        <Card isFullHeight>
           <CardBody isFilled>
-            <EventTabs targetSelected={targetSelected} />
+            <EventTabs />
           </CardBody>
         </Card>
         <Card isFullHeight>
           <CardBody isFilled>
-            <AgentTabs targetSelected={targetSelected} />
+            <AgentTabs />
           </CardBody>
         </Card>
       </BreadcrumbPage>
@@ -63,13 +54,18 @@ enum EventTab {
   EVENT_TYPE = 'event-type',
 }
 
-export interface TabsProps {
-  targetSelected: boolean;
-}
+export const EventTabs: React.FC = () => {
+  const context = React.useContext(ServiceContext);
+  const addSubscription = useSubscriptions();
 
-export const EventTabs: React.FC<TabsProps> = ({ targetSelected }) => {
   const { search, pathname } = useLocation();
   const navigate = useNavigate();
+
+  const [targetSelected, setTargetSelected] = React.useState(false);
+
+  React.useEffect(() => {
+    addSubscription(context.target.target().subscribe((t) => setTargetSelected(!!t)));
+  }, [addSubscription, context, context.target]);
 
   const activeTab = React.useMemo(() => {
     return getActiveTab(search, 'eventTab', Object.values(EventTab), EventTab.EVENT_TEMPLATE);
@@ -98,12 +94,18 @@ enum AgentTab {
   AGENT_PROBE = 'agent-probe',
 }
 
-export const AgentTabs: React.FC<TabsProps> = ({ targetSelected }) => {
+export const AgentTabs: React.FC = () => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
 
   const { search, pathname } = useLocation();
   const navigate = useNavigate();
+
+  const [targetSelected, setTargetSelected] = React.useState(false);
+
+  React.useEffect(() => {
+    addSubscription(context.target.target().subscribe((t) => setTargetSelected(!!t)));
+  }, [addSubscription, context, context.target]);
 
   const activeTab = React.useMemo(() => {
     return getActiveTab(search, 'agentTab', Object.values(AgentTab), AgentTab.AGENT_TEMPLATE);

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -15,7 +15,9 @@
  */
 import { AgentLiveProbes } from '@app/Agent/AgentLiveProbes';
 import { AgentProbeTemplates } from '@app/Agent/AgentProbeTemplates';
+import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { TargetContextSelector } from '@app/TargetView/TargetContextSelector';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { getActiveTab, switchTab } from '@app/utils/utils';
 import { Card, CardBody, Tab, Tabs, Tooltip } from '@patternfly/react-core';
@@ -24,8 +26,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { concatMap, filter } from 'rxjs';
 import { EventTemplates } from './EventTemplates';
 import { EventTypes } from './EventTypes';
-import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
-import { TargetContextSelector } from '@app/TargetView/TargetContextSelector';
 
 export interface EventsProps {}
 

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -25,24 +25,48 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { concatMap, filter } from 'rxjs';
 import { EventTemplates } from './EventTemplates';
 import { EventTypes } from './EventTypes';
+import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
+import { TargetContextSelector } from '@app/TargetView/TargetContextSelector';
 
 export interface EventsProps {}
 
 export const Events: React.FC<EventsProps> = ({ ...props }) => {
+  const context = React.useContext(ServiceContext);
+  const addSubscription = useSubscriptions();
+  const [targetSelected, setTargetSelected] = React.useState(false);
+
+  React.useEffect(() => {
+    addSubscription(context.target.target().subscribe((t) => setTargetSelected(!!t)));
+  }, [context, context.target, setTargetSelected]);
+
   return (
-    <TargetView {...props} pageTitle="Events">
-      <Card isFullHeight>
-        <CardBody isFilled>
-          <EventTabs />
-        </CardBody>
-      </Card>
-      <Card isFullHeight>
-        <CardBody isFilled>
-          <AgentTabs />
-        </CardBody>
-      </Card>
-      <></>
-    </TargetView>
+    <>
+      <TargetContextSelector />
+      <BreadcrumbPage {...props} pageTitle="Events">
+        {targetSelected ? (
+          <>
+            <Card>
+              <CardBody isFilled>
+                <EventTabs targetSelected={targetSelected} />
+              </CardBody>
+            </Card>
+            <Card isFullHeight>
+              <CardBody isFilled>
+                <AgentTabs />
+              </CardBody>
+            </Card>
+          </>
+        ) : (
+          <>
+            <Card>
+              <CardBody isFilled>
+                <EventTabs targetSelected={targetSelected} />
+              </CardBody>
+            </Card>
+          </>
+        )}
+      </BreadcrumbPage>
+    </>
   );
 };
 
@@ -51,7 +75,11 @@ enum EventTab {
   EVENT_TYPE = 'event-type',
 }
 
-export const EventTabs: React.FC = () => {
+export interface EventTabsProps {
+  targetSelected: boolean;
+}
+
+export const EventTabs: React.FC<EventTabsProps> = (props: EventTabsProps) => {
   const { search, pathname } = useLocation();
   const navigate = useNavigate();
 
@@ -70,9 +98,11 @@ export const EventTabs: React.FC = () => {
       <Tab eventKey={EventTab.EVENT_TEMPLATE} title="Event Templates">
         <EventTemplates />
       </Tab>
-      <Tab eventKey={EventTab.EVENT_TYPE} title="Event types">
-        <EventTypes />
-      </Tab>
+      {props?.targetSelected && (
+        <Tab eventKey={EventTab.EVENT_TYPE} title="Event types">
+          <EventTypes />
+        </Tab>
+      )}
     </Tabs>
   );
 };

--- a/src/app/Events/Events.tsx
+++ b/src/app/Events/Events.tsx
@@ -43,28 +43,16 @@ export const Events: React.FC<EventsProps> = ({ ...props }) => {
     <>
       <TargetContextSelector />
       <BreadcrumbPage {...props} pageTitle="Events">
-        {targetSelected ? (
-          <>
-            <Card>
-              <CardBody isFilled>
-                <EventTabs targetSelected={targetSelected} />
-              </CardBody>
-            </Card>
-            <Card isFullHeight>
-              <CardBody isFilled>
-                <AgentTabs />
-              </CardBody>
-            </Card>
-          </>
-        ) : (
-          <>
-            <Card>
-              <CardBody isFilled>
-                <EventTabs targetSelected={targetSelected} />
-              </CardBody>
-            </Card>
-          </>
-        )}
+        <Card>
+          <CardBody isFilled>
+            <EventTabs targetSelected={targetSelected} />
+          </CardBody>
+        </Card>
+        <Card isFullHeight>
+          <CardBody isFilled>
+            <AgentTabs targetSelected={targetSelected} />
+          </CardBody>
+        </Card>
       </BreadcrumbPage>
     </>
   );
@@ -75,11 +63,11 @@ enum EventTab {
   EVENT_TYPE = 'event-type',
 }
 
-export interface EventTabsProps {
+export interface TabsProps {
   targetSelected: boolean;
 }
 
-export const EventTabs: React.FC<EventTabsProps> = (props: EventTabsProps) => {
+export const EventTabs: React.FC<TabsProps> = ({ targetSelected }) => {
   const { search, pathname } = useLocation();
   const navigate = useNavigate();
 
@@ -98,7 +86,7 @@ export const EventTabs: React.FC<EventTabsProps> = (props: EventTabsProps) => {
       <Tab eventKey={EventTab.EVENT_TEMPLATE} title="Event Templates">
         <EventTemplates />
       </Tab>
-      {props?.targetSelected && (
+      {targetSelected && (
         <Tab eventKey={EventTab.EVENT_TYPE} title="Event types">
           <EventTypes />
         </Tab>
@@ -112,7 +100,7 @@ enum AgentTab {
   AGENT_PROBE = 'agent-probe',
 }
 
-export const AgentTabs: React.FC = () => {
+export const AgentTabs: React.FC<TabsProps> = ({ targetSelected }) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
 
@@ -148,18 +136,20 @@ export const AgentTabs: React.FC = () => {
       <Tab eventKey={AgentTab.AGENT_TEMPLATE} title="Probe Templates">
         <AgentProbeTemplates agentDetected={agentDetected} />
       </Tab>
-      <Tab
-        eventKey={AgentTab.AGENT_PROBE}
-        title="Live Configuration"
-        isAriaDisabled={!agentDetected}
-        tooltip={
-          agentDetected ? undefined : (
-            <Tooltip content="JMC ByteCode Instrumentation Agent not detected for the selected Target JVM" />
-          )
-        }
-      >
-        <AgentLiveProbes />
-      </Tab>
+      {targetSelected && (
+        <Tab
+          eventKey={AgentTab.AGENT_PROBE}
+          title="Live Configuration"
+          isAriaDisabled={!agentDetected}
+          tooltip={
+            agentDetected ? undefined : (
+              <Tooltip content="JMC ByteCode Instrumentation Agent not detected for the selected Target JVM" />
+            )
+          }
+        >
+          <AgentLiveProbes />
+        </Tab>
+      )}
     </Tabs>
   );
 };

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -285,7 +285,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
                     : [];
                 }),
               ),
-              of([]),
+              context.api.getEventTemplates().pipe(catchError((_) => of<EventTemplate[]>([]))),
             ),
           ),
         )

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -592,7 +592,7 @@ export class ApiService {
 
     const body = new window.FormData();
     body.append('template', file);
-    return this.sendLegacyRequest('v4', 'templates', 'Template Upload Failed', {
+    return this.sendLegacyRequest('v4', 'event_templates', 'Template Upload Failed', {
       body: body,
       method: 'POST',
       headers: {},
@@ -1359,6 +1359,10 @@ export class ApiService {
     skipStatusCheck = false,
   ): Observable<ActiveRecording[]> {
     return this.doGet(`targets/${target.id}/recordings`, 'v4', undefined, suppressNotifications, skipStatusCheck);
+  }
+
+  getEventTemplates(suppressNotifications = false, skipStatusCheck = false): Observable<EventTemplate[]> {
+    return this.doGet<EventTemplate[]>('event_templates', 'v4', undefined, suppressNotifications, skipStatusCheck);
   }
 
   getTargetEventTemplates(

--- a/src/test/Rules/CreateRule.test.tsx
+++ b/src/test/Rules/CreateRule.test.tsx
@@ -43,6 +43,12 @@ const mockEventTemplate: EventTemplate = {
   provider: 'some provider',
   description: 'some description',
 };
+const mockCustomEventTemplate: EventTemplate = {
+  name: 'CustomTemplate',
+  type: 'CUSTOM',
+  provider: 'some provider',
+  description: 'some description',
+};
 
 const mockRule: Rule = {
   name: 'mockRule',
@@ -64,6 +70,7 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+jest.spyOn(defaultServices.api, 'getEventTemplates').mockReturnValue(of([mockCustomEventTemplate]));
 jest.spyOn(defaultServices.api, 'getTargetEventTemplates').mockReturnValue(of([mockEventTemplate]));
 
 jest.spyOn(defaultServices.targets, 'targets').mockReturnValue(of([mockTarget]));


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-web/issues/225

## Description of the change:
1. Allows the Event Templates view to be displayed even when there is no target selected. This allows the user to view, add, or remove Custom Event Templates without needing to select a target - particularly useful when there aren't any targets currently discovered.
2. Similarly, the Agent Probe Templates view is displayed when there is no target selected.
3. Fixes a similar bug on the Automated Rule creation form where the event template selections were limited to the set intersection of those available on the matched targets. If there were no matched targets (including if no targets are discovered), then the event template list would be empty. Now, if there are no matched targets, the non-target event template list (ie the custom templates, and the upcoming preset templates) will be provided as options.
4. Fixes an API V4 bug (oversight) where custom event templates cannot be uploaded

## How to manually test:
1. Build and run Cryostat with this PR
2. Go to Events view
3. Do not select a Target
5. Ensure that Event Templates and Agent Probe Templates views are visible, and that templates can be listed/added/removed from each
6. Select a Target, creating one (`localhost:0`) if necessary
7. Repeat step 4, and ensure that target-specific views (ex. Event Types) are now also interactable as normal
