### PR TITLE
fix(eventtypes): remove duplicate word in search placeholder

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -367,7 +367,7 @@
     "ARIA_LABELS": {
       "SEARCH_INPUT": "event-type-search-input"
     },
-    "SEARCH_PLACEHOLDER": "Find by name, description, typeId, or description..."
+    "SEARCH_PLACEHOLDER": "Find by name, typeId, or description..."
   },
   "ImportCertificate": {
     "CARD_DESCRIPTION": "The following certificates are present in Cryostat&apos's additional trust store. Contact your Cryostat administrator if your application requires a new trusted certificate. You must restart the Cryostat server to reload the certificate store after adding new certificates.",

--- a/src/test/Events/__snapshots__/EventTypes.test.tsx.snap
+++ b/src/test/Events/__snapshots__/EventTypes.test.tsx.snap
@@ -59,7 +59,7 @@ Array [
                   disabled={false}
                   name="eventFilter"
                   onChange={[Function]}
-                  placeholder="Find by name, description, typeId, or description..."
+                  placeholder="Find by name, typeId, or description..."
                   type="text"
                   value=""
                 />


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Since #1303

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
