### PR TITLE
fix(storedcredentials): define target match array to avoid undefined reference error

### DIFF
--- a/src/app/SecurityPanel/Credentials/StoredCredentials.tsx
+++ b/src/app/SecurityPanel/Credentials/StoredCredentials.tsx
@@ -249,6 +249,7 @@ export const StoredCredentials = () => {
               map((cred) => ({
                 id: message.id,
                 matchExpression: cred.matchExpression,
+                targets: cred.targets,
                 numMatchingTargets: cred.targets.length,
               })),
             );
@@ -425,7 +426,7 @@ export const StoredCredentials = () => {
               <Icon iconSize="md">
                 <ContainerNodeIcon />
               </Icon>
-              <span style={{ marginLeft: 'var(--pf-v5-global--spacer--sm)' }}>{credential.targets.length}</span>
+              <span style={{ marginLeft: 'var(--pf-v5-global--spacer--sm)' }}>{credential?.targets?.length ?? 0}</span>
             </Button>
           </Td>
         </Tr>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat/issues/756

## Description of the change:
When a `CredentialsStored` notification is emitted, use the contents of that notification to patch the client-side model of the stored Credentials objects. The original returned value from the API response [does not contain](https://github.com/cryostatio/cryostat/blob/443c9c09ec8dd819476b661eb8a384d64d3cbefb/src/main/java/io/cryostat/credentials/Credentials.java#L157) the real value, so this workaround keeps the UI in sync and avoids a `t.targets is undefined` error.

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. See https://github.com/cryostatio/cryostat/issues/756
