### PR TITLE
build(deps): bump nanoid from 3.3.4 to 3.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "i18next-parser": "^9.0.2",
     "js-base64": "3.7.7",
     "lodash": "^4.17.21",
-    "nanoid": "^3.3.8",
+    "nanoid": "3.3.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "i18next-parser": "^9.0.2",
     "js-base64": "3.7.7",
     "lodash": "^4.17.21",
-    "nanoid": "^3.3.4",
+    "nanoid": "^3.3.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^15.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4392,7 +4392,7 @@ __metadata:
     mini-css-extract-plugin: ^2.9.1
     miragejs: ^0.1.48
     mock-socket: ^9.3.1
-    nanoid: ^3.3.4
+    nanoid: ^3.3.8
     npm-run-all: ^4.1.5
     prettier: ^3.3.3
     prop-types: ^15.7.2
@@ -10021,21 +10021,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.4":
-  version: 3.3.4
-  resolution: "nanoid@npm:3.3.4"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 2fddd6dee994b7676f008d3ffa4ab16035a754f4bb586c61df5a22cf8c8c94017aadd360368f47d653829e0569a92b129979152ff97af23a558331e47e37cd9c
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.7":
   version: 3.3.7
   resolution: "nanoid@npm:3.3.7"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: d36c427e530713e4ac6567d488b489a36582ef89da1d6d4e3b87eded11eb10d7042a877958c6f104929809b2ab0bafa17652b076cdf84324aa75b30b722204f2
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.3.8":
+  version: 3.3.8
+  resolution: "nanoid@npm:3.3.8"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: dfe0adbc0c77e9655b550c333075f51bb28cfc7568afbf3237249904f9c86c9aaaed1f113f0fddddba75673ee31c758c30c43d4414f014a52a7a626efc5958c9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4392,7 +4392,7 @@ __metadata:
     mini-css-extract-plugin: ^2.9.1
     miragejs: ^0.1.48
     mock-socket: ^9.3.1
-    nanoid: ^3.3.8
+    nanoid: 3.3.8
     npm-run-all: ^4.1.5
     prettier: ^3.3.3
     prop-types: ^15.7.2
@@ -10021,21 +10021,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:3.3.8":
+  version: 3.3.8
+  resolution: "nanoid@npm:3.3.8"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: dfe0adbc0c77e9655b550c333075f51bb28cfc7568afbf3237249904f9c86c9aaaed1f113f0fddddba75673ee31c758c30c43d4414f014a52a7a626efc5958c9
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.7":
   version: 3.3.7
   resolution: "nanoid@npm:3.3.7"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: d36c427e530713e4ac6567d488b489a36582ef89da1d6d4e3b87eded11eb10d7042a877958c6f104929809b2ab0bafa17652b076cdf84324aa75b30b722204f2
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.8":
-  version: 3.3.8
-  resolution: "nanoid@npm:3.3.8"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: dfe0adbc0c77e9655b550c333075f51bb28cfc7568afbf3237249904f9c86c9aaaed1f113f0fddddba75673ee31c758c30c43d4414f014a52a7a626efc5958c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See https://github.com/cryostatio/cryostat-web/pull/1493
https://github.com/ai/nanoid/issues/365

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
