### PR TITLE
build(deps): bump nanoid from 3.3.8 to 5.0.9

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -56,7 +56,7 @@ module.exports = {
     }
   },
 
-  // An array of regexp pattern strings that are matched against all source file paths before transformation. 
+  // An array of regexp pattern strings that are matched against all source file paths before transformation.
   // If the file path matches any of the patterns, it will not be transformed.
   transformIgnorePatterns: [
     "/node_modules/(?!@patternfly|d3|d3-array|internmap|delaunator|robust-predicates)",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "i18next-parser": "^9.0.2",
     "js-base64": "3.7.7",
     "lodash": "^4.17.21",
-    "nanoid": "^3.3.8",
+    "nanoid": "^5.0.9",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-i18next": "^15.1.0",

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,4 +1,4 @@
-// Mock out the services shared across the app in order to help isolate 
+// Mock out the services shared across the app in order to help isolate
 // components from the ServiceContext
 import '@i18n/config';
 
@@ -27,7 +27,7 @@ jest.mock('@i18n/datetime', () => ({
         short: 'EST',
       },
     ],
-  defaultDatetimeFormat: 
+  defaultDatetimeFormat:
     {
       dateLocale: {
         key: 'en',
@@ -51,3 +51,6 @@ jest.mock('@i18n/datetime', () => ({
     }
   ]
 }));
+jest.mock('nanoid', () => {
+  return { nanoid: () => '1234' };
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4392,7 +4392,7 @@ __metadata:
     mini-css-extract-plugin: ^2.9.1
     miragejs: ^0.1.48
     mock-socket: ^9.3.1
-    nanoid: ^3.3.8
+    nanoid: ^5.0.9
     npm-run-all: ^4.1.5
     prettier: ^3.3.3
     prop-types: ^15.7.2
@@ -10030,12 +10030,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.8":
-  version: 3.3.8
-  resolution: "nanoid@npm:3.3.8"
+"nanoid@npm:^5.0.9":
+  version: 5.0.9
+  resolution: "nanoid@npm:5.0.9"
   bin:
-    nanoid: bin/nanoid.cjs
-  checksum: dfe0adbc0c77e9655b550c333075f51bb28cfc7568afbf3237249904f9c86c9aaaed1f113f0fddddba75673ee31c758c30c43d4414f014a52a7a626efc5958c9
+    nanoid: bin/nanoid.js
+  checksum: 8a3f9104f81095e3e4785f58caae47a05755599824b8611b9730cbf73db706b664f100e6189f8303f08764f144d499613d8e4a39e83125c53f4b4986d6576621
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1518 #1515 #663
See https://github.com/ai/nanoid/issues/365#issuecomment-2035498047

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
