### PR TITLE
feat(i18n): allow setting i18n namespaces via an environment variable

### DIFF
--- a/LOCALIZATION.md
+++ b/LOCALIZATION.md
@@ -4,9 +4,9 @@ Cryostat-web uses [i18next](https://www.i18next.com/) as an internationalization
 
 ### Adding a new translation
 
-The current list of language locales supported in Cryostat can be found in `src/i18n/config.ts`. The translations themselves can be found in `locales/{LOCALE_CODE}` 
+The current list of language locales supported in Cryostat can be found in `src/i18n/i18nextUtil.ts`. The translations themselves can be found in `locales/{LOCALE_CODE}` 
 
-To add a new language, add a new entry to the `i18nResources` object in `src/i18n.ts`. The key should be the language locale, and the value should be the translation object containing the corresponding namespace json files in `locales`.
+To add a new language, add a new entry to the `i18nResources` object in `src/i18nextUtil.ts`. The key should be the language locale, and the value should be the translation object containing the corresponding namespace json files in `locales`.
 
 To add a new localization key for a user-facing string in `cryostat-web`, use the `t` function from `react-i18next`:
 

--- a/LOCALIZATION.md
+++ b/LOCALIZATION.md
@@ -11,10 +11,10 @@ To add a new language, add a new entry to the `i18nResources` object in `src/i18
 To add a new localization key for a user-facing string in `cryostat-web`, use the `t` function from `react-i18next`:
 
 ```tsx
-import { useTranslation } from 'react-i18next';
+import { useCryostatTranslation } from 'react-i18next';
 ...
 export const SomeFC = (props) => {
-    const { t } = useTranslation();
+    const { t } = useCryostatTranslation();
 
     return (
         <div>

--- a/src/app/About/About.tsx
+++ b/src/app/About/About.tsx
@@ -20,15 +20,15 @@ import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 import build from '@app/build.json';
 import { ThemeSetting } from '@app/Settings/types';
 import { useTheme } from '@app/utils/hooks/useTheme';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Brand, Card, CardBody, CardFooter, CardHeader } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { AboutDescription } from './AboutDescription';
 
 export interface AboutProps {}
 
 export const About: React.FC<AboutProps> = (_) => {
-  const { t } = useTranslation('public');
+  const { t } = useCryostatTranslation();
   const [theme] = useTheme();
 
   const logo = React.useMemo(() => (theme === ThemeSetting.DARK ? cryostatLogoDark : cryostatLogo), [theme]);
@@ -42,7 +42,7 @@ export const About: React.FC<AboutProps> = (_) => {
         <CardBody>
           <AboutDescription />
         </CardBody>
-        <CardFooter>{t('CRYOSTAT_TRADEMARK', { ns: 'common' })}</CardFooter>
+        <CardFooter>{t('CRYOSTAT_TRADEMARK')}</CardFooter>
       </Card>
     </BreadcrumbPage>
   );

--- a/src/app/About/AboutCryostatModal.tsx
+++ b/src/app/About/AboutCryostatModal.tsx
@@ -17,9 +17,9 @@ import bkgImg from '@app/assets/cryostat_icon_bg.svg';
 import cryostatLogo from '@app/assets/cryostat_icon_rgb_reverse.svg';
 import build from '@app/build.json';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { AboutModal } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { AboutDescription } from './AboutDescription';
 
 export interface AboutCryostatModalProps {
@@ -28,7 +28,7 @@ export interface AboutCryostatModalProps {
 }
 
 export const AboutCryostatModal: React.FC<AboutCryostatModalProps> = ({ isOpen, onClose }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   return (
     <AboutModal
       appendTo={portalRoot}
@@ -37,7 +37,7 @@ export const AboutCryostatModal: React.FC<AboutCryostatModalProps> = ({ isOpen, 
       brandImageAlt="Cryostat Logo"
       isOpen={isOpen}
       onClose={onClose}
-      trademark={t('CRYOSTAT_TRADEMARK', { ns: 'common' })}
+      trademark={t('CRYOSTAT_TRADEMARK')}
       backgroundImageSrc={bkgImg}
     >
       <AboutDescription />

--- a/src/app/About/AboutDescription.tsx
+++ b/src/app/About/AboutDescription.tsx
@@ -19,9 +19,9 @@ import { BuildInfo } from '@app/Shared/Services/api.types';
 import { NotificationsContext } from '@app/Shared/Services/Notifications.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Text, TextContent, TextList, TextListItem, TextVariants } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export const VERSION_REGEX = /^(v?[0-9]+\.[0-9]+\.[0-9]+)(?:-(.+))?$/;
 
@@ -30,7 +30,7 @@ export const AboutDescription: React.FC = () => {
   const notificationsContext = React.useContext(NotificationsContext);
   const [cryostatVersion, setCryostatVersion] = React.useState(undefined as string | undefined);
   const [buildInfo, setBuildInfo] = React.useState<BuildInfo>({ git: { hash: '' } });
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const addSubscription = useSubscriptions();
 
   React.useEffect(() => {

--- a/src/app/Agent/AgentLiveProbes.tsx
+++ b/src/app/Agent/AgentLiveProbes.tsx
@@ -23,6 +23,7 @@ import { EventProbe, NotificationCategory } from '@app/Shared/Services/api.types
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { sortResources, TableColumn } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   Toolbar,
@@ -51,7 +52,6 @@ import {
 } from '@patternfly/react-table';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { combineLatest } from 'rxjs';
 import { AboutAgentCard } from './AboutAgentCard';
 
@@ -89,7 +89,7 @@ export interface AgentLiveProbesProps {}
 
 export const AgentLiveProbes: React.FC<AgentLiveProbesProps> = () => {
   const context = React.useContext(ServiceContext);
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const addSubscription = useSubscriptions();
 
   const [probes, setProbes] = React.useState<EventProbe[]>([]);

--- a/src/app/Agent/AgentProbeTemplates.tsx
+++ b/src/app/Agent/AgentProbeTemplates.tsx
@@ -23,6 +23,7 @@ import { ProbeTemplate, NotificationCategory } from '@app/Shared/Services/api.ty
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { TableColumn, portalRoot, sortResources } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ActionGroup,
   Button,
@@ -62,7 +63,6 @@ import {
 } from '@patternfly/react-table';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { forkJoin, Observable, of } from 'rxjs';
 import { catchError, defaultIfEmpty, first, tap } from 'rxjs/operators';
 import { AboutAgentCard } from './AboutAgentCard';
@@ -86,7 +86,7 @@ export interface AgentProbeTemplatesProps {
 
 export const AgentProbeTemplates: React.FC<AgentProbeTemplatesProps> = ({ agentDetected }) => {
   const context = React.useContext(ServiceContext);
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const addSubscription = useSubscriptions();
 
   const [templates, setTemplates] = React.useState<ProbeTemplate[]>([]);
@@ -365,7 +365,7 @@ export interface AgentProbeTemplateUploadModalProps {
 }
 
 export const AgentProbeTemplateUploadModal: React.FC<AgentProbeTemplateUploadModalProps> = ({ onClose, isOpen }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const addSubscription = useSubscriptions();
   const context = React.useContext(ServiceContext);
   const submitRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to submit trigger div
@@ -478,7 +478,7 @@ export const AgentProbeTemplateUploadModal: React.FC<AgentProbeTemplateUploadMod
         <ActionGroup>
           {allOks && numOfFiles ? (
             <Button variant="primary" onClick={handleClose}>
-              {t('CLOSE', { ns: 'common' })}
+              {t('CLOSE')}
             </Button>
           ) : (
             <>
@@ -488,10 +488,10 @@ export const AgentProbeTemplateUploadModal: React.FC<AgentProbeTemplateUploadMod
                 isDisabled={!numOfFiles || uploading}
                 {...submitButtonLoadingProps}
               >
-                {t('SUBMIT', { ns: 'common' })}
+                {t('SUBMIT')}
               </Button>
               <Button variant="link" onClick={handleClose}>
-                {t('CANCEL', { ns: 'common' })}
+                {t('CANCEL')}
               </Button>
             </>
           )}
@@ -508,7 +508,7 @@ export interface AgentTemplateActionProps {
 }
 
 export const AgentTemplateAction: React.FC<AgentTemplateActionProps> = ({ onInsert, onDelete, template }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [isOpen, setIsOpen] = React.useState(false);
 
   const actionItems = React.useMemo(() => {

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -34,6 +34,7 @@ import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { useTheme } from '@app/utils/hooks/useTheme';
 import { saveToLocalStorage } from '@app/utils/LocalStorage';
 import { cleanDataId, isAssetNew, openTabForUrl, portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Alert,
   AlertActionCloseButton,
@@ -79,7 +80,7 @@ import {
 } from '@patternfly/react-icons';
 import _ from 'lodash';
 import * as React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 import { Link, matchPath, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { map } from 'rxjs/operators';
 import { LogoutIcon } from './LogoutIcon';
@@ -93,7 +94,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const serviceContext = React.useContext(ServiceContext);
   const notificationsContext = React.useContext(NotificationsContext);
   const addSubscription = useSubscriptions();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const {
     setState: setJoyState,
     state: joyState,

--- a/src/app/AppLayout/ThemeToggle.tsx
+++ b/src/app/AppLayout/ThemeToggle.tsx
@@ -17,17 +17,17 @@
 import { ThemeSetting } from '@app/Settings/types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useTheme } from '@app/utils/hooks/useTheme';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Icon, ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 import { SunIcon, MoonIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface ThemeToggleProps {}
 
 export const ThemeToggle: React.FC<ThemeToggleProps> = () => {
   const context = React.useContext(ServiceContext);
   const [_theme] = useTheme();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const handleThemeSelect = React.useCallback(
     (_, setting: ThemeSetting) => {

--- a/src/app/Archives/AllArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllArchivedRecordingsTable.tsx
@@ -22,6 +22,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSort } from '@app/utils/hooks/useSort';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { TableColumn, portalRoot, sortResources } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Toolbar,
   ToolbarContent,
@@ -54,7 +55,6 @@ import {
 } from '@patternfly/react-table';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Observable, of } from 'rxjs';
 import { getTargetFromDirectory, includesDirectory, indexOfDirectory } from './utils';
 
@@ -82,7 +82,7 @@ export interface AllArchivedRecordingsTableProps {}
 
 export const AllArchivedRecordingsTable: React.FC<AllArchivedRecordingsTableProps> = () => {
   const context = React.useContext(ServiceContext);
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [directories, setDirectories] = React.useState<_RecordingDirectory[]>([]);
   const [searchText, setSearchText] = React.useState('');

--- a/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllTargetsArchivedRecordingsTable.tsx
@@ -23,6 +23,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSort } from '@app/utils/hooks/useSort';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { hashCode, sortResources, TableColumn } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Toolbar,
   ToolbarContent,
@@ -53,7 +54,6 @@ import {
 import { TFunction } from 'i18next';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -103,7 +103,7 @@ export interface AllTargetsArchivedRecordingsTableProps {}
 
 export const AllTargetsArchivedRecordingsTable: React.FC<AllTargetsArchivedRecordingsTableProps> = () => {
   const context = React.useContext(ServiceContext);
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [searchText, setSearchText] = React.useState('');
   const [archivesForTargets, setArchivesForTargets] = React.useState<ArchivesForTarget[]>([]);

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -21,6 +21,7 @@ import { fakeChartContext, fakeServices } from '@app/utils/fakeData';
 import { useFeatureLevel } from '@app/utils/hooks/useFeatureLevel';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
 import {
   Bullseye,
@@ -79,7 +80,6 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { TFunction } from 'i18next';
 import { nanoid } from 'nanoid';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { Observable, of } from 'rxjs';
 import { ChartContext } from './Charts/context';
@@ -92,7 +92,7 @@ export interface AddCardProps {
 
 export const AddCard: React.FC<AddCardProps> = ({ variant }) => {
   const dispatch = useDispatch<StateDispatch>();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [showWizard, setShowWizard] = React.useState(false);
   const [selection, setSelection] = React.useState('');
@@ -240,7 +240,7 @@ export const AddCard: React.FC<AddCardProps> = ({ variant }) => {
         >
           <WizardStep
             id="card-type-select"
-            name={t('CARD_TYPE', { ns: 'common' })}
+            name={t('CARD_TYPE')}
             footer={{
               isNextDisabled: !selection,
               nextButtonText:
@@ -312,7 +312,7 @@ export interface CardGalleryProps {
 }
 
 export const CardGallery: React.FC<CardGalleryProps> = ({ selection, onSelect }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const activeLevel = useFeatureLevel();
   const [toViewCard, setToViewCard] = React.useState<DashboardCardDescriptor>();
 
@@ -444,7 +444,7 @@ interface PropsConfigFormProps {
 }
 
 const PropsConfigForm: React.FC<PropsConfigFormProps> = ({ onChange, ...props }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const handleChange = React.useCallback(
     (k: string) => (e: unknown) => {
       const copy = { ...props.config };

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.tsx
@@ -51,6 +51,7 @@ import { automatedAnalysisConfigToRecordingAttributes } from '@app/Shared/Servic
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { calculateAnalysisTimer, portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   CardBody,
@@ -96,7 +97,6 @@ import {
 } from '@patternfly/react-icons';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { concatMap, filter, first, map, tap } from 'rxjs';
 import { DashboardCard } from '../DashboardCard';
@@ -119,7 +119,7 @@ export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> 
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const dispatch = useDispatch<StateDispatch>();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [targetConnectURL, setTargetConnectURL] = React.useState('');
   const [results, setResults] = React.useState<AnalysisResult[]>([]);
@@ -445,7 +445,7 @@ export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> 
         if (errorMessage === NO_RECORDINGS_MESSAGE) {
           return [undefined, undefined];
         } else if (isAuthFail(errorMessage)) {
-          return [t('RETRY', { ns: 'common' }), generateReport];
+          return [t('RETRY'), generateReport];
         } else if (errorMessage === RECORDING_FAILURE_MESSAGE) {
           return [t('AutomatedAnalysisCard.RETRY_STARTING'), startProfilingRecording];
         } else if (errorMessage === FAILED_REPORT_MESSAGE) {
@@ -453,7 +453,7 @@ export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> 
         } else if (errorMessage === TEMPLATE_UNSUPPORTED_MESSAGE) {
           return [undefined, undefined];
         } else {
-          return [t('RETRY', { ns: 'common' }), generateReport];
+          return [t('RETRY'), generateReport];
         }
       }
       return [undefined, undefined];
@@ -619,7 +619,7 @@ export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> 
           <EmptyStateFooter>
             <EmptyStateActions>
               <Button variant="link" onClick={handleClearFilters}>
-                {t('CLEAR_FILTERS', { ns: 'common' })}
+                {t('CLEAR_FILTERS')}
               </Button>
               <Button variant="link" onClick={showUnavailableScores}>
                 {t('AutomatedAnalysisCard.TOOLBAR.CHECKBOX.SHOW_NA.LABEL')}
@@ -672,7 +672,7 @@ export const AutomatedAnalysisCard: DashboardCardFC<AutomatedAnalysisCardProps> 
         id="automated-analysis-toolbar"
         aria-label={t('AutomatedAnalysisCard.TOOLBAR.LABEL')}
         clearAllFilters={handleClearFilters}
-        clearFiltersButtonText={t('CLEAR_FILTERS', { ns: 'common' })}
+        clearFiltersButtonText={t('CLEAR_FILTERS')}
         isFullHeight
       >
         <ToolbarContent>
@@ -906,7 +906,7 @@ export interface AutomatedAnalysisHeaderLabelProps {
 
 export const AutomatedAnalysisHeaderLabel: React.FC<AutomatedAnalysisHeaderLabelProps> = (props) => {
   const dispatch = useDispatch();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [isHoveredOrFocused, setIsHoveredOrFocused] = React.useState(false);
   const handleHoveredOrFocused = React.useCallback(() => setIsHoveredOrFocused(true), [setIsHoveredOrFocused]);

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCardList.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCardList.tsx
@@ -133,9 +133,7 @@ export const AutomatedAnalysisCardList: React.FC<AutomatedAnalysisCardListProps>
                   <Td dataLabel={t('SCORE')} modifier="wrap">
                     <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                       <FlexItem>
-                        {result.score == AutomatedAnalysisScore.NA_SCORE
-                          ? t('N/A')
-                          : result.score.toFixed(1)}
+                        {result.score == AutomatedAnalysisScore.NA_SCORE ? t('N/A') : result.score.toFixed(1)}
                       </FlexItem>
                       <FlexItem>{icon(result.score)}</FlexItem>
                     </Flex>

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCardList.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCardList.tsx
@@ -15,6 +15,7 @@
  */
 
 import { CategorizedRuleEvaluations, AutomatedAnalysisScore } from '@app/Shared/Services/api.types';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
@@ -36,7 +37,6 @@ import {
   Tr,
 } from '@patternfly/react-table';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { transformAADescription } from './utils';
 
 export interface AutomatedAnalysisCardListProps {
@@ -44,7 +44,7 @@ export interface AutomatedAnalysisCardListProps {
 }
 
 export const AutomatedAnalysisCardList: React.FC<AutomatedAnalysisCardListProps> = ({ evaluations }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [sortBy, setSortBy] = React.useState<ISortBy>({});
 
@@ -116,31 +116,31 @@ export const AutomatedAnalysisCardList: React.FC<AutomatedAnalysisCardListProps>
         <Table aria-label={'Automated analysis data list'} gridBreakPoint={'grid-md'} isStickyHeader>
           <Thead>
             <Tr>
-              <Th sort={getSortParams(0)}>{t('NAME', { ns: 'common' })}</Th>
+              <Th sort={getSortParams(0)}>{t('NAME')}</Th>
               <Th modifier="wrap" sort={getSortParams(1)}>
-                {t('SCORE', { ns: 'common' })}
+                {t('SCORE')}
               </Th>
-              <Th modifier="truncate">{t('DESCRIPTION', { ns: 'common' })}</Th>
+              <Th modifier="truncate">{t('DESCRIPTION')}</Th>
             </Tr>
           </Thead>
           <Tbody>
             {flatFiltered.map((result) => {
               return (
                 <Tr key={result.name}>
-                  <Td dataLabel={t('NAME', { ns: 'common' })} width={10}>
+                  <Td dataLabel={t('NAME')} width={10}>
                     {result.name}
                   </Td>
-                  <Td dataLabel={t('SCORE', { ns: 'common' })} modifier="wrap">
+                  <Td dataLabel={t('SCORE')} modifier="wrap">
                     <Flex spaceItems={{ default: 'spaceItemsSm' }}>
                       <FlexItem>
                         {result.score == AutomatedAnalysisScore.NA_SCORE
-                          ? t('N/A', { ns: 'common' })
+                          ? t('N/A')
                           : result.score.toFixed(1)}
                       </FlexItem>
                       <FlexItem>{icon(result.score)}</FlexItem>
                     </Flex>
                   </Td>
-                  <Td modifier="breakWord" dataLabel={t('DESCRIPTION', { ns: 'common' })}>
+                  <Td modifier="breakWord" dataLabel={t('DESCRIPTION')}>
                     {transformAADescription(result)}
                   </Td>
                 </Tr>

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigDrawer.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigDrawer.tsx
@@ -23,6 +23,7 @@ import {
 import { automatedAnalysisConfigToRecordingAttributes } from '@app/Shared/Services/service.utils';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   Drawer,
@@ -40,7 +41,6 @@ import {
 } from '@patternfly/react-core';
 import { CogIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { AutomatedAnalysisConfigForm } from './AutomatedAnalysisConfigForm';
 
 interface AutomatedAnalysisConfigDrawerProps {
@@ -57,7 +57,7 @@ export const AutomatedAnalysisConfigDrawer: React.FC<AutomatedAnalysisConfigDraw
 }) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(false);

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.tsx
@@ -24,6 +24,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetSelect } from '@app/TargetView/TargetSelect';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { formatBytes, formatDuration } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ActionList,
   ActionListItem,
@@ -58,7 +59,6 @@ import {
 } from '@patternfly/react-core';
 import { CloseIcon, PencilAltIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { first, iif, of, ReplaySubject, take } from 'rxjs';
 import { AutomatedAnalysisConfigFormData } from './types';
 
@@ -73,7 +73,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
 }) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const _targetSubjectRef = React.useRef(new ReplaySubject<NullableTarget>(1));
   const _targetSubject = _targetSubjectRef.current;
@@ -225,7 +225,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
       return (
         <Grid hasGutter lg={4} md={12}>
           <GridItem>
-            <FormGroup label={t(`TEMPLATE`, { ns: 'common' })} isRequired fieldId="recording-template">
+            <FormGroup label={t(`TEMPLATE`)} isRequired fieldId="recording-template">
               {isLoading ? (
                 <Spinner size="md" />
               ) : errorMessage != '' ? (
@@ -256,7 +256,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
             </FormGroup>
           </GridItem>
           <GridItem>
-            <FormGroup label={t('MAXIMUM_SIZE', { ns: 'common' })} fieldId="maxSize">
+            <FormGroup label={t('MAXIMUM_SIZE')} fieldId="maxSize">
               <Split hasGutter={true}>
                 <SplitItem isFilled>
                   <TextInput
@@ -264,7 +264,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
                     isRequired
                     type="number"
                     id="maxSize"
-                    aria-label={t('AriaLabels.MAXIMUM_SIZE', { ns: 'common' })}
+                    aria-label={t('AriaLabels.MAXIMUM_SIZE')}
                     onChange={handleMaxSizeChange}
                     min="0"
                   />
@@ -273,7 +273,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
                   <FormSelect
                     value={formData.maxSizeUnit}
                     onChange={handleMaxSizeUnitChange}
-                    aria-label={t('AriaLabels.MAXIMUM_SIZE_UNITS_INPUT', { ns: 'common' })}
+                    aria-label={t('AriaLabels.MAXIMUM_SIZE_UNITS_INPUT')}
                   >
                     <FormSelectOption key="1" value="1" label="B" />
                     <FormSelectOption key="2" value={1024} label="KiB" />
@@ -283,13 +283,13 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
               </Split>
               <FormHelperText>
                 <HelperText>
-                  <HelperTextItem>{t('MAXIMUM_SIZE_HELPER_TEXT', { ns: 'common' })}</HelperTextItem>
+                  <HelperTextItem>{t('MAXIMUM_SIZE_HELPER_TEXT')}</HelperTextItem>
                 </HelperText>
               </FormHelperText>
             </FormGroup>
           </GridItem>
           <GridItem>
-            <FormGroup label={t('MAXIMUM_AGE', { ns: 'common' })} fieldId="maxAge">
+            <FormGroup label={t('MAXIMUM_AGE')} fieldId="maxAge">
               <Split hasGutter={true}>
                 <SplitItem isFilled>
                   <TextInput
@@ -297,7 +297,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
                     isRequired
                     type="number"
                     id="maxAgeDuration"
-                    aria-label={t('AriaLabels.MAXIMUM_AGE', { ns: 'common' })}
+                    aria-label={t('AriaLabels.MAXIMUM_AGE')}
                     onChange={handleMaxAgeChange}
                     min="0"
                   />
@@ -307,7 +307,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
                     className={`${automatedAnalysisRecordingName}__form_select`}
                     value={formData.maxAgeUnit}
                     onChange={handleMaxAgeUnitChange}
-                    aria-label={t('AriaLabels.MAXIMUM_AGE_UNITS_INPUT', { ns: 'common' })}
+                    aria-label={t('AriaLabels.MAXIMUM_AGE_UNITS_INPUT')}
                   >
                     <FormSelectOption key="1" value="1" label={t('SECOND', { count: 0, ns: 'common' })} />
                     <FormSelectOption key="2" value={60} label={t('MINUTE', { count: 0, ns: 'common' })} />
@@ -318,7 +318,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
 
               <FormHelperText>
                 <HelperText>
-                  <HelperTextItem>{t('MAXIMUM_AGE_HELPER_TEXT', { ns: 'common' })}</HelperTextItem>
+                  <HelperTextItem>{t('MAXIMUM_AGE_HELPER_TEXT')}</HelperTextItem>
                 </HelperText>
               </FormHelperText>
             </FormGroup>
@@ -329,7 +329,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
     return (
       <DescriptionList isCompact isAutoFit>
         <DescriptionListGroup>
-          <DescriptionListTerm>{t('TEMPLATE', { ns: 'common' })}</DescriptionListTerm>
+          <DescriptionListTerm>{t('TEMPLATE')}</DescriptionListTerm>
           <DescriptionListDescription>
             {t('AutomatedAnalysisConfigForm.FORMATTED_TEMPLATE', { template: recordingConfig.template })}
           </DescriptionListDescription>
@@ -400,7 +400,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
                 <Button
                   variant="plain"
                   onClick={toggleEdit}
-                  aria-label={editing ? t('CANCEL', { ns: 'common' }) : t('EDIT', { ns: 'common' })}
+                  aria-label={editing ? t('CANCEL') : t('EDIT')}
                 >
                   {editing ? <CloseIcon /> : <PencilAltIcon />}
                 </Button>
@@ -427,12 +427,12 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
                       variant={'primary'}
                       isDisabled={!formData.template?.name || !formData.template?.type}
                     >
-                      {t('SAVE', { ns: 'common' })}
+                      {t('SAVE')}
                     </Button>
                   </ActionListItem>
                   <ActionListItem>
                     <Button variant="secondary" onClick={toggleEdit}>
-                      {t('CANCEL', { ns: 'common' })}
+                      {t('CANCEL')}
                     </Button>
                   </ActionListItem>
                 </ActionList>

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.tsx
@@ -397,11 +397,7 @@ export const AutomatedAnalysisConfigForm: React.FC<AutomatedAnalysisConfigFormPr
           <CardHeader
             actions={{
               actions: (
-                <Button
-                  variant="plain"
-                  onClick={toggleEdit}
-                  aria-label={editing ? t('CANCEL') : t('EDIT')}
-                >
+                <Button variant="plain" onClick={toggleEdit} aria-label={editing ? t('CANCEL') : t('EDIT')}>
                   {editing ? <CloseIcon /> : <PencilAltIcon />}
                 </Button>
               ),

--- a/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters.tsx
@@ -17,6 +17,7 @@ import { allowedAutomatedAnalysisFilters } from '@app/Shared/Redux/Filters/Autom
 import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 import { automatedAnalysisUpdateCategoryIntent, RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
 import { AnalysisResult } from '@app/Shared/Services/api.types';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ToolbarChipGroup,
   ToolbarFilter,
@@ -31,7 +32,6 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { AutomatedAnalysisNameFilter } from './Filters/AutomatedAnalysisNameFilter';
 import { AutomatedAnalysisTopicFilter } from './Filters/AutomatedAnalysisTopicFilter';
@@ -60,7 +60,7 @@ export const AutomatedAnalysisFilters: React.FC<AutomatedAnalysisFiltersProps> =
   ..._props
 }) => {
   const dispatch = useDispatch<StateDispatch>();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const currentCategory = useSelector((state: RootState) => {
     const targetAutomatedAnalysisFilters = state.automatedAnalysisFilters.targetFilters.filter(
@@ -114,9 +114,9 @@ export const AutomatedAnalysisFilters: React.FC<AutomatedAnalysisFiltersProps> =
     (category: string) => {
       switch (category) {
         case 'Name':
-          return t('FILTER_NAME', { ns: 'common' });
+          return t('FILTER_NAME');
         case 'Topic':
-          return t('FILTER_TOPIC', { ns: 'common' });
+          return t('FILTER_TOPIC');
         default:
           throw new Error(`Unknown automated analysis filter category: ${category}`);
       }

--- a/src/app/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel.tsx
@@ -16,12 +16,12 @@
 
 import { AutomatedAnalysisScore, AnalysisResult } from '@app/Shared/Services/api.types';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Label, LabelProps, Popover } from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationCircleIcon, InfoCircleIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import popoverStyles from '@patternfly/react-styles/css/components/Popover/popover';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { transformAADescription } from './utils';
 
 export interface ClickableAutomatedAnalysisLabelProps {
@@ -31,7 +31,7 @@ export interface ClickableAutomatedAnalysisLabelProps {
 export const clickableAutomatedAnalysisKey = 'clickable-automated-analysis-label';
 
 export const ClickableAutomatedAnalysisLabel: React.FC<ClickableAutomatedAnalysisLabelProps> = ({ result }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [isHoveredOrFocused, setIsHoveredOrFocused] = React.useState(false);
   const [isDescriptionVisible, setIsDescriptionVisible] = React.useState(false);

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.tsx
@@ -17,6 +17,7 @@
 import { automatedAnalysisAddGlobalFilterIntent, RootState, StateDispatch } from '@app/Shared/Redux/ReduxStore';
 import { AutomatedAnalysisScore } from '@app/Shared/Services/api.types';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   Level,
@@ -28,14 +29,13 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
 export interface AutomatedAnalysisScoreFilterProps {}
 
 export const AutomatedAnalysisScoreFilter: React.FC<AutomatedAnalysisScoreFilterProps> = (_) => {
   const dispatch = useDispatch<StateDispatch>();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const currentScore = useSelector((state: RootState) => {
     const filters = state.automatedAnalysisFilters.globalFilters.filters;
     if (!filters) return 0;
@@ -44,14 +44,14 @@ export const AutomatedAnalysisScoreFilter: React.FC<AutomatedAnalysisScoreFilter
 
   const steps = [
     { value: 0, label: '0' },
-    { value: 12.5, label: t('OK', { ns: 'common' }) }, // some hacks that work with css to get bolded and coloured labels above slider
+    { value: 12.5, label: t('OK') }, // some hacks that work with css to get bolded and coloured labels above slider
     {
       value: AutomatedAnalysisScore.ORANGE_SCORE_THRESHOLD,
       label: String(AutomatedAnalysisScore.ORANGE_SCORE_THRESHOLD),
     },
-    { value: 50, label: t('WARNING', { ns: 'common' }) },
+    { value: 50, label: t('WARNING') },
     { value: AutomatedAnalysisScore.RED_SCORE_THRESHOLD, label: String(AutomatedAnalysisScore.RED_SCORE_THRESHOLD) },
-    { value: 87.5, label: t('CRITICAL', { ns: 'common' }) },
+    { value: 87.5, label: t('CRITICAL') },
     { value: 100, label: '100' },
   ] as SliderStepObject[];
 
@@ -104,7 +104,7 @@ export const AutomatedAnalysisScoreFilter: React.FC<AutomatedAnalysisScoreFilter
         startActions={
           <Level hasGutter>
             <LevelItem>
-              <Text component={TextVariants.small}>{t('RESET', { ns: 'common' })}:</Text>
+              <Text component={TextVariants.small}>{t('RESET')}:</Text>
             </LevelItem>
             <LevelItem>
               <Button
@@ -135,7 +135,7 @@ export const AutomatedAnalysisScoreFilter: React.FC<AutomatedAnalysisScoreFilter
         areCustomStepsContinuous
         customSteps={steps}
         isInputVisible
-        inputLabel={t('SCORE', { ns: 'common' })}
+        inputLabel={t('SCORE')}
         inputValue={currentScore}
         value={currentScore}
         onChange={onChange}

--- a/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/jfr/JFRMetricsChartCard.tsx
@@ -25,6 +25,7 @@ import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { useTheme } from '@app/utils/hooks/useTheme';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Bullseye,
   Button,
@@ -41,7 +42,7 @@ import {
 } from '@patternfly/react-core';
 import { DataSourceIcon, ExternalLinkAltIcon, SyncAltIcon, TachometerAltIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { interval } from 'rxjs';
 import { DashboardCard } from '../../DashboardCard';
@@ -91,7 +92,7 @@ export function kindToId(kind: string): number {
 }
 
 export const JFRMetricsChartCard: DashboardCardFC<JFRMetricsChartCardProps> = (props) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const serviceContext = React.useContext(ServiceContext);
   const controllerContext = React.useContext(ChartContext);
   const navigate = useNavigate();

--- a/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
+++ b/src/app/Dashboard/Charts/mbean/MBeanMetricsChartCard.tsx
@@ -29,6 +29,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import useDayjs from '@app/utils/hooks/useDayjs';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { useTheme } from '@app/utils/hooks/useTheme';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Chart,
   ChartArea,
@@ -44,7 +45,6 @@ import { getResizeObserver, Button, CardBody, CardHeader, CardTitle, Tooltip } f
 import { MonitoringIcon, SyncAltIcon } from '@patternfly/react-icons';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { interval } from 'rxjs';
 import { DashboardCard } from '../../DashboardCard';
 import { ChartContext } from '../context';
@@ -364,7 +364,7 @@ function getChartKindByName(name: string): MBeanMetricsChartKind {
 }
 
 export const MBeanMetricsChartCard: DashboardCardFC<MBeanMetricsChartCardProps> = (props) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [theme] = useTheme();
   const serviceContext = React.useContext(ServiceContext);
   const controllerContext = React.useContext(ChartContext);

--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -26,9 +26,9 @@ import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { TargetView } from '@app/TargetView/TargetView';
 import { getFromLocalStorage } from '@app/utils/LocalStorage';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Grid, GridItem } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { AddCard } from './AddCard';
@@ -46,7 +46,7 @@ export const Dashboard: React.FC<DashboardComponentProps> = (_) => {
   const navigate = useNavigate();
   const serviceContext = React.useContext(ServiceContext);
   const dispatch = useDispatch<StateDispatch>();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const dashboardConfigs: DashboardConfig = useSelector((state: RootState) => state.dashboardConfigs);
   const jfrChartController = React.useRef(
     new JFRMetricsChartController(

--- a/src/app/Dashboard/DashboardCardActionMenu.tsx
+++ b/src/app/Dashboard/DashboardCardActionMenu.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Divider, Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface DashboardCardActionProps {
   onRemove: () => void;
@@ -28,7 +28,7 @@ export interface DashboardCardActionProps {
 export const DashboardCardActionMenu: React.FC<DashboardCardActionProps> = ({ onRemove, onResetSize, onView }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const onSelect = React.useCallback((_) => setIsOpen(false), [setIsOpen]);
 
@@ -64,7 +64,7 @@ export const DashboardCardActionMenu: React.FC<DashboardCardActionProps> = ({ on
     >
       <DropdownList>
         <DropdownItem key="View" onClick={onView}>
-          {t('VIEW', { ns: 'common' })}
+          {t('VIEW')}
         </DropdownItem>
 
         <DropdownItem key="Reset Size" onClick={onResetSize}>
@@ -72,7 +72,7 @@ export const DashboardCardActionMenu: React.FC<DashboardCardActionProps> = ({ on
         </DropdownItem>
         <Divider />
         <DropdownItem key="Remove" onClick={onRemove} isDanger>
-          {t('REMOVE', { ns: 'common' })}
+          {t('REMOVE')}
         </DropdownItem>
       </DropdownList>
     </Dropdown>

--- a/src/app/Dashboard/DashboardLayoutCreateModal.tsx
+++ b/src/app/Dashboard/DashboardLayoutCreateModal.tsx
@@ -21,6 +21,7 @@ import {
   RootState,
 } from '@app/Shared/Redux/ReduxStore';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ActionGroup,
   Button,
@@ -37,7 +38,6 @@ import {
   ValidatedOptions,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { DEFAULT_DASHBOARD_NAME } from './const';
 import { BlankLayout } from './cryostat-dashboard-templates';
@@ -53,7 +53,7 @@ export interface DashboardLayoutCreateModalProps {
 
 export const DashboardLayoutCreateModal: React.FC<DashboardLayoutCreateModalProps> = ({ onClose, ...props }) => {
   const dispatch = useDispatch();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const dashboardConfigs = useSelector((state: RootState) => state.dashboardConfigs);
   const [nameValidated, setNameValidated] = React.useState<ValidatedOptions>(ValidatedOptions.default);
   const [errorMessage, setErrorMessage] = React.useState<string>('');
@@ -183,10 +183,10 @@ export const DashboardLayoutCreateModal: React.FC<DashboardLayoutCreateModalProp
     return (
       <ActionGroup>
         <Button variant="primary" onClick={handleSubmit} isAriaDisabled={nameValidated !== 'success'}>
-          {isCreateModal ? t('CREATE', { ns: 'common' }) : t('RENAME', { ns: 'common' })}
+          {isCreateModal ? t('CREATE') : t('RENAME')}
         </Button>
         <Button variant="link" onClick={handleClose}>
-          {t('CANCEL', { ns: 'common' })}
+          {t('CANCEL')}
         </Button>
       </ActionGroup>
     );

--- a/src/app/Dashboard/DashboardLayoutSetAsTemplateModal.tsx
+++ b/src/app/Dashboard/DashboardLayoutSetAsTemplateModal.tsx
@@ -18,6 +18,7 @@ import { NotificationCategory } from '@app/Shared/Services/api.types';
 import { NotificationsContext } from '@app/Shared/Services/Notifications.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ActionGroup,
   Button,
@@ -33,7 +34,6 @@ import {
 } from '@patternfly/react-core';
 import { ValidatedOptions } from '@patternfly/react-core/dist/js/helpers';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { LAYOUT_TEMPLATE_DESCRIPTION_WORD_LIMIT } from './const';
 import { DashboardLayoutNamePattern, LayoutTemplateDescriptionPattern, templatize } from './utils';
@@ -54,7 +54,7 @@ export const DashboardLayoutSetAsTemplateModal: React.FC<DashboardLayoutSetAsTem
   const templates = dashboardConfigs.customTemplates;
   const serviceContext = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [name, setName] = React.useState('');
   const [description, setDescription] = React.useState('');
 
@@ -216,10 +216,10 @@ export const DashboardLayoutSetAsTemplateModal: React.FC<DashboardLayoutSetAsTem
             onClick={handleSubmit}
             isDisabled={nameValidated !== ValidatedOptions.success || descriptionValidated === ValidatedOptions.error}
           >
-            {downloadModal ? t('DOWNLOAD', { ns: 'common' }) : t('SUBMIT', { ns: 'common' })}
+            {downloadModal ? t('DOWNLOAD') : t('SUBMIT')}
           </Button>
           <Button variant="link" onClick={handleClose}>
-            {t('CANCEL', { ns: 'common' })}
+            {t('CANCEL')}
           </Button>
         </ActionGroup>
       </Form>

--- a/src/app/Dashboard/DashboardLayoutToolbar.tsx
+++ b/src/app/Dashboard/DashboardLayoutToolbar.tsx
@@ -25,6 +25,7 @@ import {
   StateDispatch,
 } from '@app/Shared/Redux/ReduxStore';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   Divider,
@@ -56,7 +57,6 @@ import {
   UploadIcon,
 } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { AddCard } from './AddCard';
 import { DEFAULT_DASHBOARD_NAME } from './const';
@@ -79,7 +79,7 @@ const DefaultSelectedTemplate: SelectedLayoutTemplate = {
 export const DashboardLayoutToolbar: React.FC<DashboardLayoutToolbarProps> = (_props) => {
   const dispatch = useDispatch<StateDispatch>();
   const context = React.useContext(ServiceContext);
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const dashboardConfigs = useSelector((state: RootState) => state.dashboardConfigs);
 
   const [selectedTemplate, setSelectedTemplate] = React.useState<SelectedLayoutTemplate>({
@@ -347,7 +347,7 @@ export const DashboardLayoutToolbar: React.FC<DashboardLayoutToolbarProps> = (_p
         icon={<TrashIcon />}
         data-quickstart-id="dashboard-delete-btn"
       >
-        {t('DELETE', { ns: 'common' })}
+        {t('DELETE')}
       </Button>
     ),
     [t, handleDeleteButton, currLayout.name],
@@ -558,7 +558,7 @@ export const DashboardLayoutToolbar: React.FC<DashboardLayoutToolbarProps> = (_p
         visible={showClearConfirmation}
         onClose={() => setShowClearConfirmation(false)}
         onAccept={handleConfirmClearDashboardLayout}
-        acceptButtonText={t('CLEAR', { ns: 'common' })}
+        acceptButtonText={t('CLEAR')}
       />
     );
   }, [showClearConfirmation, handleConfirmClearDashboardLayout, t]);

--- a/src/app/Dashboard/Diagnostics/DiagnosticsCard.tsx
+++ b/src/app/Dashboard/Diagnostics/DiagnosticsCard.tsx
@@ -24,6 +24,7 @@ import { NotificationsContext } from '@app/Shared/Services/Notifications.service
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Bullseye,
   Button,
@@ -39,13 +40,12 @@ import {
 } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { DashboardCard } from '../DashboardCard';
 
 export interface DiagnosticsCardProps extends DashboardCardTypeProps {}
 
 export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const serviceContext = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const addSubscription = useSubscriptions();

--- a/src/app/Dashboard/ErrorCard.tsx
+++ b/src/app/Dashboard/ErrorCard.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Bullseye,
   CardBody,
@@ -31,7 +32,6 @@ import {
 } from '@patternfly/react-core';
 import { WrenchIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { DashboardCard } from './DashboardCard';
 import { CardConfig, CardValidationResult, DashboardCardFC, DashboardCardSizes, DashboardCardTypeProps } from './types';
 
@@ -48,7 +48,7 @@ export const ErrorCard: DashboardCardFC<ErrorCardProps> = ({
   actions,
   ...props
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const { errors, callForAction } = validationResult;
 
   const errorDescription = React.useMemo(() => {

--- a/src/app/Dashboard/LayoutTemplateGroup.tsx
+++ b/src/app/Dashboard/LayoutTemplateGroup.tsx
@@ -16,6 +16,7 @@
 import { dashboardConfigTemplateHistoryClearIntent } from '@app/Shared/Redux/ReduxStore';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
 import {
   Button,
@@ -33,7 +34,6 @@ import {
 } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import {
   LayoutTemplateFilter,
@@ -64,7 +64,7 @@ export const LayoutTemplateGroup: React.FC<LayoutTemplateGroupProps> = ({
   onTemplateDelete,
   ...props
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const dispatch = useDispatch();
   const { selectedTemplate, setSelectedTemplate } = React.useContext(LayoutTemplateContext);
 
@@ -89,7 +89,7 @@ export const LayoutTemplateGroup: React.FC<LayoutTemplateGroupProps> = ({
       <Split>
         <SplitItem>
           <Title headingLevel="h2" size="lg" style={{ padding: '1em' }}>
-            {t(props.title, { ns: 'common' })} ({t('LayoutTemplateGroup.ITEMS', { count: props.templates.length })})
+            {t(props.title)} ({t('LayoutTemplateGroup.ITEMS', { count: props.templates.length })})
           </Title>
         </SplitItem>
         {props.title === 'Suggested' && props.templates.length !== 1 && (
@@ -97,7 +97,7 @@ export const LayoutTemplateGroup: React.FC<LayoutTemplateGroupProps> = ({
             <SplitItem isFilled></SplitItem>
             <SplitItem>
               <Button variant="link" onClick={handleClearRecent}>
-                {t('CLEAR_RECENT', { ns: 'common' })}
+                {t('CLEAR_RECENT')}
               </Button>
             </SplitItem>
           </>
@@ -147,7 +147,7 @@ export interface KebabCatalogTileBadgeProps {
 
 export const KebabCatalogTileBadge: React.FC<KebabCatalogTileBadgeProps> = ({ template, onTemplateDelete }) => {
   const serviceContext = React.useContext(ServiceContext);
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
 
@@ -174,11 +174,11 @@ export const KebabCatalogTileBadge: React.FC<KebabCatalogTileBadgeProps> = ({ te
   const dropdownItems = React.useMemo(() => {
     return [
       <DropdownItem key={'download'} onClick={handleTemplateDownload}>
-        {t('DOWNLOAD', { ns: 'common' })}
+        {t('DOWNLOAD')}
       </DropdownItem>,
       <Divider key="divider" />,
       <DropdownItem key={'delete'} onClick={handleTemplateDelete} isDanger>
-        {t('DELETE', { ns: 'common' })}
+        {t('DELETE')}
       </DropdownItem>,
     ];
   }, [t, handleTemplateDownload, handleTemplateDelete]);

--- a/src/app/Dashboard/LayoutTemplatePicker.tsx
+++ b/src/app/Dashboard/LayoutTemplatePicker.tsx
@@ -19,6 +19,7 @@ import { RootState, dashboardConfigDeleteTemplateIntent } from '@app/Shared/Redu
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { fakeChartContext, fakeServices } from '@app/utils/fakeData';
 import { useFeatureLevel } from '@app/utils/hooks/useFeatureLevel';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Bullseye,
   Button,
@@ -77,7 +78,6 @@ import { InnerScrollContainer } from '@patternfly/react-table';
 import { TFunction } from 'i18next';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { ChartContext } from './Charts/context';
 import { CryostatLayoutTemplates, BlankLayout } from './cryostat-dashboard-templates';
@@ -133,7 +133,7 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
   const [isDeleteWarningModalOpen, setIsDeleteWarningModalOpen] = React.useState(false);
   const [toDelete, setToDelete] = React.useState<string>('');
 
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const recentTemplateRecords: LayoutTemplateRecord[] = useSelector(
     (state: RootState) => state.dashboardConfigs.templateHistory,
   );
@@ -556,7 +556,7 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
                           hasCheckbox
                           isSelected={selectedFilters.includes('Suggested')}
                         >
-                          {t('SUGGESTED', { ns: 'common' })}
+                          {t('SUGGESTED')}
                         </SelectOption>
                         <SelectOption
                           key="cryostat"
@@ -572,7 +572,7 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
                           hasCheckbox
                           isSelected={selectedFilters.includes('User-submitted')}
                         >
-                          {t('USER_SUBMITTED', { ns: 'common' })}
+                          {t('USER_SUBMITTED')}
                         </SelectOption>
                       </SelectList>
                     </Select>
@@ -597,7 +597,7 @@ export const LayoutTemplatePicker: React.FC<LayoutTemplatePickerProps> = ({ onTe
                   >
                     <SelectList>
                       <SelectOption key={LayoutTemplateSort.NAME} value={LayoutTemplateSort.NAME}>
-                        {t('NAME', { ns: 'common' })}
+                        {t('NAME')}
                       </SelectOption>
                       <SelectOption key={LayoutTemplateSort.CARD_COUNT} value={LayoutTemplateSort.CARD_COUNT}>
                         {t('LayoutTemplatePicker.CARD_COUNT')}

--- a/src/app/Dashboard/LayoutTemplateUploadModal.tsx
+++ b/src/app/Dashboard/LayoutTemplateUploadModal.tsx
@@ -19,10 +19,10 @@ import { dashboardConfigCreateTemplateIntent, RootState } from '@app/Shared/Redu
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { ActionGroup, Button, Form, FormGroup, Modal, ModalVariant, Popover, Text } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { forkJoin, from, Observable, of } from 'rxjs';
 import { catchError, concatMap, defaultIfEmpty, first } from 'rxjs/operators';
@@ -53,7 +53,7 @@ export const LayoutTemplateUploadModal: React.FC<LayoutTemplateUploadModalProps>
   const dispatch = useDispatch();
   const { setSelectedTemplate } = React.useContext(LayoutTemplateContext);
   const customTemplates = useSelector((state: RootState) => state.dashboardConfigs.customTemplates);
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const submitRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to submit trigger div
   const abortRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to abort trigger div
 
@@ -221,7 +221,7 @@ export const LayoutTemplateUploadModal: React.FC<LayoutTemplateUploadModalProps>
   const submitButtonLoadingProps = React.useMemo(
     () =>
       ({
-        spinnerAriaValueText: t('SUBMITTING', { ns: 'common' }),
+        spinnerAriaValueText: t('SUBMITTING'),
         spinnerAriaLabel: 'submitting-layout-templates',
         isLoading: uploading,
       }) as LoadingProps,
@@ -239,11 +239,11 @@ export const LayoutTemplateUploadModal: React.FC<LayoutTemplateUploadModalProps>
       description={t(`LayoutTemplateUploadModal.DESCRIPTION`)}
       help={
         <Popover
-          headerContent={<div>{t('WHATS_THIS', { ns: 'common' })}</div>}
+          headerContent={<div>{t('WHATS_THIS')}</div>}
           bodyContent={<div>{t(`LayoutTemplateUploadModal.HELP.CONTENT`)}</div>}
           appendTo={portalRoot}
         >
-          <Button variant="plain" aria-label={t('HELP', { ns: 'common' })}>
+          <Button variant="plain" aria-label={t('HELP')}>
             <HelpIcon />
           </Button>
         </Popover>
@@ -266,7 +266,7 @@ export const LayoutTemplateUploadModal: React.FC<LayoutTemplateUploadModalProps>
         <ActionGroup>
           {allOks && numOfFiles ? (
             <Button variant="primary" onClick={handleClose}>
-              {t('CLOSE', { ns: 'common' })}
+              {t('CLOSE')}
             </Button>
           ) : (
             <>
@@ -276,10 +276,10 @@ export const LayoutTemplateUploadModal: React.FC<LayoutTemplateUploadModalProps>
                 isDisabled={!numOfFiles || uploading}
                 {...submitButtonLoadingProps}
               >
-                {t('SUBMIT', { ns: 'common' })}
+                {t('SUBMIT')}
               </Button>
               <Button variant="link" onClick={handleClose}>
-                {t('CANCEL', { ns: 'common' })}
+                {t('CANCEL')}
               </Button>
             </>
           )}

--- a/src/app/Dashboard/utils.tsx
+++ b/src/app/Dashboard/utils.tsx
@@ -19,12 +19,12 @@ import cryostatLogoDark from '@app/assets/cryostat_icon_rgb_reverse.svg';
 import { dashboardConfigDeleteCardIntent } from '@app/Shared/Redux/ReduxStore';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { withThemedIcon } from '@app/utils/withThemedIcon';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { FileIcon, UnknownIcon, UserIcon } from '@patternfly/react-icons';
 import { nanoid } from '@reduxjs/toolkit';
 import { TFunction } from 'i18next';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { AutomatedAnalysisCardDescriptor } from './AutomatedAnalysis/AutomatedAnalysisCard';
 import { JFRMetricsChartCardDescriptor } from './Charts/jfr/JFRMetricsChartCard';
@@ -173,7 +173,7 @@ export const getDashboardCards: (featureLevel?: FeatureLevel) => DashboardCardDe
 
 export const RemoveCardAction: React.FC<{ cardIndex: number }> = ({ cardIndex }) => {
   const dispatch = useDispatch();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const handleClick = React.useCallback(() => {
     dispatch(dashboardConfigDeleteCardIntent(cardIndex));
@@ -181,7 +181,7 @@ export const RemoveCardAction: React.FC<{ cardIndex: number }> = ({ cardIndex })
 
   return (
     <Button onClick={handleClick} variant={ButtonVariant.danger}>
-      {t('REMOVE', { ns: 'common' })}
+      {t('REMOVE')}
     </Button>
   );
 };

--- a/src/app/DateTimePicker/DateTimePicker.tsx
+++ b/src/app/DateTimePicker/DateTimePicker.tsx
@@ -17,6 +17,7 @@ import { TimePicker } from '@app/DateTimePicker/TimePicker';
 import { useDayjs } from '@app/utils/hooks/useDayjs';
 import { Timezone, defaultDatetimeFormat } from '@i18n/datetime';
 import { isHourIn24hAM } from '@i18n/datetimeUtils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ActionGroup,
   Button,
@@ -30,7 +31,6 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { TimezonePicker } from './TimezonePicker';
 
 export interface DateTimePickerProps {
@@ -46,7 +46,7 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
   prefilledDate,
   dateValidators,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [dayjs, _] = useDayjs();
   const [datetime, setDatetime] = React.useState<Date>(new Date());
   const [timezone, setTimezone] = React.useState<Timezone>(defaultDatetimeFormat.timeZone); // Not affected by user preferences
@@ -152,15 +152,15 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
           value={selectedDatetimeDisplay}
         />
       </FormGroup>
-      <FormGroup label={t('TIMEZONE', { ns: 'common' })}>
+      <FormGroup label={t('TIMEZONE')}>
         <TimezonePicker id="timezone-picker" onTimezoneChange={setTimezone} selected={timezone} />
       </FormGroup>
       <ActionGroup style={{ marginTop: 0 }}>
         <Button variant="primary" onClick={handleSubmit}>
-          {t('SELECT', { ns: 'common' })}
+          {t('SELECT')}
         </Button>
         <Button variant="link" onClick={onDismiss}>
-          {t('CANCEL', { ns: 'common' })}
+          {t('CANCEL')}
         </Button>
       </ActionGroup>
     </Form>

--- a/src/app/DateTimePicker/MeridiemPicker.tsx
+++ b/src/app/DateTimePicker/MeridiemPicker.tsx
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { css } from '@patternfly/react-styles';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface MeridiemPickerProps {
   onSelect?: (isAM: boolean) => void;
@@ -23,7 +23,7 @@ export interface MeridiemPickerProps {
 }
 
 export const MeridiemPicker: React.FC<MeridiemPickerProps> = ({ onSelect = () => undefined, isAM = true }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const handleSelectAM = React.useCallback(() => {
     onSelect(true);
   }, [onSelect]);
@@ -39,10 +39,10 @@ export const MeridiemPicker: React.FC<MeridiemPickerProps> = ({ onSelect = () =>
       className="datetime-picker__meridiem-title-stack"
     >
       <div className={css('datetime-picker__meridiem-tile', `${isAM ? '' : 'un'}selected`)} onClick={handleSelectAM}>
-        {t('MERIDIEM_AM', { ns: 'common' })}
+        {t('MERIDIEM_AM')}
       </div>
       <div className={css('datetime-picker__meridiem-tile', `${isAM ? 'un' : ''}selected`)} onClick={handleSelectPM}>
-        {t('MERIDIEM_PM', { ns: 'common' })}
+        {t('MERIDIEM_PM')}
       </div>
     </div>
   );

--- a/src/app/DateTimePicker/TimePicker.tsx
+++ b/src/app/DateTimePicker/TimePicker.tsx
@@ -15,6 +15,7 @@
  */
 import { MeridiemPicker } from '@app/DateTimePicker/MeridiemPicker';
 import { format2Digit, hourIn12HrFormat, hourIn24HrFormat, isHourIn24hAM } from '@i18n/datetimeUtils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   Divider,
@@ -36,7 +37,6 @@ import { AngleDownIcon, AngleUpIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface TimePickerProps {
   id?: string;
@@ -60,7 +60,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
   selected,
   id,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [is24h, setIs24h] = React.useState(true);
 
   const meridiemAM = React.useMemo(() => isHourIn24hAM(selected.hour24), [selected.hour24]);
@@ -99,7 +99,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
               <LevelItem key={'hour'}>
                 <TimeSpinner
                   variant={is24h ? 'hour24' : 'hour12'}
-                  label={t('HOUR', { ns: 'common' })}
+                  label={t('HOUR')}
                   selected={is24h ? selected.hour24 : hourIn12HrFormat(selected.hour24)[0]}
                   onChange={handleHourSelect}
                 />
@@ -110,7 +110,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
               <LevelItem key={'minute'}>
                 <TimeSpinner
                   variant={'minute'}
-                  label={t('MINUTE', { ns: 'common' })}
+                  label={t('MINUTE')}
                   selected={selected.minute}
                   onChange={onMinuteSelect}
                 />
@@ -121,7 +121,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
               <LevelItem key={'second'}>
                 <TimeSpinner
                   variant={'second'}
-                  label={t('SECOND', { ns: 'common' })}
+                  label={t('SECOND')}
                   selected={selected.second}
                   onChange={onSecondSelect}
                 />
@@ -147,7 +147,7 @@ interface TimeSpinnerProps {
 }
 
 const TimeSpinner: React.FC<TimeSpinnerProps> = ({ variant, onChange, selected, label }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const computedMax = React.useMemo(() => {
     switch (variant) {
       case 'hour12':

--- a/src/app/DateTimePicker/TimezonePicker.tsx
+++ b/src/app/DateTimePicker/TimezonePicker.tsx
@@ -170,9 +170,7 @@ export const TimezonePicker: React.FC<TimezonePickerProps> = ({
         )}
         {numOfOptions < timezones.length && filteredTimezones.length > 0 ? (
           <SelectOption key="view-more" onClick={handleViewMore} value={undefined}>
-            <span className={css('pf-v5-c-button', 'pf-m-link', 'pf-m-inline')}>
-              {t('VIEW_MORE')}
-            </span>
+            <span className={css('pf-v5-c-button', 'pf-m-link', 'pf-m-inline')}>{t('VIEW_MORE')}</span>
           </SelectOption>
         ) : null}
       </SelectList>

--- a/src/app/DateTimePicker/TimezonePicker.tsx
+++ b/src/app/DateTimePicker/TimezonePicker.tsx
@@ -17,6 +17,7 @@
 import { useDayjs } from '@app/utils/hooks/useDayjs';
 import { portalRoot } from '@app/utils/utils';
 import { supportedTimezones, Timezone } from '@i18n/datetime';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Divider,
   Icon,
@@ -33,7 +34,6 @@ import { GlobeIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 const DEFAULT_NUM_OPTIONS = 10;
 
@@ -52,7 +52,7 @@ export const TimezonePicker: React.FC<TimezonePickerProps> = ({
   selected,
   onTimezoneChange = (_) => undefined,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [dayjs, _dateFormat] = useDayjs();
   const [numOfOptions, setNumOfOptions] = React.useState(DEFAULT_NUM_OPTIONS);
   const [isTimezoneOpen, setIsTimezoneOpen] = React.useState(false);
@@ -171,7 +171,7 @@ export const TimezonePicker: React.FC<TimezonePickerProps> = ({
         {numOfOptions < timezones.length && filteredTimezones.length > 0 ? (
           <SelectOption key="view-more" onClick={handleViewMore} value={undefined}>
             <span className={css('pf-v5-c-button', 'pf-m-link', 'pf-m-inline')}>
-              {t('VIEW_MORE', { ns: 'common' })}
+              {t('VIEW_MORE')}
             </span>
           </SelectOption>
         ) : null}

--- a/src/app/DateTimePicker/i18n.ts
+++ b/src/app/DateTimePicker/i18n.ts
@@ -26,6 +26,6 @@
  * t('TimeSpinner.DECREMENT_HOUR24_VALUE')
  * t('TimeSpinner.DECREMENT_MINUTE_VALUE')
  * t('TimeSpinner.DECREMENT_SECOND_VALUE')
- * t('DATE', { ns: 'common' })
- * t('TIME', { ns: 'common' })
+ * t('DATE')
+ * t('TIME')
  */

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -26,6 +26,7 @@ import { EventTemplate, NotificationCategory, Target } from '@app/Shared/Service
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot, sortResources, TableColumn } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ActionGroup,
   Button,
@@ -59,7 +60,6 @@ import {
 } from '@patternfly/react-table';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { forkJoin, Observable, of } from 'rxjs';
 import { catchError, concatMap, defaultIfEmpty, first, tap } from 'rxjs/operators';
@@ -92,7 +92,7 @@ export interface EventTemplatesProps {}
 export const EventTemplates: React.FC<EventTemplatesProps> = () => {
   const context = React.useContext(ServiceContext);
   const navigate = useNavigate();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [templates, setTemplates] = React.useState<EventTemplate[]>([]);
   const [filteredTemplates, setFilteredTemplates] = React.useState<EventTemplate[]>([]);

--- a/src/app/Events/EventTypes.tsx
+++ b/src/app/Events/EventTypes.tsx
@@ -22,6 +22,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSort } from '@app/utils/hooks/useSort';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { hashCode, sortResources, TableColumn } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Toolbar,
   ToolbarContent,
@@ -48,7 +49,6 @@ import {
 } from '@patternfly/react-table';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { concatMap, filter, first } from 'rxjs/operators';
 
 interface RowData {
@@ -86,7 +86,7 @@ export interface EventTypesProps {}
 export const EventTypes: React.FC<EventTypesProps> = () => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const prevPerPage = React.useRef(10);
 
   const [types, setTypes] = React.useState<EventType[]>([]);

--- a/src/app/NotFound/NotFound.tsx
+++ b/src/app/NotFound/NotFound.tsx
@@ -18,6 +18,7 @@ import { IAppRoute, routes, flatten } from '@app/routes';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   EmptyState,
@@ -31,14 +32,13 @@ import {
 } from '@patternfly/react-core';
 import { MapMarkedAltIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { NotFoundCard } from './NotFoundCard';
 
 export interface NotFoundProps {}
 
 export const NotFound: React.FC<NotFoundProps> = (_) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [activeLevel, setActiveLevel] = React.useState(FeatureLevel.PRODUCTION);

--- a/src/app/QuickStarts/QuickStartDrawer.tsx
+++ b/src/app/QuickStarts/QuickStartDrawer.tsx
@@ -20,6 +20,7 @@ import { SessionState } from '@app/Shared/Services/service.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useFeatureLevel } from '@app/utils/hooks/useFeatureLevel';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   QuickStartContext,
   QuickStartDrawer,
@@ -27,7 +28,6 @@ import {
   useValuesForQuickStartContext,
 } from '@patternfly/quickstarts';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 const LINK_LABEL = "[\\d\\w\\s-()$!&']+"; // has extra &' in matcher
 const HIGHLIGHT_ACTIONS = ['highlight']; // use native quickstarts highlight markdown extension
@@ -40,7 +40,7 @@ export interface GlobalQuickStartDrawerProps {
 }
 
 export const GlobalQuickStartDrawer: React.FC<GlobalQuickStartDrawerProps> = ({ children }) => {
-  const { i18n } = useTranslation();
+  const { i18n } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [activeQuickStartID, setActiveQuickStartID] = useLocalStorage('quickstartId', '');

--- a/src/app/QuickStarts/QuickStartsCatalogPage.tsx
+++ b/src/app/QuickStarts/QuickStartsCatalogPage.tsx
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { QuickStartCatalogPage } from '@patternfly/quickstarts';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface QuickStartsCatalogPageProps {}
 
 const QuickStartsCatalogPage: React.FC<QuickStartsCatalogPageProps> = (_) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   // TODO: Quick start categories (patternfly/quickstarts supports this through individual components)
   // e.g. Dashboard Quick starts, Topology Quick starts, Recording Quick starts, etc.

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -17,6 +17,7 @@ import { LoadingView } from '@app/Shared/Components/LoadingView';
 import { KeyValue, keyValueToString } from '@app/Shared/Services/api.types';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ActionList,
   ActionListItem,
@@ -33,7 +34,6 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, FileIcon, UploadIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { catchError, Observable, of, zip } from 'rxjs';
 import { isValidLabel, getValidatedOption, isDuplicateKey, parseLabelsFromFile, getLabelFromInput } from './utils';
 
@@ -54,7 +54,7 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
 }) => {
   const inputRef = React.useRef<HTMLInputElement>(null); // Use ref to refer to child component
   const addSubscription = useSubscriptions();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [loading, setLoading] = React.useState(false);
   const [invalidUploads, setInvalidUploads] = React.useState<string[]>([]);

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -47,6 +47,7 @@ import { useDayjs } from '@app/utils/hooks/useDayjs';
 import { useSort } from '@app/utils/hooks/useSort';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { formatBytes, formatDuration, LABEL_TEXT_MAXWIDTH, sortResources, TableColumn } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Bullseye,
   Button,
@@ -86,7 +87,6 @@ import {
 import { EllipsisVIcon, RedoIcon } from '@patternfly/react-icons';
 import { ExpandableRowContent, SortByDirection, Tbody, Td, Tr } from '@patternfly/react-table';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { combineLatest, forkJoin, merge, Observable } from 'rxjs';
@@ -885,7 +885,7 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
   handleRowCheck,
   updateFilters,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [dayjs, datetimeContext] = useDayjs();
   const context = React.useContext(ServiceContext);
   const [loadingAnalysis, setLoadingAnalysis] = React.useState(false);
@@ -1054,7 +1054,7 @@ export const ActiveRecordingRow: React.FC<ActiveRecordingRowProps> = ({
                     isDisabled={loadingAnalysis}
                     onClick={handleLoadAnalysis}
                     icon={
-                      <Tooltip content={t('REFRESH', { ns: 'common' })}>
+                      <Tooltip content={t('REFRESH')}>
                         <RedoIcon />
                       </Tooltip>
                     }

--- a/src/app/Recordings/Filters/DatetimeFilter.tsx
+++ b/src/app/Recordings/Filters/DatetimeFilter.tsx
@@ -18,6 +18,7 @@ import { ActiveRecording } from '@app/Shared/Services/api.types';
 import { useDayjs } from '@app/utils/hooks/useDayjs';
 import { portalRoot } from '@app/utils/utils';
 import dayjs, { Timezone } from '@i18n/datetime';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   ButtonVariant,
@@ -35,7 +36,6 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedCalendarAltIcon, SearchIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { DATETIME_INPUT_MAXLENGTH } from './const';
 
 interface _DatetimeState {
@@ -75,7 +75,7 @@ export interface DateTimeFilterProps {
 }
 
 export const DateTimeFilter: React.FC<DateTimeFilterProps> = ({ onSubmit }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [dayjs, _] = useDayjs();
   const [fromDatetimeInput, setFromDatetimeInput] = React.useState<_DatetimeState>(_emptyDatetimeInput);
   const [toDatetimeInput, setToDatetimeInput] = React.useState<_DatetimeState>(_emptyDatetimeInput);
@@ -132,13 +132,13 @@ export const DateTimeFilter: React.FC<DateTimeFilterProps> = ({ onSubmit }) => {
       <Flex spaceItems={{ default: 'spaceItemsSm' }}>
         <FlexItem>
           <InputGroup>
-            <InputGroupText>{t('FROM', { ns: 'common' })}</InputGroupText>
+            <InputGroupText>{t('FROM')}</InputGroupText>
             <DateTimeInput
               onChange={setFromDatetimeInput}
               selectedDateTime={fromDatetimeInput}
               dateValidators={fromValidators}
             />
-            <InputGroupText>{t('TO', { ns: 'common' })}</InputGroupText>
+            <InputGroupText>{t('TO')}</InputGroupText>
             <DateTimeInput
               onChange={setToDatetimeInput}
               selectedDateTime={toDatetimeInput}
@@ -175,7 +175,7 @@ export interface DateTimeInputProps {
 }
 
 export const DateTimeInput: React.FC<DateTimeInputProps> = ({ selectedDateTime, dateValidators, onChange }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [dayjs, datetimeContext] = useDayjs();
   const [isCalendarOpen, setIsCalendarOpen] = React.useState(false);
 

--- a/src/app/Recordings/Filters/DurationFilter.tsx
+++ b/src/app/Recordings/Filters/DurationFilter.tsx
@@ -16,6 +16,7 @@
 
 import { DurationUnit, DurationUnitSelect } from '@app/Shared/Components/DurationUnitSelect';
 import { ActiveRecording } from '@app/Shared/Services/api.types';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   ButtonVariant,
@@ -33,7 +34,6 @@ import {
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { DURATION_INPUT_MAXLENGTH } from './const';
 
 export const CONTINUOUS_INDICATOR = 'continuous';
@@ -87,7 +87,7 @@ export interface DurationFilterProps {
 }
 
 export const DurationFilter: React.FC<DurationFilterProps> = ({ durations, onDurationInput }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [fromDuration, setFromDuration] = React.useState<number | undefined>();
   const [fromDurationUnit, setFromDurationUnit] = React.useState(DurationUnit.SECOND);
 
@@ -149,7 +149,7 @@ export const DurationFilter: React.FC<DurationFilterProps> = ({ durations, onDur
       <Flex direction={{ default: 'column' }}>
         <FlexItem>
           <InputGroup>
-            <InputGroupText>{t('FROM', { ns: 'common' })}</InputGroupText>
+            <InputGroupText>{t('FROM')}</InputGroupText>
             <InputGroupItem>
               <TextInput
                 // Uncontrolled input
@@ -164,7 +164,7 @@ export const DurationFilter: React.FC<DurationFilterProps> = ({ durations, onDur
             <InputGroupItem>
               <DurationUnitSelect selected={fromDurationUnit} onSelect={setFromDurationUnit} />
             </InputGroupItem>
-            <InputGroupText>{t('TO', { ns: 'common' })}</InputGroupText>
+            <InputGroupText>{t('TO')}</InputGroupText>
             <InputGroupItem>
               <TextInput
                 // Uncontrolled input

--- a/src/app/Recordings/Filters/RecordingStateFilter.tsx
+++ b/src/app/Recordings/Filters/RecordingStateFilter.tsx
@@ -15,9 +15,9 @@
  */
 
 import { RecordingState } from '@app/Shared/Services/api.types';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Badge, MenuToggle, MenuToggleElement, Select, SelectOption } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface RecordingStateFilterProps {
   filteredStates: RecordingState[] | undefined;
@@ -25,7 +25,7 @@ export interface RecordingStateFilterProps {
 }
 
 export const RecordingStateFilter: React.FC<RecordingStateFilterProps> = ({ filteredStates, onSelectToggle }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [isOpen, setIsOpen] = React.useState(false);
 
   const onSelect = React.useCallback(

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -17,11 +17,11 @@ import { NotificationCategory, Recording, Target } from '@app/Shared/Services/ap
 import { NotificationsContext } from '@app/Shared/Services/Notifications.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Divider, Dropdown, DropdownItem, DropdownList, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import { Td } from '@patternfly/react-table';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Observable } from 'rxjs';
 import { concatMap, filter, first, tap } from 'rxjs/operators';
 
@@ -40,7 +40,7 @@ export interface RecordingActionsProps {
 }
 
 export const RecordingActions: React.FC<RecordingActionsProps> = ({ recording, uploadFn, ...props }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const [grafanaEnabled, setGrafanaEnabled] = React.useState(false);

--- a/src/app/Recordings/RecordingFilters.tsx
+++ b/src/app/Recordings/RecordingFilters.tsx
@@ -24,6 +24,7 @@ import { recordingUpdateCategoryIntent, RootState, StateDispatch } from '@app/Sh
 import { KeyValue, Recording, RecordingState, keyValueToString } from '@app/Shared/Services/api.types';
 import useDayjs, { Dayjs } from '@app/utils/hooks/useDayjs';
 // import dayjs from '@i18n/datetime';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ToolbarFilter,
   ToolbarGroup,
@@ -39,7 +40,6 @@ import {
 import { FilterIcon } from '@patternfly/react-icons';
 import { TFunction } from 'i18next';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { DateTimeFilter, DateTimeRange, filterRecordingByDatetime } from './Filters/DatetimeFilter';
 import { compareDuration, DurationFilter, DurationRange, filterRecordingByDuration } from './Filters/DurationFilter';
@@ -58,13 +58,13 @@ export interface RecordingFiltersCategories {
 export const getCategoryDisplay = (t: TFunction, category: string): string => {
   switch (category) {
     case 'Name':
-      return t('NAME', { ns: 'common' });
+      return t('NAME');
     case 'Label':
-      return t('LABEL', { ns: 'common' });
+      return t('LABEL');
     case 'State':
-      return t('STATE', { ns: 'common' });
+      return t('STATE');
     case 'Duration':
-      return t('DURATION', { ns: 'common' });
+      return t('DURATION');
     case 'StartTime':
       return t('RecordingFilters.START_TIME');
     default:
@@ -148,7 +148,7 @@ export const RecordingFilters: React.FC<RecordingFiltersProps> = ({
   breakpoint = 'xl',
   updateFilters,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [dayjs] = useDayjs();
   const dispatch = useDispatch<StateDispatch>();
 

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -28,6 +28,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useMatchExpressionSvc } from '@app/utils/hooks/useMatchExpressionSvc';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ActionGroup,
   Button,
@@ -56,7 +57,7 @@ import {
 import { HelpIcon } from '@patternfly/react-icons';
 import _ from 'lodash';
 import * as React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { combineLatest, forkJoin, iif, of, Subject } from 'rxjs';
 import { catchError, debounceTime, map, switchMap, tap } from 'rxjs/operators';
@@ -69,7 +70,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
   const context = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const navigate = useNavigate();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   // Do not use useSearchExpression for display. This causes the cursor to jump to the end due to async updates.
   const matchExprService = useMatchExpressionSvc();
   const addSubscription = useSubscriptions();
@@ -341,7 +342,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
   return (
     <Form>
       <Text component={TextVariants.small}>{t('CreateRule.ABOUT')}</Text>
-      <FormGroup label={t('NAME', { ns: 'common' })} isRequired fieldId="rule-name" data-quickstart-id="rule-name">
+      <FormGroup label={t('NAME')} isRequired fieldId="rule-name" data-quickstart-id="rule-name">
         <TextInput
           value={formData.name}
           isDisabled={loading}
@@ -363,7 +364,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
         </FormHelperText>
       </FormGroup>
       <FormGroup
-        label={t('DESCRIPTION', { ns: 'common' })}
+        label={t('DESCRIPTION')}
         fieldId="rule-description"
         data-quickstart-id="rule-description"
       >
@@ -384,7 +385,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
         </FormHelperText>
       </FormGroup>
       <FormGroup
-        label={t('MATCH_EXPRESSION', { ns: 'common' })}
+        label={t('MATCH_EXPRESSION')}
         labelIcon={
           <Popover
             appendTo={portalRoot}
@@ -440,7 +441,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
           </HelperText>
         </FormHelperText>
       </FormGroup>
-      <FormGroup label={t('ENABLED', { ns: 'common' })} isRequired fieldId="rule-enabled">
+      <FormGroup label={t('ENABLED')} isRequired fieldId="rule-enabled">
         <Switch
           id="rule-enabled"
           isDisabled={loading}
@@ -455,7 +456,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
         </FormHelperText>
       </FormGroup>
       <FormGroup
-        label={t('TEMPLATE', { ns: 'common' })}
+        label={t('TEMPLATE')}
         isRequired
         fieldId="recording-template"
         data-quickstart-id="rule-evt-template"
@@ -475,7 +476,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
           </HelperText>
         </FormHelperText>
       </FormGroup>
-      <FormGroup label={t('MAXIMUM_SIZE', { ns: 'common' })} fieldId="maxSize" data-quickstart-id="rule-max-size">
+      <FormGroup label={t('MAXIMUM_SIZE')} fieldId="maxSize" data-quickstart-id="rule-max-size">
         <Split hasGutter={true}>
           <SplitItem isFilled>
             <TextInput
@@ -509,7 +510,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
           </HelperText>
         </FormHelperText>
       </FormGroup>
-      <FormGroup label={t('MAXIMUM_AGE', { ns: 'common' })} fieldId="maxAge" data-quickstart-id="rule-max-age">
+      <FormGroup label={t('MAXIMUM_AGE')} fieldId="maxAge" data-quickstart-id="rule-max-age">
         <Split hasGutter={true}>
           <SplitItem isFilled>
             <TextInput
@@ -531,9 +532,9 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
               onChange={handleMaxAgeUnitChange}
               aria-label="Max Age units Input"
             >
-              <FormSelectOption key="1" value="1" label={t('SECOND_other', { ns: 'common' })} />
-              <FormSelectOption key="2" value={60} label={t('MINUTE_other', { ns: 'common' })} />
-              <FormSelectOption key="3" value={60 * 60} label={t('HOUR_other', { ns: 'common' })} />
+              <FormSelectOption key="1" value="1" label={t('SECOND_other')} />
+              <FormSelectOption key="2" value={60} label={t('MINUTE_other')} />
+              <FormSelectOption key="3" value={60 * 60} label={t('HOUR_other')} />
             </FormSelect>
           </SplitItem>
         </Split>
@@ -544,7 +545,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
         </FormHelperText>
       </FormGroup>
       <FormGroup
-        label={t('ARCHIVAL_PERIOD', { ns: 'common' })}
+        label={t('ARCHIVAL_PERIOD')}
         fieldId="archivalPeriod"
         data-quickstart-id="rule-archival-period"
       >
@@ -569,9 +570,9 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
               onChange={handleArchivalPeriodUnitsChange}
               aria-label="archival period units input"
             >
-              <FormSelectOption key="1" value="1" label={t('SECOND_other', { ns: 'common' })} />
-              <FormSelectOption key="2" value={60} label={t('MINUTE_other', { ns: 'common' })} />
-              <FormSelectOption key="3" value={60 * 60} label={t('HOUR_other', { ns: 'common' })} />
+              <FormSelectOption key="1" value="1" label={t('SECOND_other')} />
+              <FormSelectOption key="2" value={60} label={t('MINUTE_other')} />
+              <FormSelectOption key="3" value={60 * 60} label={t('HOUR_other')} />
             </FormSelect>
           </SplitItem>
         </Split>
@@ -582,7 +583,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
         </FormHelperText>
       </FormGroup>
       <FormGroup
-        label={t('INITIAL_DELAY', { ns: 'common' })}
+        label={t('INITIAL_DELAY')}
         fieldId="initialDelay"
         data-quickstart-id="rule-initial-delay"
       >
@@ -607,9 +608,9 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
               onChange={handleInitialDelayUnitsChanged}
               aria-label="initial delay units input"
             >
-              <FormSelectOption key="1" value="1" label={t('SECOND_other', { ns: 'common' })} />
-              <FormSelectOption key="2" value={60} label={t('MINUTE_other', { ns: 'common' })} />
-              <FormSelectOption key="3" value={60 * 60} label={t('HOUR_other', { ns: 'common' })} />
+              <FormSelectOption key="1" value="1" label={t('SECOND_other')} />
+              <FormSelectOption key="2" value={60} label={t('MINUTE_other')} />
+              <FormSelectOption key="3" value={60 * 60} label={t('HOUR_other')} />
             </FormSelect>
           </SplitItem>
         </Split>
@@ -620,7 +621,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
         </FormHelperText>
       </FormGroup>
       <FormGroup
-        label={t('PRESERVED_ARCHIVES', { ns: 'common' })}
+        label={t('PRESERVED_ARCHIVES')}
         fieldId="preservedArchives"
         data-quickstart-id="rule-preserved-archives"
       >
@@ -654,10 +655,10 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
           data-quickstart-id="rule-create-btn"
           {...createButtonLoadingProps}
         >
-          {t(loading ? 'CREATING' : 'CREATE', { ns: 'common' })}
+          {t(loading ? 'CREATING' : 'CREATE')}
         </Button>
         <Button variant="secondary" onClick={exitForm} isAriaDisabled={loading}>
-          {t('CANCEL', { ns: 'common' })}
+          {t('CANCEL')}
         </Button>
       </ActionGroup>
     </Form>
@@ -666,12 +667,12 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
 
 export const CreateRule: React.FC = () => {
   const matchExpreRef = React.useRef(new MatchExpressionService());
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const breadcrumbs: BreadcrumbTrail[] = React.useMemo(
     () => [
       {
-        title: t('AUTOMATED_RULES', { ns: 'common' }),
+        title: t('AUTOMATED_RULES'),
         path: '/rules',
       },
     ],
@@ -687,7 +688,7 @@ export const CreateRule: React.FC = () => {
   );
 
   return (
-    <BreadcrumbPage pageTitle={t('CREATE', { ns: 'common' })} breadcrumbs={breadcrumbs}>
+    <BreadcrumbPage pageTitle={t('CREATE')} breadcrumbs={breadcrumbs}>
       <SearchExprServiceContext.Provider value={matchExpreRef.current} data-full-height>
         <Grid hasGutter style={gridStyles}>
           <GridItem xl={5} order={{ xl: '0', default: '1' }}>

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -363,11 +363,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
           </HelperText>
         </FormHelperText>
       </FormGroup>
-      <FormGroup
-        label={t('DESCRIPTION')}
-        fieldId="rule-description"
-        data-quickstart-id="rule-description"
-      >
+      <FormGroup label={t('DESCRIPTION')} fieldId="rule-description" data-quickstart-id="rule-description">
         <TextArea
           value={formData.description}
           isDisabled={loading}
@@ -455,12 +451,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
           </HelperText>
         </FormHelperText>
       </FormGroup>
-      <FormGroup
-        label={t('TEMPLATE')}
-        isRequired
-        fieldId="recording-template"
-        data-quickstart-id="rule-evt-template"
-      >
+      <FormGroup label={t('TEMPLATE')} isRequired fieldId="recording-template" data-quickstart-id="rule-evt-template">
         <SelectTemplateSelectorForm
           selected={selectedSpecifier}
           disabled={loading}
@@ -544,11 +535,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
           </HelperText>
         </FormHelperText>
       </FormGroup>
-      <FormGroup
-        label={t('ARCHIVAL_PERIOD')}
-        fieldId="archivalPeriod"
-        data-quickstart-id="rule-archival-period"
-      >
+      <FormGroup label={t('ARCHIVAL_PERIOD')} fieldId="archivalPeriod" data-quickstart-id="rule-archival-period">
         <Split hasGutter={true}>
           <SplitItem isFilled>
             <TextInput
@@ -582,11 +569,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = (_props) => {
           </HelperText>
         </FormHelperText>
       </FormGroup>
-      <FormGroup
-        label={t('INITIAL_DELAY')}
-        fieldId="initialDelay"
-        data-quickstart-id="rule-initial-delay"
-      >
+      <FormGroup label={t('INITIAL_DELAY')} fieldId="initialDelay" data-quickstart-id="rule-initial-delay">
         <Split hasGutter={true}>
           <SplitItem isFilled>
             <TextInput

--- a/src/app/Rules/RuleDeleteWarningModal.tsx
+++ b/src/app/Rules/RuleDeleteWarningModal.tsx
@@ -15,10 +15,10 @@
  */
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Modal, ModalVariant, Button, Checkbox, Stack, Split } from '@patternfly/react-core';
 import * as React from 'react';
 import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { DeleteWarningProps } from '../Modal/DeleteWarningModal';
 import { getFromWarningMap } from '../Modal/utils';
 
@@ -37,7 +37,7 @@ export const RuleDeleteWarningModal = ({
   clean,
   setClean,
 }: RuleDeleteWarningProps): JSX.Element => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const [doNotAsk, setDoNotAsk] = useState(false);
 
@@ -66,10 +66,10 @@ export const RuleDeleteWarningModal = ({
         <Stack hasGutter key="modal-footer-stack">
           <Split key="modal-footer-split">
             <Button variant="danger" onClick={onAcceptClose}>
-              {t(warningType.match(/disable/i) ? 'DISABLE' : 'DELETE', { ns: 'common' })}
+              {t(warningType.match(/disable/i) ? 'DISABLE' : 'DELETE')}
             </Button>
             <Button variant="link" onClick={onClose}>
-              {t('CANCEL', { ns: 'common' })}
+              {t('CANCEL')}
             </Button>
           </Split>
         </Stack>,
@@ -78,14 +78,14 @@ export const RuleDeleteWarningModal = ({
       <Stack hasGutter key="modal-checkboxes-stack">
         <Checkbox
           id="clean-rule-enabled"
-          label={t('CLEAN', { ns: 'common' })}
+          label={t('CLEAN')}
           description={t('RuleDeleteWarningModal.CLEAN_DESCRIPTION', { ruleName: ruleName })}
           isChecked={clean}
           onChange={(_, checked) => setClean(checked)}
         />
         <Checkbox
           id="do-not-ask-enabled"
-          label={t('DONOT_ASK_AGAIN', { ns: 'common' })}
+          label={t('DONOT_ASK_AGAIN')}
           isChecked={doNotAsk}
           onChange={(_event, checked) => setDoNotAsk(checked)}
         />

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -58,12 +58,13 @@ import {
 } from '@patternfly/react-table';
 import _ from 'lodash';
 import * as React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
 import { first } from 'rxjs/operators';
 import { RuleDeleteWarningModal } from './RuleDeleteWarningModal';
 import { RuleUploadModal } from './RulesUploadModal';
 import { RuleToDeleteOrDisable } from './types';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 
 export interface RulesTableProps {}
 
@@ -71,7 +72,7 @@ export const RulesTable: React.FC<RulesTableProps> = () => {
   const context = React.useContext(ServiceContext);
   const navigate = useNavigate();
   const addSubscription = useSubscriptions();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [isLoading, setIsLoading] = React.useState(false);
   const [sortBy, setSortBy] = React.useState({} as ISortBy);
@@ -85,51 +86,51 @@ export const RulesTable: React.FC<RulesTableProps> = () => {
   const tableColumns: TableColumn[] = React.useMemo(
     () => [
       {
-        title: t('ENABLED', { ns: 'common' }),
+        title: t('ENABLED'),
         keyPaths: ['enabled'],
       },
       {
-        title: t('NAME', { ns: 'common' }),
+        title: t('NAME'),
         keyPaths: ['name'],
         sortable: true,
       },
       {
-        title: t('DESCRIPTION', { ns: 'common' }),
+        title: t('DESCRIPTION'),
         keyPaths: ['description'],
       },
       {
-        title: t('MATCH_EXPRESSION', { ns: 'common' }),
+        title: t('MATCH_EXPRESSION'),
         keyPaths: ['matchExpression'],
         sortable: true,
         tooltip: t('Rules.MATCH_EXPRESSION_TOOLTIP'),
       },
       {
-        title: t('EVENT_SPECIFIER', { ns: 'common' }),
+        title: t('EVENT_SPECIFIER'),
         keyPaths: ['eventSpecifier'],
         tooltip: t('Rules.EVENT_SPECIFIER_TOOLTIP'),
       },
       {
-        title: t('MAXIMUM_AGE', { ns: 'common' }),
+        title: t('MAXIMUM_AGE'),
         keyPaths: ['maxAgeSeconds'],
         tooltip: t('Rules.MAX_AGE_TOOLTIP'),
       },
       {
-        title: t('MAXIMUM_SIZE', { ns: 'common' }),
+        title: t('MAXIMUM_SIZE'),
         keyPaths: ['maxSizeBytes'],
         tooltip: t('Rules.MAX_SIZE_TOOLTIP'),
       },
       {
-        title: t('ARCHIVAL_PERIOD', { ns: 'common' }),
+        title: t('ARCHIVAL_PERIOD'),
         keyPaths: ['archivalPeriodSeconds'],
         tooltip: t('Rules.ARCHIVAL_PERIOD_TOOLTIP'),
       },
       {
-        title: t('INITIAL_DELAY', { ns: 'common' }),
+        title: t('INITIAL_DELAY'),
         keyPaths: ['initialDelaySeconds'],
         tooltip: t('Rules.INITIAL_DELAY_TOOLTIP'),
       },
       {
-        title: t('PRESERVED_ARCHIVES', { ns: 'common' }),
+        title: t('PRESERVED_ARCHIVES'),
         keyPaths: ['preservedArchives'],
         tooltip: t('Rules.PRESERVED_ARCHIVES_TOOLTIP'),
       },
@@ -292,14 +293,14 @@ export const RulesTable: React.FC<RulesTableProps> = () => {
     (rule: Rule): IAction[] => {
       return [
         {
-          title: t('DOWNLOAD', { ns: 'common' }),
+          title: t('DOWNLOAD'),
           onClick: () => context.api.downloadRule(rule.name),
         },
         {
           isSeparator: true,
         },
         {
-          title: t('DELETE', { ns: 'common' }),
+          title: t('DELETE'),
           onClick: () => handleDeleteButton(rule),
           isDanger: true,
         },
@@ -340,7 +341,7 @@ export const RulesTable: React.FC<RulesTableProps> = () => {
             {r.name}
           </Td>
           <Td key={`automatic-rule-description-${index}`} dataLabel={tableColumns[2].title}>
-            {r.description || <EmptyText text={t('NO_DESCRIPTION', { ns: 'common' })} />}
+            {r.description || <EmptyText text={t('NO_DESCRIPTION')} />}
           </Td>
           <Td key={`automatic-rule-matchExpression-${index}`} width={25} dataLabel={tableColumns[3].title}>
             <MatchExpressionDisplay matchExpression={r.matchExpression} />
@@ -391,7 +392,7 @@ export const RulesTable: React.FC<RulesTableProps> = () => {
           <ToolbarItem variant="separator" />
           <ToolbarItem key="create" spacer={{ default: 'spacerSm' }}>
             <Button variant="primary" onClick={handleCreateRule} data-quickstart-id="create-rule-btn">
-              {t('CREATE', { ns: 'common' })}
+              {t('CREATE')}
             </Button>
           </ToolbarItem>
           <ToolbarItem key="upload">
@@ -490,7 +491,7 @@ export const RulesTable: React.FC<RulesTableProps> = () => {
       <BreadcrumbPage pageTitle="Automated Rules">
         <Card isFullHeight>
           <CardTitle>
-            {t('AUTOMATED_RULES', { ns: 'common' })}
+            {t('AUTOMATED_RULES')}
             <TextContent>
               <Text component={TextVariants.small}>
                 <Trans

--- a/src/app/Rules/RulesUploadModal.tsx
+++ b/src/app/Rules/RulesUploadModal.tsx
@@ -19,11 +19,11 @@ import { Rule } from '@app/Shared/Services/api.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { ActionGroup, Button, Form, FormGroup, Modal, ModalVariant, Popover } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import { TFunction } from 'i18next';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { forkJoin, from, Observable, of } from 'rxjs';
 import { catchError, concatMap, defaultIfEmpty, first, tap } from 'rxjs/operators';
 import { isRule } from './utils';
@@ -51,7 +51,7 @@ export const parseRule = (file: File, t: TFunction): Observable<Rule> => {
 
 export const RuleUploadModal: React.FC<RuleUploadModalProps> = ({ onClose, ...props }) => {
   const addSubscription = useSubscriptions();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const submitRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to submit trigger div
   const abortRef = React.useRef<HTMLDivElement>(null); // Use ref to refer to abort trigger div
@@ -172,7 +172,7 @@ export const RuleUploadModal: React.FC<RuleUploadModalProps> = ({ onClose, ...pr
         <ActionGroup>
           {allOks && numOfFiles ? (
             <Button variant="primary" onClick={handleClose}>
-              {t('CLOSE', { ns: 'common' })}
+              {t('CLOSE')}
             </Button>
           ) : (
             <>
@@ -182,10 +182,10 @@ export const RuleUploadModal: React.FC<RuleUploadModalProps> = ({ onClose, ...pr
                 isDisabled={!numOfFiles || uploading}
                 {...submitButtonLoadingProps}
               >
-                {t('SUBMIT', { ns: 'common' })}
+                {t('SUBMIT')}
               </Button>
               <Button variant="link" onClick={handleClose}>
-                {t('CANCEL', { ns: 'common' })}
+                {t('CANCEL')}
               </Button>
             </>
           )}

--- a/src/app/SecurityPanel/Credentials/CreateCredentialModal.tsx
+++ b/src/app/SecurityPanel/Credentials/CreateCredentialModal.tsx
@@ -24,6 +24,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useMatchExpressionSvc } from '@app/utils/hooks/useMatchExpressionSvc';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot, StreamOf } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   Card,
@@ -46,7 +47,7 @@ import {
 } from '@patternfly/react-core';
 import { FlaskIcon, HelpIcon, TopologyIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 import { catchError, combineLatest, distinctUntilChanged, interval, map, of, switchMap, tap } from 'rxjs';
 import { CredentialTestTable } from './CredentialTestTable';
 import { TestRequest } from './types';
@@ -64,7 +65,7 @@ export const CreateCredentialModal: React.FC<CreateCredentialModalProps> = ({
   onPropsSave,
   ...props
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const matchExpreRef = React.useRef(new MatchExpressionService());
   const loadingRef = React.useRef(new StreamOf(false));
   const credentialRef = React.useRef(new StreamOf<AuthCredential>({ username: '', password: '' }));
@@ -124,7 +125,7 @@ interface AuthFormProps extends Omit<CreateCredentialModalProps, 'visible'> {
 }
 
 export const AuthForm: React.FC<AuthFormProps> = ({ onDismiss, onPropsSave, progressChange, ...props }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const matchExprService = useMatchExpressionSvc();
@@ -224,7 +225,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onDismiss, onPropsSave, prog
       onCredentialChange={setCredential}
     >
       <FormGroup
-        label={t('MATCH_EXPRESSION', { ns: 'common' })}
+        label={t('MATCH_EXPRESSION')}
         labelIcon={
           <Popover
             appendTo={portalRoot}
@@ -286,7 +287,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onDismiss, onPropsSave, prog
 type _SupportedTab = 'visualizer' | 'test';
 
 export const FormHelper: React.FC = ({ ...props }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const alertOptions = React.useMemo(() => ({ hideActions: true }), []);
   const [activeTab, setActiveTab] = React.useState<_SupportedTab>('visualizer');
 
@@ -319,7 +320,7 @@ export const FormHelper: React.FC = ({ ...props }) => {
             <TabTitleIcon>
               <FlaskIcon />
             </TabTitleIcon>
-            <TabTitleText>{t('TEST', { ns: 'common' })}</TabTitleText>
+            <TabTitleText>{t('TEST')}</TabTitleText>
           </>
         }
       >

--- a/src/app/SecurityPanel/Credentials/CredentialTestTable.tsx
+++ b/src/app/SecurityPanel/Credentials/CredentialTestTable.tsx
@@ -21,6 +21,7 @@ import { useMatchExpressionSvc } from '@app/utils/hooks/useMatchExpressionSvc';
 import { useSort } from '@app/utils/hooks/useSort';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { TableColumn, portalRoot, sortResources } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Bullseye,
   Button,
@@ -59,7 +60,6 @@ import {
 } from '@patternfly/react-table';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { catchError, combineLatest, of, switchMap, tap } from 'rxjs';
 import { TestPoolContext, useAuthCredential } from './utils';
 
@@ -82,7 +82,7 @@ const tableColumns: TableColumn[] = [
 export interface CredentialTestTableProps {}
 
 export const CredentialTestTable: React.FC<CredentialTestTableProps> = ({ ...props }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const addSubscription = useSubscriptions();
   const context = React.useContext(ServiceContext);
   const matchExprService = useMatchExpressionSvc();
@@ -145,9 +145,9 @@ export const CredentialTestTable: React.FC<CredentialTestTableProps> = ({ ...pro
         <Table {...props}>
           <Thead>
             <Tr>
-              <Th sort={getSortParams(0)}>{t('TARGET', { ns: 'common' })}</Th>
+              <Th sort={getSortParams(0)}>{t('TARGET')}</Th>
               <Th textCenter width={20}>
-                {t('STATUS', { ns: 'common' })}
+                {t('STATUS')}
               </Th>
             </Tr>
           </Thead>
@@ -209,7 +209,7 @@ export const CredentialTestRow: React.FC<CredentialTestRowProps> = ({
   searchText = '',
   ...props
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [status, setStatus] = React.useState<TestStatus>({
     state: CredentialTestState.NO_STATUS,
     error: undefined,
@@ -258,12 +258,12 @@ export const CredentialTestRow: React.FC<CredentialTestRowProps> = ({
 
   return isShowed ? (
     <Tr {...props} id={`${target.connectUrl}-test-row`}>
-      <Td dataLabel={t('TARGET', { ns: 'common' })}>
+      <Td dataLabel={t('TARGET')}>
         {!target.alias || target.alias === target.connectUrl
           ? target.connectUrl
           : `${target.alias} (${target.connectUrl})`}
       </Td>
-      <Td dataLabel={t('STATUS', { ns: 'common' })} textCenter>
+      <Td dataLabel={t('STATUS')} textCenter>
         {loading ? (
           <Bullseye>
             <LinearDotSpinner />
@@ -279,10 +279,10 @@ export const CredentialTestRow: React.FC<CredentialTestRowProps> = ({
               <div>
                 {status.state === CredentialTestState.INVALID
                   ? t('CredentialTestTable.TEST_FAILED')
-                  : t('CAUTION', { ns: 'common' })}
+                  : t('CAUTION')}
               </div>
             }
-            bodyContent={<div>{status.error?.message || t('UNKNOWN_ERROR', { ns: 'common' })}</div>}
+            bodyContent={<div>{status.error?.message || t('UNKNOWN_ERROR')}</div>}
             appendTo={portalRoot}
           >
             <Label style={{ cursor: 'pointer' }} color={getColor(status.state)}>
@@ -300,7 +300,7 @@ export const CredentialTestRow: React.FC<CredentialTestRowProps> = ({
           isDisabled={loading || isEmptyCredential}
           onClick={handleTest}
         >
-          {t('TEST', { ns: 'common' })}
+          {t('TEST')}
         </Button>
       </Td>
     </Tr>
@@ -323,7 +323,7 @@ const CredentialToolbar: React.FC<CredentialToolbarProps> = ({
   searchText,
   ...props
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [credential] = useAuthCredential();
   const [disableTest, setDisableTest] = React.useState(false);
 
@@ -383,7 +383,7 @@ interface StatusFilterProps {
 }
 
 const StatusFilter: React.FC<StatusFilterProps> = ({ onChange, filters, ...props }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [isOpen, setIsOpen] = React.useState(false);
   const handleToggle = React.useCallback(() => setIsOpen((old) => !old), [setIsOpen]);
 
@@ -398,7 +398,7 @@ const StatusFilter: React.FC<StatusFilterProps> = ({ onChange, filters, ...props
   const toggle = React.useCallback(
     (toggleRef: React.Ref<MenuToggleElement>) => (
       <MenuToggle ref={toggleRef} onClick={handleToggle} isExpanded={isOpen}>
-        {t('STATUS', { ns: 'common' })}
+        {t('STATUS')}
       </MenuToggle>
     ),
     [handleToggle, isOpen, t],

--- a/src/app/SecurityPanel/Credentials/CredentialTestTable.tsx
+++ b/src/app/SecurityPanel/Credentials/CredentialTestTable.tsx
@@ -277,9 +277,7 @@ export const CredentialTestRow: React.FC<CredentialTestRowProps> = ({
             }
             headerContent={
               <div>
-                {status.state === CredentialTestState.INVALID
-                  ? t('CredentialTestTable.TEST_FAILED')
-                  : t('CAUTION')}
+                {status.state === CredentialTestState.INVALID ? t('CredentialTestTable.TEST_FAILED') : t('CAUTION')}
               </div>
             }
             bodyContent={<div>{status.error?.message || t('UNKNOWN_ERROR')}</div>}

--- a/src/app/SecurityPanel/Credentials/MatchedTargetsTable.tsx
+++ b/src/app/SecurityPanel/Credentials/MatchedTargetsTable.tsx
@@ -19,12 +19,12 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSort } from '@app/utils/hooks/useSort';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { TableColumn, sortResources } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { EmptyState, EmptyStateIcon, EmptyStateHeader } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { InnerScrollContainer, SortByDirection, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface MatchedTargetsTableProps {
   id: number;
@@ -46,7 +46,7 @@ const tableColumns: TableColumn[] = [
 
 export const MatchedTargetsTable: React.FC<MatchedTargetsTableProps> = ({ id, matchExpression }) => {
   const context = React.useContext(ServiceContext);
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [targets, setTargets] = React.useState([] as Target[]);
   const [sortBy, getSortParams] = useSort();

--- a/src/app/SecurityPanel/Credentials/StoredCredentials.tsx
+++ b/src/app/SecurityPanel/Credentials/StoredCredentials.tsx
@@ -23,6 +23,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSort } from '@app/utils/hooks/useSort';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { TableColumn, sortResources, portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   Checkbox,
@@ -62,7 +63,6 @@ import {
 import { TFunction } from 'i18next';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { concatMap, forkJoin, map } from 'rxjs';
 import { SecurityCard } from '../types';
 import { CreateCredentialModal } from './CreateCredentialModal';
@@ -198,7 +198,7 @@ const tableColumns: TableColumn[] = [
 ];
 
 export const StoredCredentials = () => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [state, dispatch] = React.useReducer(reducer, {
@@ -324,7 +324,7 @@ export const StoredCredentials = () => {
         aria-label={t('StoredCredentials.ARIA_LABELS.Add')}
         onClick={handleAuthModalOpen}
       >
-        {t('ADD', { ns: 'common' })}
+        {t('ADD')}
       </Button>,
       <Button
         key="delete"
@@ -333,7 +333,7 @@ export const StoredCredentials = () => {
         onClick={handleDeleteButton}
         isDisabled={!state.checkedCredentials.length}
       >
-        {t('DELETE', { ns: 'common' })}
+        {t('DELETE')}
       </Button>,
     ];
 
@@ -545,7 +545,7 @@ export const CheckBoxActions: React.FC<CheckBoxActionsProps> = ({
   onSelectAll,
   isSelectAll,
 }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [isOpen, setIsOpen] = React.useState(false);
 
   const handleToggle = React.useCallback(() => setIsOpen((isOpen) => !isOpen), [setIsOpen]);

--- a/src/app/SecurityPanel/ImportCertificate.tsx
+++ b/src/app/SecurityPanel/ImportCertificate.tsx
@@ -17,6 +17,7 @@
 import { JmxSslDescription } from '@app/Shared/Components/JmxSslDescription';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   EmptyState,
@@ -37,12 +38,11 @@ import {
 import { FileIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { TFunction } from 'i18next';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { tap } from 'rxjs/operators';
 import { SecurityCard } from './types';
 
 export const CertificateImport: React.FC = () => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [loading, setLoading] = React.useState(true);

--- a/src/app/SecurityPanel/SecurityPanel.tsx
+++ b/src/app/SecurityPanel/SecurityPanel.tsx
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Card, CardBody, CardTitle, Text, TextVariants } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { StoredCredentialsCard } from './Credentials/StoredCredentials';
 import { ListCertificates } from './ImportCertificate';
 
 export interface SecurityPanelProps {}
 
 export const SecurityPanel: React.FC<SecurityPanelProps> = (_) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const securityCards = [ListCertificates, StoredCredentialsCard].map((c) => ({
     key: c.key,
     title: c.title(t),

--- a/src/app/Settings/Config/AutoRefresh.tsx
+++ b/src/app/Settings/Config/AutoRefresh.tsx
@@ -16,9 +16,9 @@
 
 import { DurationPicker } from '@app/DurationPicker/DurationPicker';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Checkbox } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { SettingTab, UserSetting } from '../types';
 
 const defaultPreferences = {
@@ -28,7 +28,7 @@ const defaultPreferences = {
 };
 
 const Component = () => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const [state, setState] = React.useState(defaultPreferences);
 

--- a/src/app/Settings/Config/ChartCards.tsx
+++ b/src/app/Settings/Config/ChartCards.tsx
@@ -15,6 +15,7 @@
  */
 
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   FormGroup,
   FormHelperText,
@@ -25,13 +26,12 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { SettingTab, UserSetting } from '../types';
 
 const min = 1;
 
 const Component = () => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
 
   const [minRefresh, setMinRefresh] = React.useState(context.settings.chartControllerConfig().minRefresh);
@@ -75,7 +75,7 @@ const Component = () => {
             onChange={handleChange}
             onMinus={handleVisibleStep(-1)}
             onPlus={handleVisibleStep(1)}
-            unit={t('SECOND_other', { ns: 'common' })}
+            unit={t('SECOND_other')}
           />
         </FormGroup>
       </StackItem>

--- a/src/app/Settings/Config/DatetimeControl.tsx
+++ b/src/app/Settings/Config/DatetimeControl.tsx
@@ -18,6 +18,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import useDayjs from '@app/utils/hooks/useDayjs';
 import { portalRoot } from '@app/utils/utils';
 import { locales, Timezone } from '@i18n/datetime';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Divider,
   FormGroup,
@@ -36,11 +37,10 @@ import {
 } from '@patternfly/react-core';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { SettingTab, UserSetting } from '../types';
 
 const Component = () => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const [dateLocaleOpen, setDateLocaleOpen] = React.useState(false);
   const [_dayjs, datetimeFormat] = useDayjs();

--- a/src/app/Settings/Config/DeletionDialogControl.tsx
+++ b/src/app/Settings/Config/DeletionDialogControl.tsx
@@ -17,6 +17,7 @@
 import { DeleteOrDisableWarningType } from '@app/Modal/types';
 import { getFromWarningMap } from '@app/Modal/utils';
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ExpandableSection,
   FormGroup,
@@ -27,11 +28,10 @@ import {
   Switch,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { SettingTab, UserSetting } from '../types';
 
 const Component = () => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const [state, setState] = React.useState(context.settings.deletionDialogsEnabled());
   const [expanded, setExpanded] = React.useState(false);
@@ -92,7 +92,7 @@ const Component = () => {
         </StackItem>
         <StackItem key={'expandable-delete-warning-switch-list'}>
           <ExpandableSection
-            toggleText={(expanded ? t('SHOW_LESS', { ns: 'common' }) : t('SHOW_MORE', { ns: 'common' })) || ''}
+            toggleText={(expanded ? t('SHOW_LESS') : t('SHOW_MORE')) || ''}
             onToggle={(_, expanded: boolean) => setExpanded(expanded)}
             isExpanded={expanded}
             toggleId="delete-dialog-options-toggle"

--- a/src/app/Settings/Config/FeatureLevels.tsx
+++ b/src/app/Settings/Config/FeatureLevels.tsx
@@ -18,14 +18,14 @@ import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { MenuToggle, MenuToggleElement, Select, SelectList, SelectOption } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { SettingTab, UserSetting } from '../types';
 import { isDevNodeEnv } from '../utils';
 
 const Component = () => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [featureLevel, setFeatureLevel] = React.useState(FeatureLevel.PRODUCTION);

--- a/src/app/Settings/Config/Language.tsx
+++ b/src/app/Settings/Config/Language.tsx
@@ -15,15 +15,14 @@
  */
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { portalRoot } from '@app/utils/utils';
-import { i18nLanguages, i18nResources } from '@i18n/config';
-import { localeReadable } from '@i18n/i18nextUtil';
+import { i18nLanguages, i18nResources, localeReadable } from '@i18n/i18nextUtil';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { MenuToggle, MenuToggleElement, Select, SelectList, SelectOption } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { SettingTab, UserSetting } from '../types';
 
 const Component = () => {
-  const [t, i18n] = useTranslation();
+  const [t, i18n] = useCryostatTranslation();
   const [open, setOpen] = React.useState(false);
 
   const handleLanguageToggle = React.useCallback(() => setOpen((v) => !v), [setOpen]);

--- a/src/app/Settings/Config/NotificationControl.tsx
+++ b/src/app/Settings/Config/NotificationControl.tsx
@@ -18,6 +18,7 @@ import { NotificationCategory } from '@app/Shared/Services/api.types';
 import { messageKeys } from '@app/Shared/Services/api.utils';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   ExpandableSection,
   Switch,
@@ -29,14 +30,13 @@ import {
   HelperTextItem,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { SettingTab, UserSetting } from '../types';
 
 const min = 0;
 const max = 10;
 
 const Component = () => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
   const [state, setState] = React.useState(context.settings.notificationsEnabled());
@@ -148,7 +148,7 @@ const Component = () => {
         </StackItem>
         <StackItem key={'expandable-noti-switch-list'}>
           <ExpandableSection
-            toggleText={expanded ? t('SHOW_LESS', { ns: 'common' }) : t('SHOW_MORE', { ns: 'common' })}
+            toggleText={expanded ? t('SHOW_LESS') : t('SHOW_MORE')}
             onToggle={(_, expanded: boolean) => setExpanded(expanded)}
             isExpanded={expanded}
             toggleId="notification-options-toggle"

--- a/src/app/Settings/Config/Theme.tsx
+++ b/src/app/Settings/Config/Theme.tsx
@@ -16,13 +16,13 @@
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useTheme } from '@app/utils/hooks/useTheme';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { MenuToggle, MenuToggleElement, Select, SelectList, SelectOption } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { SettingTab, ThemeSetting, UserSetting } from '../types';
 
 const Component = () => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const [open, setOpen] = React.useState(false);
   const [_theme, themeSetting] = useTheme();

--- a/src/app/Settings/Config/WebSocketDebounce.tsx
+++ b/src/app/Settings/Config/WebSocketDebounce.tsx
@@ -15,9 +15,9 @@
  */
 
 import { ServiceContext } from '@app/Shared/Services/Services';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { NumberInput } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { SettingTab, UserSetting } from '../types';
 
 const defaultPreferences = {
@@ -28,7 +28,7 @@ const debounceMin = 1;
 const debounceMax = 1000;
 
 const Component = () => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const [state, setState] = React.useState(defaultPreferences);
 
@@ -89,7 +89,7 @@ const Component = () => {
         onChange={handleWebSocketDebounceChange}
         onMinus={handleWebSocketDebounceMinus}
         onPlus={handleWebSocketDebouncePlus}
-        unit={t('MILLISECOND_other', { ns: 'common' })}
+        unit={t('MILLISECOND_other')}
       />
     </>
   );

--- a/src/app/Settings/Settings.tsx
+++ b/src/app/Settings/Settings.tsx
@@ -18,6 +18,7 @@ import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { FeatureFlag } from '@app/Shared/Components/FeatureFlag';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { cleanDataId, getActiveTab, hashCode, switchTab } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Card,
   Form,
@@ -36,7 +37,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { AutomatedAnalysis } from './Config/AutomatedAnalysis';
 import { AutoRefresh } from './Config/AutoRefresh';
@@ -54,7 +55,7 @@ import { paramAsTab, tabAsParam, getGroupFeatureLevel } from './utils';
 export interface SettingsProps {}
 
 export const Settings: React.FC<SettingsProps> = (_) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const settings = React.useMemo(
     () =>
@@ -208,7 +209,7 @@ interface SettingTabProps extends TabProps {
 
 // Workaround to the Tabs component requiring children to be React.FC<TabProps>
 const WrappedTab: React.FC<SettingTabProps> = ({ featureLevelConfig, eventKey, title, children }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   return (
     <FeatureFlag level={featureLevelConfig.level} strict={featureLevelConfig.strict}>

--- a/src/app/Shared/Components/DurationUnitSelect.tsx
+++ b/src/app/Shared/Components/DurationUnitSelect.tsx
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { MenuToggle, MenuToggleElement, Select, SelectList, SelectOption } from '@patternfly/react-core';
 import { TFunction } from 'i18next';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export enum DurationUnit {
   HOUR = 60 * 60,
@@ -30,11 +30,11 @@ export const getDurationUnitDisplay = (t: TFunction, unit: DurationUnit, compact
   const suffix = compact ? 'compact' : 'other';
   switch (unit) {
     case DurationUnit.HOUR:
-      return t(`HOUR_${suffix}`, { ns: 'common' });
+      return t(`HOUR_${suffix}`);
     case DurationUnit.MINUTE:
-      return t(`MINUTE_${suffix}`, { ns: 'common' });
+      return t(`MINUTE_${suffix}`);
     case DurationUnit.SECOND:
-      return t(`SECOND_${suffix}`, { ns: 'common' });
+      return t(`SECOND_${suffix}`);
     default:
       throw new Error(`Unknown unit enum value: ${unit}`);
   }
@@ -46,7 +46,7 @@ export interface DurationUnitSelectProps {
 }
 
 export const DurationUnitSelect: React.FC<DurationUnitSelectProps> = ({ onSelect, selected, ...props }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [open, setOpen] = React.useState(false);
 
   const handleToggle = React.useCallback(() => setOpen((open) => !open), [setOpen]);

--- a/src/app/Shared/Components/ErrorBoundary.tsx
+++ b/src/app/Shared/Components/ErrorBoundary.tsx
@@ -16,6 +16,7 @@
 
 import build from '@app/build.json';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Bullseye,
   EmptyState,
@@ -28,7 +29,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 import { ServiceContext } from '../Services/Services';
 
 export interface ErrorBoundaryProps {
@@ -68,7 +69,7 @@ export interface DefaultFallBackProps {
 }
 
 export const DefaultFallBack: React.FC<DefaultFallBackProps> = ({ error, ...props }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const addSubcription = useSubscriptions();
   const serviceContext = React.useContext(ServiceContext);
   const [cryostatVersion, setCryostatVersion] = React.useState(undefined as string | undefined);
@@ -81,7 +82,7 @@ export const DefaultFallBack: React.FC<DefaultFallBackProps> = ({ error, ...prop
     <Bullseye {...props}>
       <EmptyState variant={EmptyStateVariant.lg}>
         <EmptyStateHeader
-          titleText={<>{t('SOMETHING_WENT_WRONG', { ns: 'common' })}</>}
+          titleText={<>{t('SOMETHING_WENT_WRONG')}</>}
           icon={<EmptyStateIcon icon={ExclamationCircleIcon} color="red" />}
           headingLevel={'h1'}
         />

--- a/src/app/Shared/Components/MatchExpression/MatchExpressionDisplay.tsx
+++ b/src/app/Shared/Components/MatchExpression/MatchExpressionDisplay.tsx
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { ClipboardCopy } from '@patternfly/react-core';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface MatchExpressionDisplayProps {
   matchExpression: string;
 }
 
 export const MatchExpressionDisplay: React.FC<MatchExpressionDisplayProps> = ({ matchExpression }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   return (
     <ClipboardCopy
       className="match-expression-display"
-      hoverTip={t('COPY', { ns: 'common' })}
-      clickTip={t('COPIED', { ns: 'common' })}
+      hoverTip={t('COPY')}
+      clickTip={t('COPIED')}
       variant="inline-compact"
       isBlock
       isCode

--- a/src/app/Shared/Components/i18n.ts
+++ b/src/app/Shared/Components/i18n.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * t('HOUR_compact', { ns: 'common' });
- * t('MINUTE_compact', { ns: 'common' });
- * t('SECOND_compact', { ns: 'common' });
+ * t('HOUR_compact');
+ * t('MINUTE_compact');
+ * t('SECOND_compact');
  */

--- a/src/app/Shared/i18n.ts
+++ b/src/app/Shared/i18n.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * t('PRODUCTION', { ns: 'common' })
- * t('DEVELOPMENT', { ns: 'common' })
- * t('BETA', { ns: 'common' })
+ * t('PRODUCTION')
+ * t('DEVELOPMENT')
+ * t('BETA')
  */

--- a/src/app/TargetView/TargetContextSelector.tsx
+++ b/src/app/TargetView/TargetContextSelector.tsx
@@ -22,6 +22,7 @@ import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { getFromLocalStorage, removeFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
 import { getAnnotation } from '@app/utils/utils';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
   Divider,
@@ -39,7 +40,6 @@ import {
 } from '@patternfly/react-core';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
 export interface TargetContextSelectorProps {
@@ -50,7 +50,7 @@ export const TargetContextSelector: React.FC<TargetContextSelectorProps> = ({ cl
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
 
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [targets, setTargets] = React.useState<Target[]>([]);
   const [selectedTarget, setSelectedTarget] = React.useState<Target>();
   const [favorites, setFavorites] = React.useState<string[]>(getFromLocalStorage('TARGET_FAVORITES', []));

--- a/src/app/TargetView/TargetSelect.tsx
+++ b/src/app/TargetView/TargetSelect.tsx
@@ -20,6 +20,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { getFromLocalStorage } from '@app/utils/LocalStorage';
 import { getAnnotation } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Card,
   CardBody,
@@ -39,7 +40,6 @@ import {
 import { ContainerNodeIcon } from '@patternfly/react-icons';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface TargetSelectProps {
   simple?: boolean; // Display a simple, non-expandable component
@@ -51,7 +51,7 @@ export const TargetSelect: React.FC<TargetSelectProps> = ({ onSelect, simple, ..
   const addSubscription = useSubscriptions();
   const firstLoadRef = React.useRef(false);
 
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   const [isExpanded, setExpanded] = React.useState(false);
   const [selected, setSelected] = React.useState<Target>();
   const [targets, setTargets] = React.useState<Target[]>([]);

--- a/src/app/Topology/Actions/CreateTarget.tsx
+++ b/src/app/Topology/Actions/CreateTarget.tsx
@@ -23,6 +23,7 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import '@app/Topology/styles/base.css';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { getAnnotation, portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Accordion,
   AccordionContent,
@@ -54,7 +55,6 @@ import {
 import { CheckCircleIcon, ExclamationCircleIcon, PendingIcon, SyncAltIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 export const isValidTargetConnectURL = (connectUrl?: string) => connectUrl && !connectUrl.match(/\s+/);
@@ -72,7 +72,7 @@ export const CreateTarget: React.FC<CreateTargetProps> = ({ prefilled }) => {
   const addSubscription = useSubscriptions();
   const context = React.useContext(ServiceContext);
   const navigate = useNavigate();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [example, setExample] = React.useState('');
   const [{ connectUrl, alias, validConnectUrl, username, password }, setFormData] = React.useState({
@@ -411,10 +411,10 @@ export const CreateTarget: React.FC<CreateTargetProps> = ({ prefilled }) => {
                 {...createButtonLoadingProps}
                 data-quickstart-id="ct-create-btn"
               >
-                {loading ? t('CREATING', { ns: 'common' }) : t('CREATE', { ns: 'common' })}
+                {loading ? t('CREATING') : t('CREATE')}
               </Button>
               <Button variant="secondary" onClick={exitForm}>
-                {t('CANCEL', { ns: 'common' })}
+                {t('CANCEL')}
               </Button>
             </ActionGroup>
           </Form>

--- a/src/app/Topology/Shared/Components/Shortcuts.tsx
+++ b/src/app/Topology/Shared/Components/Shortcuts.tsx
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
 import _ from 'lodash';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 
 export interface IShortcut {
   id: string;
@@ -29,7 +29,7 @@ export interface ShortcutsProps {
 }
 
 export const Shortcuts: React.FC<ShortcutsProps> = ({ shortcuts, ...props }) => {
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
   return (
     <Table
       className="topology__short-cuts"

--- a/src/app/Topology/Toolbar/TopologyToolbar.tsx
+++ b/src/app/Topology/Toolbar/TopologyToolbar.tsx
@@ -15,11 +15,11 @@
  */
 import { topologyConfigSetViewModeIntent, topologyDeleteAllFiltersIntent } from '@app/Shared/Redux/ReduxStore';
 import { portalRoot } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Button, Icon, Popover, Toolbar, ToolbarContent, ToolbarItem, Tooltip } from '@patternfly/react-core';
 import { TopologyIcon, ListIcon, MouseIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 import { Visualization } from '@patternfly/react-topology';
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 import { QuickSearchModal } from '../Actions/QuickSearchPanel';
 import Shortcuts, { ShortcutCommand } from '../Shared/Components/Shortcuts';
@@ -44,7 +44,7 @@ export interface TopologyToolbarProps {
 export const TopologyToolbar: React.FC<TopologyToolbarProps> = ({ variant, visualization, isDisabled, ...props }) => {
   const isGraphView = variant === TopologyToolbarVariant.Graph;
   const dispatch = useDispatch();
-  const { t } = useTranslation();
+  const { t } = useCryostatTranslation();
 
   const [quicksearchOpen, setQuicksearchOpen] = React.useState(false);
 

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -17,30 +17,7 @@
 import i18next from 'i18next';
 import I18nextBrowserLanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
-
-import en_common from '../../locales/en/common.json';
-import en_public from '../../locales/en/public.json';
-// import zh_common from '../../locales/zh/common.json';
-// import zh_public from '../../locales/zh/public.json';
-
-// TODO: .use(Backend) eventually store translations on backend?
-// Openshift console does this already:
-// https://github.com/openshift/console/blob/master/frontend/public/i18n.js
-export const i18nResources = {
-  en: {
-    public: en_public,
-    common: en_common,
-  },
-  // zh: {
-  //   // TODO: add zh translation (and other languages)?
-  //   // public: zh_public,
-  //   // common: zh_common,
-  // },
-} as const;
-
-export const i18nNamespaces = ['public', 'common'];
-
-export const i18nLanguages = Object.keys(i18nResources);
+import { i18nNamespaces, i18nResources } from './i18nextUtil';
 
 // eslint-disable-next-line import/no-named-as-default-member
 i18next

--- a/src/i18n/i18nextUtil.ts
+++ b/src/i18n/i18nextUtil.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useTranslation, UseTranslationResponse } from "react-i18next";
+import { useTranslation, UseTranslationResponse } from 'react-i18next';
 
 import en_common from '../../locales/en/common.json';
 import en_public from '../../locales/en/public.json';

--- a/src/i18n/i18nextUtil.ts
+++ b/src/i18n/i18nextUtil.ts
@@ -14,6 +14,41 @@
  * limitations under the License.
  */
 
+import { useTranslation, UseTranslationResponse } from "react-i18next";
+
+import en_common from '../../locales/en/common.json';
+import en_public from '../../locales/en/public.json';
+// import zh_common from '../../locales/zh/common.json';
+// import zh_public from '../../locales/zh/public.json';
+
+// TODO: .use(Backend) eventually store translations on backend?
+// Openshift console does this already:
+// https://github.com/openshift/console/blob/master/frontend/public/i18n.js
+export const i18nResources = {
+  en: {
+    public: en_public,
+    common: en_common,
+  },
+  // zh: {
+  //   // TODO: add zh translation (and other languages)?
+  //   // public: zh_public,
+  //   // common: zh_common,
+  // },
+} as const;
+
+export const i18nLanguages = Object.keys(i18nResources);
+
+export const i18nNamespaces = ['public', 'common'];
+
+const I18N_NAMESPACES = process.env.I18N_NAMESPACE || i18nNamespaces;
+
 export const localeReadable = (locale: string): string => {
   return new Intl.DisplayNames([locale], { type: 'language', languageDisplay: 'standard' }).of(locale) || locale;
+};
+
+/**
+ * Hook for using the i18n translation with I18_NAMESPACE namespace
+ */
+export const useCryostatTranslation = (): UseTranslationResponse<string, undefined> => {
+  return useTranslation(I18N_NAMESPACES);
 };

--- a/src/test/About/About.test.tsx
+++ b/src/test/About/About.test.tsx
@@ -65,6 +65,6 @@ describe('<About />', () => {
     expect(logo).toHaveClass('pf-v5-c-brand cryostat-logo');
     expect(logo).toHaveAttribute('alt', 'Cryostat');
     expect(logo).toHaveAttribute('src', 'test-file-stub');
-    expect(screen.getByText(testT('CRYOSTAT_TRADEMARK', { ns: 'common' }))).toBeInTheDocument();
+    expect(screen.getByText(testT('CRYOSTAT_TRADEMARK'))).toBeInTheDocument();
   });
 });

--- a/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisCard.test.tsx
@@ -319,7 +319,7 @@ describe('<AutomatedAnalysisCard />', () => {
 
     expect(screen.getByText(testT('AutomatedAnalysisCard.CARD_TITLE'))).toBeInTheDocument(); // Card title
     expect(screen.getByLabelText('Details')).toBeInTheDocument(); // Expandable content button
-    expect(screen.getByText(testT('NAME', { ns: 'common' }))).toBeInTheDocument(); // Default state filter
+    expect(screen.getByText(testT('NAME'))).toBeInTheDocument(); // Default state filter
     const refreshButton = screen.getByRole('button', {
       // Refresh button
       name: testT('AutomatedAnalysisCard.TOOLBAR.REFRESH.LABEL'),
@@ -377,7 +377,7 @@ describe('<AutomatedAnalysisCard />', () => {
 
     expect(screen.getByText(testT('AutomatedAnalysisCard.CARD_TITLE'))).toBeInTheDocument(); // Card title
     expect(screen.getByLabelText('Details')).toBeInTheDocument(); // Expandable content button
-    expect(screen.getByText(testT('NAME', { ns: 'common' }))).toBeInTheDocument(); // Default state filter
+    expect(screen.getByText(testT('NAME'))).toBeInTheDocument(); // Default state filter
     const refreshButton = screen.getByRole('button', {
       // Refresh button
       name: testT('AutomatedAnalysisCard.TOOLBAR.REFRESH.LABEL'),
@@ -449,7 +449,7 @@ describe('<AutomatedAnalysisCard />', () => {
 
     expect(screen.getByText(testT('AutomatedAnalysisCard.CARD_TITLE'))).toBeInTheDocument(); // Card title
     expect(screen.getByLabelText('Details')).toBeInTheDocument(); // Expandable content button
-    expect(screen.getByText(testT('NAME', { ns: 'common' }))).toBeInTheDocument(); // Default state filter
+    expect(screen.getByText(testT('NAME'))).toBeInTheDocument(); // Default state filter
     const refreshButton = screen.getByRole('button', {
       // Refresh button
       name: testT('AutomatedAnalysisCard.TOOLBAR.REFRESH.LABEL'),
@@ -532,7 +532,7 @@ describe('<AutomatedAnalysisCard />', () => {
       expect(screen.getByText(evaluation.topic)).toBeInTheDocument();
     });
 
-    const filterToggle = screen.getByText(testT('NAME', { ns: 'common' }));
+    const filterToggle = screen.getByText(testT('NAME'));
 
     await act(async () => {
       await user.click(filterToggle);

--- a/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.test.tsx
+++ b/src/test/Dashboard/AutomatedAnalysis/AutomatedAnalysisConfigForm.test.tsx
@@ -186,7 +186,7 @@ describe('<AutomatedAnalysisConfigForm />', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: testT('SAVE', { ns: 'common' }),
+        name: testT('SAVE'),
       }),
     );
     expect(setConfigRequestSpy).toHaveBeenCalledWith(config);

--- a/src/test/DateTimePicker/DateTimePicker.test.tsx
+++ b/src/test/DateTimePicker/DateTimePicker.test.tsx
@@ -113,7 +113,7 @@ describe('<DateTimePicker/>', () => {
     await user.click(selectedDate);
 
     // Switched to time now
-    const mInput = within(screen.getByLabelText(testT('MINUTE', { ns: 'common' }))).getByLabelText(
+    const mInput = within(screen.getByLabelText(testT('MINUTE'))).getByLabelText(
       testT('TimeSpinner.INPUT_MINUTE_VALUE'),
     );
     expect(mInput).toBeInTheDocument();
@@ -139,7 +139,7 @@ describe('<DateTimePicker/>', () => {
       },
     });
 
-    const submitButton = screen.getByText(testT('SELECT', { ns: 'common' }));
+    const submitButton = screen.getByText(testT('SELECT'));
     expect(submitButton).toBeInTheDocument();
     expect(submitButton).toBeVisible();
 
@@ -161,7 +161,7 @@ describe('<DateTimePicker/>', () => {
       },
     });
 
-    const dismissButton = screen.getByText(testT('CANCEL', { ns: 'common' }));
+    const dismissButton = screen.getByText(testT('CANCEL'));
     expect(dismissButton).toBeInTheDocument();
     expect(dismissButton).toBeVisible();
 

--- a/src/test/DateTimePicker/MeridiemPicker.test.tsx
+++ b/src/test/DateTimePicker/MeridiemPicker.test.tsx
@@ -53,7 +53,7 @@ describe('<MeridiemPicker/>', () => {
       },
     });
 
-    const pm = screen.getByText(testT('MERIDIEM_PM', { ns: 'common' }));
+    const pm = screen.getByText(testT('MERIDIEM_PM'));
     expect(pm).toBeInTheDocument();
     expect(pm).toBeVisible();
 

--- a/src/test/DateTimePicker/TimePicker.test.tsx
+++ b/src/test/DateTimePicker/TimePicker.test.tsx
@@ -91,9 +91,7 @@ describe('<TimePicker/>', () => {
 
     await user.click(toggleBtn12hr);
 
-    const hInput = within(screen.getByLabelText(testT('HOUR'))).getByLabelText(
-      testT('TimeSpinner.INPUT_HOUR12_VALUE'),
-    );
+    const hInput = within(screen.getByLabelText(testT('HOUR'))).getByLabelText(testT('TimeSpinner.INPUT_HOUR12_VALUE'));
     expect(hInput).toBeInTheDocument();
     expect(hInput).toBeVisible();
     expect(hInput.getAttribute('value')).toBe(format2Digit(mockSelectedIn12hr.hour12));
@@ -223,9 +221,7 @@ describe('<TimePicker/>', () => {
       },
     });
 
-    const hInput = within(screen.getByLabelText(testT('HOUR'))).getByLabelText(
-      testT('TimeSpinner.INPUT_HOUR24_VALUE'),
-    );
+    const hInput = within(screen.getByLabelText(testT('HOUR'))).getByLabelText(testT('TimeSpinner.INPUT_HOUR24_VALUE'));
     expect(hInput).toBeInTheDocument();
     expect(hInput).toBeVisible();
 

--- a/src/test/DateTimePicker/TimePicker.test.tsx
+++ b/src/test/DateTimePicker/TimePicker.test.tsx
@@ -91,21 +91,21 @@ describe('<TimePicker/>', () => {
 
     await user.click(toggleBtn12hr);
 
-    const hInput = within(screen.getByLabelText(testT('HOUR', { ns: 'common' }))).getByLabelText(
+    const hInput = within(screen.getByLabelText(testT('HOUR'))).getByLabelText(
       testT('TimeSpinner.INPUT_HOUR12_VALUE'),
     );
     expect(hInput).toBeInTheDocument();
     expect(hInput).toBeVisible();
     expect(hInput.getAttribute('value')).toBe(format2Digit(mockSelectedIn12hr.hour12));
 
-    const mInput = within(screen.getByLabelText(testT('MINUTE', { ns: 'common' }))).getByLabelText(
+    const mInput = within(screen.getByLabelText(testT('MINUTE'))).getByLabelText(
       testT('TimeSpinner.INPUT_MINUTE_VALUE'),
     );
     expect(mInput).toBeInTheDocument();
     expect(mInput).toBeVisible();
     expect(mInput.getAttribute('value')).toBe(format2Digit(mockSelectedIn12hr.minute));
 
-    const sInput = within(screen.getByLabelText(testT('SECOND', { ns: 'common' }))).getByLabelText(
+    const sInput = within(screen.getByLabelText(testT('SECOND'))).getByLabelText(
       testT('TimeSpinner.INPUT_SECOND_VALUE'),
     );
     expect(sInput).toBeInTheDocument();
@@ -137,7 +137,7 @@ describe('<TimePicker/>', () => {
       },
     });
 
-    const upHour = within(screen.getByLabelText(testT('HOUR', { ns: 'common' }))).getByLabelText(
+    const upHour = within(screen.getByLabelText(testT('HOUR'))).getByLabelText(
       testT('TimeSpinner.INCREMENT_HOUR24_VALUE'),
     );
     expect(upHour).toBeInTheDocument();
@@ -148,7 +148,7 @@ describe('<TimePicker/>', () => {
     expect(onHourSelect).toHaveBeenCalledTimes(1);
     expect(onHourSelect).toHaveBeenCalledWith(14);
 
-    const downHour = within(screen.getByLabelText(testT('HOUR', { ns: 'common' }))).getByLabelText(
+    const downHour = within(screen.getByLabelText(testT('HOUR'))).getByLabelText(
       testT('TimeSpinner.DECREMENT_HOUR24_VALUE'),
     );
     expect(downHour).toBeInTheDocument();
@@ -159,7 +159,7 @@ describe('<TimePicker/>', () => {
     expect(onHourSelect).toHaveBeenCalledTimes(2);
     expect(onHourSelect).toHaveBeenLastCalledWith(12);
 
-    const upMinute = within(screen.getByLabelText(testT('MINUTE', { ns: 'common' }))).getByLabelText(
+    const upMinute = within(screen.getByLabelText(testT('MINUTE'))).getByLabelText(
       testT('TimeSpinner.INCREMENT_MINUTE_VALUE'),
     );
     expect(upMinute).toBeInTheDocument();
@@ -170,7 +170,7 @@ describe('<TimePicker/>', () => {
     expect(onMinuteSelect).toHaveBeenCalledTimes(1);
     expect(onMinuteSelect).toHaveBeenCalledWith(12);
 
-    const downMinute = within(screen.getByLabelText(testT('MINUTE', { ns: 'common' }))).getByLabelText(
+    const downMinute = within(screen.getByLabelText(testT('MINUTE'))).getByLabelText(
       testT('TimeSpinner.DECREMENT_MINUTE_VALUE'),
     );
     expect(downMinute).toBeInTheDocument();
@@ -181,7 +181,7 @@ describe('<TimePicker/>', () => {
     expect(onMinuteSelect).toHaveBeenCalledTimes(2);
     expect(onMinuteSelect).toHaveBeenCalledWith(10);
 
-    const upSecond = within(screen.getByLabelText(testT('SECOND', { ns: 'common' }))).getByLabelText(
+    const upSecond = within(screen.getByLabelText(testT('SECOND'))).getByLabelText(
       testT('TimeSpinner.INCREMENT_SECOND_VALUE'),
     );
     expect(upSecond).toBeInTheDocument();
@@ -192,7 +192,7 @@ describe('<TimePicker/>', () => {
     expect(onSecondSelect).toHaveBeenCalledTimes(1);
     expect(onSecondSelect).toHaveBeenCalledWith(12);
 
-    const downSecond = within(screen.getByLabelText(testT('SECOND', { ns: 'common' }))).getByLabelText(
+    const downSecond = within(screen.getByLabelText(testT('SECOND'))).getByLabelText(
       testT('TimeSpinner.DECREMENT_SECOND_VALUE'),
     );
     expect(downSecond).toBeInTheDocument();
@@ -223,7 +223,7 @@ describe('<TimePicker/>', () => {
       },
     });
 
-    const hInput = within(screen.getByLabelText(testT('HOUR', { ns: 'common' }))).getByLabelText(
+    const hInput = within(screen.getByLabelText(testT('HOUR'))).getByLabelText(
       testT('TimeSpinner.INPUT_HOUR24_VALUE'),
     );
     expect(hInput).toBeInTheDocument();
@@ -233,7 +233,7 @@ describe('<TimePicker/>', () => {
     expect(onHourSelect).toHaveBeenCalledTimes(1);
     expect(onHourSelect).toHaveBeenLastCalledWith(1);
 
-    const mInput = within(screen.getByLabelText(testT('MINUTE', { ns: 'common' }))).getByLabelText(
+    const mInput = within(screen.getByLabelText(testT('MINUTE'))).getByLabelText(
       testT('TimeSpinner.INPUT_MINUTE_VALUE'),
     );
     expect(mInput).toBeInTheDocument();
@@ -243,7 +243,7 @@ describe('<TimePicker/>', () => {
     expect(onHourSelect).toHaveBeenCalledTimes(1);
     expect(onHourSelect).toHaveBeenLastCalledWith(1);
 
-    const sInput = within(screen.getByLabelText(testT('SECOND', { ns: 'common' }))).getByLabelText(
+    const sInput = within(screen.getByLabelText(testT('SECOND'))).getByLabelText(
       testT('TimeSpinner.INPUT_SECOND_VALUE'),
     );
     expect(sInput).toBeInTheDocument();

--- a/src/test/Recordings/RecordingFilters.test.tsx
+++ b/src/test/Recordings/RecordingFilters.test.tsx
@@ -175,7 +175,7 @@ describe('<RecordingFilters />', () => {
     expect(categoryToggle).toBeInTheDocument();
     expect(categoryToggle).toBeVisible();
 
-    const selectedItem = within(categoryToggle).getByText(testT('LABEL', { ns: 'common' }));
+    const selectedItem = within(categoryToggle).getByText(testT('LABEL'));
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
   });
@@ -209,7 +209,7 @@ describe('<RecordingFilters />', () => {
     expect(categoryToggle).toBeInTheDocument();
     expect(categoryToggle).toBeVisible();
 
-    const selectedItem = within(categoryToggle).getByText(testT('NAME', { ns: 'common' }));
+    const selectedItem = within(categoryToggle).getByText(testT('NAME'));
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
   });
@@ -244,7 +244,7 @@ describe('<RecordingFilters />', () => {
     expect(categoryToggle).toBeInTheDocument();
     expect(categoryToggle).toBeVisible();
 
-    const selectedItem = within(categoryToggle).getByText(testT('LABEL', { ns: 'common' }));
+    const selectedItem = within(categoryToggle).getByText(testT('LABEL'));
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
 
@@ -293,7 +293,7 @@ describe('<RecordingFilters />', () => {
     expect(categoryToggle).toBeInTheDocument();
     expect(categoryToggle).toBeVisible();
 
-    const selectedItem = within(categoryToggle).getByText(testT('NAME', { ns: 'common' }));
+    const selectedItem = within(categoryToggle).getByText(testT('NAME'));
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
 
@@ -342,7 +342,7 @@ describe('<RecordingFilters />', () => {
     expect(categoryToggle).toBeInTheDocument();
     expect(categoryToggle).toBeVisible();
 
-    const selectedItem = within(categoryToggle).getByText(testT('LABEL', { ns: 'common' }));
+    const selectedItem = within(categoryToggle).getByText(testT('LABEL'));
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
 
@@ -391,7 +391,7 @@ describe('<RecordingFilters />', () => {
     expect(categoryToggle).toBeInTheDocument();
     expect(categoryToggle).toBeVisible();
 
-    let selectedItem = within(categoryToggle).getByText(testT('LABEL', { ns: 'common' }));
+    let selectedItem = within(categoryToggle).getByText(testT('LABEL'));
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
 
@@ -411,11 +411,11 @@ describe('<RecordingFilters />', () => {
       await user.click(toSelectItem);
     });
 
-    selectedItem = within(categoryToggle).getByText(testT('NAME', { ns: 'common' }));
+    selectedItem = within(categoryToggle).getByText(testT('NAME'));
     expect(selectedItem).toBeInTheDocument();
     expect(selectedItem).toBeVisible();
 
-    const prevSelectedItem = within(categoryToggle).queryByText(testT('LABEL', { ns: 'common' }));
+    const prevSelectedItem = within(categoryToggle).queryByText(testT('LABEL'));
     expect(prevSelectedItem).not.toBeInTheDocument();
 
     const newFilterTool = container.querySelector("input[placeholder='Filter by name...'][type='text']");
@@ -450,11 +450,11 @@ describe('<RecordingFilters />', () => {
     });
 
     // Label group
-    let chipGroup = screen.getByRole('group', { name: testT('LABEL', { ns: 'common' }) });
+    let chipGroup = screen.getByRole('group', { name: testT('LABEL') });
     expect(chipGroup).toBeInTheDocument();
     expect(chipGroup).toBeVisible();
 
-    let chipGroupName = within(chipGroup).getByText(testT('LABEL', { ns: 'common' }));
+    let chipGroupName = within(chipGroup).getByText(testT('LABEL'));
     expect(chipGroupName).toBeInTheDocument();
     expect(chipGroupName).toBeVisible();
 
@@ -463,11 +463,11 @@ describe('<RecordingFilters />', () => {
     expect(chip).toBeVisible();
 
     // Name group
-    chipGroup = screen.getByRole('group', { name: testT('NAME', { ns: 'common' }) });
+    chipGroup = screen.getByRole('group', { name: testT('NAME') });
     expect(chipGroup).toBeInTheDocument();
     expect(chipGroup).toBeVisible();
 
-    chipGroupName = within(chipGroup).getByText(testT('NAME', { ns: 'common' }));
+    chipGroupName = within(chipGroup).getByText(testT('NAME'));
     expect(chipGroupName).toBeInTheDocument();
     expect(chipGroupName).toBeVisible();
 

--- a/src/test/Settings/FeatureLevels.test.tsx
+++ b/src/test/Settings/FeatureLevels.test.tsx
@@ -42,7 +42,7 @@ describe('<FeatureLevels/>', () => {
       },
     });
 
-    const productionOption = screen.getByText(testT(FeatureLevel[FeatureLevel.PRODUCTION], { ns: 'common' }));
+    const productionOption = screen.getByText(testT(FeatureLevel[FeatureLevel.PRODUCTION]));
     expect(productionOption).toBeInTheDocument();
     expect(productionOption).toBeVisible();
   });
@@ -72,17 +72,17 @@ describe('<FeatureLevels/>', () => {
     expect(ul).toBeVisible();
 
     await act(async () => {
-      await user.click(within(ul).getByText(testT(FeatureLevel[FeatureLevel.BETA], { ns: 'common' })));
+      await user.click(within(ul).getByText(testT(FeatureLevel[FeatureLevel.BETA])));
     });
 
     await waitFor(() => expect(ul).not.toBeInTheDocument()); // Should close menu
 
-    const betaOption = screen.getByText(testT(FeatureLevel[FeatureLevel.BETA], { ns: 'common' }));
+    const betaOption = screen.getByText(testT(FeatureLevel[FeatureLevel.BETA]));
 
     expect(betaOption).toBeInTheDocument();
     expect(betaOption).toBeVisible();
 
-    const productionOption = screen.queryByText(testT(FeatureLevel[FeatureLevel.PRODUCTION], { ns: 'common' }));
+    const productionOption = screen.queryByText(testT(FeatureLevel[FeatureLevel.PRODUCTION]));
     expect(productionOption).not.toBeInTheDocument();
   });
 });

--- a/src/test/Settings/Language.test.tsx
+++ b/src/test/Settings/Language.test.tsx
@@ -15,9 +15,9 @@
  */
 
 import { Language } from '@app/Settings/Config/Language';
-import i18next, { i18nLanguages } from '@i18n/config';
-import { localeReadable } from '@i18n/i18nextUtil';
+import { i18nLanguages, localeReadable } from '@i18n/i18nextUtil';
 import { act, cleanup, screen, waitFor, within } from '@testing-library/react';
+import i18next from 'i18next';
 import * as React from 'react';
 import { render, testT } from '../utils';
 

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -35,7 +35,8 @@ module.exports = merge(common('development'), {
       // Requests are proxied by dev-server
       // In preview mode, a base url is required.
       CRYOSTAT_AUTHORITY: process.env.PREVIEW? 'http://localhost:8181': '', 
-      PREVIEW: process.env.PREVIEW || 'false'
+      PREVIEW: process.env.PREVIEW || 'false',
+      I18N_NAMESPACE: process.env.I18N_NAMESPACE || ''
     })
   ],
   module: {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -44,7 +44,8 @@ module.exports = merge(common('production'), {
     }),
     new EnvironmentPlugin({
       CRYOSTAT_AUTHORITY: process.env.PREVIEW ? 'http://localhost:8181' : '',
-      PREVIEW: process.env.PREVIEW || 'false'
+      PREVIEW: process.env.PREVIEW || 'false',
+      I18N_NAMESPACE: process.env.I18N_NAMESPACE || ''
     })
   ],
   module: {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: [#1526 ](https://github.com/cryostatio/cryostat-web/issues/1526)

## Description of the change:
This change allows the i18n namespace(s) to be set as an environment variable.

To do so, I've added `useCryostatTranslation` to `@i18n/i18nextUtil` which is just `useTranslation` with the required namespaces being set.

I've also moved `i18nResources` and `i18nLanguages` from `@i18n/config` to `@i18n/i18nextUtil`, because I was encountering issues where the Settings page was breaking on the Console plugin side and using a different i18n object than what the Console was expecting.

I have a branch for the console plugin that includes some work to use these changes: https://github.com/aptmac/cryostat-openshift-console-plugin/commit/c8d2d547c34cc1ff1f3960bfd79148086594c3eb

At the moment that branch is out of sync with upstream, I'll be fixing that up soon. That commit includes the ability to combine the cryostat-web `common` and `public` with the console plugin side `common`, and renames it to `plugin__cryostat-plugin` so it can be picked up by the Console.

## Motivation for the change:
This change is helpful because it will allow the console plugin to pass it's i18n namespace (something like `plugin__cryostat-plugin`) and allow the cryostat-web pages to access the localized strings.

## Before
(nothing changes for cryostat-web, but here's the console plugin):

![Screenshot from 2025-01-09 11-52-35](https://github.com/user-attachments/assets/05837fc6-4a96-4ff0-9979-367edb47bc8c)

## After
![Screenshot from 2025-01-09 11-52-45](https://github.com/user-attachments/assets/6047f286-3b67-4328-972d-6562d6417253)
