### PR TITLE
fix(recordings): Fix active recordings table refresh behavior for replace:"ALWAYS"

### DIFF
--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -260,10 +260,10 @@ export const ActiveRecordingsTable: React.FC<ActiveRecordingsTableProps> = (prop
         if (currentTarget?.jvmId != event.message.jvmId) {
           return;
         }
-        setRecordings((old) => old.concat([event.message.recording]));
+        refreshRecordingList();
       }),
     );
-  }, [addSubscription, context, context.notificationChannel, setRecordings]);
+  }, [addSubscription, context, context.notificationChannel, refreshRecordingList]);
 
   React.useEffect(() => {
     addSubscription(
@@ -277,12 +277,11 @@ export const ActiveRecordingsTable: React.FC<ActiveRecordingsTableProps> = (prop
         if (currentTarget?.jvmId != event.message.jvmId) {
           return;
         }
-
-        setRecordings((old) => old.filter((r) => r.name !== event.message.recording.name));
         setCheckedIndices((old) => old.filter((idx) => idx !== event.message.recording.id));
+        refreshRecordingList();
       }),
     );
-  }, [addSubscription, context, context.notificationChannel, setRecordings, setCheckedIndices]);
+  }, [addSubscription, context, context.notificationChannel, setCheckedIndices, refreshRecordingList]);
 
   React.useEffect(() => {
     addSubscription(

--- a/src/app/Recordings/ActiveRecordingsTable.tsx
+++ b/src/app/Recordings/ActiveRecordingsTable.tsx
@@ -260,10 +260,10 @@ export const ActiveRecordingsTable: React.FC<ActiveRecordingsTableProps> = (prop
         if (currentTarget?.jvmId != event.message.jvmId) {
           return;
         }
-        refreshRecordingList();
+        setRecordings((old) => old.concat([event.message.recording]));
       }),
     );
-  }, [addSubscription, context, context.notificationChannel, refreshRecordingList]);
+  }, [addSubscription, context, context.notificationChannel, setRecordings]);
 
   React.useEffect(() => {
     addSubscription(
@@ -277,11 +277,11 @@ export const ActiveRecordingsTable: React.FC<ActiveRecordingsTableProps> = (prop
         if (currentTarget?.jvmId != event.message.jvmId) {
           return;
         }
+        setRecordings((old) => old.filter((r) => r.id !== event.message.recording.id));
         setCheckedIndices((old) => old.filter((idx) => idx !== event.message.recording.id));
-        refreshRecordingList();
       }),
     );
-  }, [addSubscription, context, context.notificationChannel, setCheckedIndices, refreshRecordingList]);
+  }, [addSubscription, context, context.notificationChannel, setRecordings, setCheckedIndices]);
 
   React.useEffect(() => {
     addSubscription(


### PR DESCRIPTION
Fixes: [#1286](https://github.com/cryostatio/cryostat-web/issues/1286)

This changes the activeRecordingsTable notification handling logic to call refreshRecordingsList when receiving creation/deletion notifications rather than updating with only the fields in the notification. This ensures that the state of the table remains accurate.

When the query in the linked issue is run a second time it results in the notifications being fired in the following order:

Recording Created
Recording Deleted

Pre-patch the table would see the recording deleted notification last and remove it from the table despite the recording still being present in the target. Calling refreshRecordingsList and getting the state of the target's recordings from the API shows the same.

## How to manually test:
1. Run Cryostat via smoketest or ./mvnw quarkus:dev
2. Run the following query twice: (Replace 8080 with 8181 if in quarkus:dev mode)

http --follow -v --auth='user:pass' POST :8080/api/v4/graphql \
                                                                  Content-Type:application/json \
                                                                  query='
                                                          query {
                                                            targetNodes(filter: { annotations: ["PORT = 9091"] }) {
                                                              name
                                                              target {
                                                                doStartRecording(recording: {
                                                                  name: "test9", 
                                                                  template: "Profiling",
                                                                  templateType: "TARGET",
                                                                  replace: "ALWAYS" 
                                                                }) {
                                                                  name
                                                                  state
                                                                }
                                                              }
                                                            }
                                                          }'