### PR TITLE
fix(routing): fix Link routing when using custom basepath

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -85,6 +85,7 @@ import { Link, matchPath, NavLink, useLocation, useNavigate } from 'react-router
 import { map } from 'rxjs/operators';
 import { LogoutIcon } from './LogoutIcon';
 import { ThemeToggle } from './ThemeToggle';
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 
 export interface AppLayoutProps {
   children?: React.ReactNode;
@@ -507,9 +508,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
           </MastheadToggle>
           <MastheadMain>
             <MastheadBrand component={'div'}>
-              <Link to={toPath("/")}>
+              <CryostatLink to={'/'}>
                 <Brand alt="Cryostat" src={cryostatLogo} className="cryostat-logo" />
-              </Link>
+              </CryostatLink>
             </MastheadBrand>
             <DynamicFeatureFlag levels={[FeatureLevel.DEVELOPMENT, FeatureLevel.BETA]} component={levelBadge} />
           </MastheadMain>

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -507,7 +507,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
           </MastheadToggle>
           <MastheadMain>
             <MastheadBrand component={'div'}>
-              <Link to="/">
+              <Link to={toPath("/")}>
                 <Brand alt="Cryostat" src={cryostatLogo} className="cryostat-logo" />
               </Link>
             </MastheadBrand>

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -25,6 +25,7 @@ import { GlobalQuickStartDrawer } from '@app/QuickStarts/QuickStartDrawer';
 import { IAppRoute, navGroups, routes } from '@app/routes';
 import { ThemeSetting, SettingTab } from '@app/Settings/types';
 import { DARK_THEME_CLASS, selectTab, tabAsParam } from '@app/Settings/utils';
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 import { DynamicFeatureFlag, FeatureFlag } from '@app/Shared/Components/FeatureFlag';
 import { NotificationCategory, Notification } from '@app/Shared/Services/api.types';
 import { NotificationsContext } from '@app/Shared/Services/Notifications.service';
@@ -85,7 +86,6 @@ import { Link, matchPath, NavLink, useLocation, useNavigate } from 'react-router
 import { map } from 'rxjs/operators';
 import { LogoutIcon } from './LogoutIcon';
 import { ThemeToggle } from './ThemeToggle';
-import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 
 export interface AppLayoutProps {
   children?: React.ReactNode;

--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { toPath } from '@app/utils/utils';
 import {
   Breadcrumb,
   BreadcrumbHeading,
@@ -40,7 +41,7 @@ export const BreadcrumbPage: React.FC<BreadcrumbPageProps> = ({ pageTitle, bread
         <Breadcrumb>
           {(breadcrumbs || []).map(({ title, path }) => (
             <BreadcrumbItem key={path}>
-              <Link to={path}>{title}</Link>
+              <Link to={toPath(path)}>{title}</Link>
             </BreadcrumbItem>
           ))}
           <BreadcrumbHeading>{pageTitle}</BreadcrumbHeading>

--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -27,6 +27,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 import { BreadcrumbTrail } from './types';
 import { isItemFilled } from './utils';
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 
 interface BreadcrumbPageProps {
   pageTitle: string;
@@ -41,7 +42,7 @@ export const BreadcrumbPage: React.FC<BreadcrumbPageProps> = ({ pageTitle, bread
         <Breadcrumb>
           {(breadcrumbs || []).map(({ title, path }) => (
             <BreadcrumbItem key={path}>
-              <Link to={toPath(path)}>{title}</Link>
+              <CryostatLink to={path}>{title}</CryostatLink>
             </BreadcrumbItem>
           ))}
           <BreadcrumbHeading>{pageTitle}</BreadcrumbHeading>

--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { toPath } from '@app/utils/utils';
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 import {
   Breadcrumb,
   BreadcrumbHeading,
@@ -24,10 +24,8 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { Link } from 'react-router-dom-v5-compat';
 import { BreadcrumbTrail } from './types';
 import { isItemFilled } from './utils';
-import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 
 interface BreadcrumbPageProps {
   pageTitle: string;

--- a/src/app/NotFound/NotFoundCard.tsx
+++ b/src/app/NotFound/NotFoundCard.tsx
@@ -15,11 +15,8 @@
  */
 
 import { CryostatLink } from '@app/Shared/Components/CryostatLink';
-import { toPath } from '@app/utils/utils';
 import { Card, CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
 import * as React from 'react';
-import { Link } from 'react-router-dom-v5-compat';
-
 export interface NotFoundCardProps {
   title: React.ReactNode;
   bodyText: React.ReactNode;

--- a/src/app/NotFound/NotFoundCard.tsx
+++ b/src/app/NotFound/NotFoundCard.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { toPath } from '@app/utils/utils';
 import { Card, CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
@@ -31,7 +32,7 @@ export const NotFoundCard: React.FC<NotFoundCardProps> = ({ title, bodyText, lin
       <CardTitle>{title}</CardTitle>
       <CardBody isFilled>{bodyText}</CardBody>
       <CardFooter>
-        <Link to={linkPath}>{linkText}</Link>
+        <Link to={toPath(linkPath)}>{linkText}</Link>
       </CardFooter>
     </Card>
   );

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -21,7 +21,7 @@ import { MatchExpressionDisplay } from '@app/Shared/Components/MatchExpression/M
 import { Rule, NotificationCategory } from '@app/Shared/Services/api.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
-import { TableColumn, formatBytes, formatDuration, sortResources, portalRoot } from '@app/utils/utils';
+import { TableColumn, formatBytes, formatDuration, sortResources, portalRoot, toPath } from '@app/utils/utils';
 import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
@@ -497,10 +497,10 @@ export const RulesTable: React.FC<RulesTableProps> = () => {
                 <Trans
                   t={t}
                   components={[
-                    <Link to={'/recordings'} />,
-                    <Link to={'/events'} />,
-                    <Link to={'/security'} />,
-                    <Link to={'/archives'} />,
+                    <Link to={toPath('/recordings')} />,
+                    <Link to={toPath('/events')} />,
+                    <Link to={toPath('/security')} />,
+                    <Link to={toPath('/archives')} />,
                   ]}
                 >
                   Rules.ABOUT_BODY

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -15,13 +15,14 @@
  */
 import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { DeleteOrDisableWarningType } from '@app/Modal/types';
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 import { EmptyText } from '@app/Shared/Components/EmptyText';
 import { LoadingView } from '@app/Shared/Components/LoadingView';
 import { MatchExpressionDisplay } from '@app/Shared/Components/MatchExpression/MatchExpressionDisplay';
 import { Rule, NotificationCategory } from '@app/Shared/Services/api.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
-import { TableColumn, formatBytes, formatDuration, sortResources, portalRoot, toPath } from '@app/utils/utils';
+import { TableColumn, formatBytes, formatDuration, sortResources, portalRoot } from '@app/utils/utils';
 import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Button,
@@ -60,12 +61,11 @@ import {
 import _ from 'lodash';
 import * as React from 'react';
 import { Trans } from 'react-i18next';
-import { Link, useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import { first } from 'rxjs/operators';
 import { RuleDeleteWarningModal } from './RuleDeleteWarningModal';
 import { RuleUploadModal } from './RulesUploadModal';
 import { RuleToDeleteOrDisable } from './types';
-import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 
 export interface RulesTableProps {}
 

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -65,6 +65,7 @@ import { first } from 'rxjs/operators';
 import { RuleDeleteWarningModal } from './RuleDeleteWarningModal';
 import { RuleUploadModal } from './RulesUploadModal';
 import { RuleToDeleteOrDisable } from './types';
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 
 export interface RulesTableProps {}
 
@@ -497,10 +498,10 @@ export const RulesTable: React.FC<RulesTableProps> = () => {
                 <Trans
                   t={t}
                   components={[
-                    <Link to={toPath('/recordings')} />,
-                    <Link to={toPath('/events')} />,
-                    <Link to={toPath('/security')} />,
-                    <Link to={toPath('/archives')} />,
+                    <CryostatLink to={'/recordings'} />,
+                    <CryostatLink to={'/events'} />,
+                    <CryostatLink to={'/security'} />,
+                    <CryostatLink to={'/archives'} />,
                   ]}
                 >
                   Rules.ABOUT_BODY

--- a/src/app/Shared/Components/CryostatLink.tsx
+++ b/src/app/Shared/Components/CryostatLink.tsx
@@ -14,27 +14,10 @@
  * limitations under the License.
  */
 
-import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 import { toPath } from '@app/utils/utils';
-import { Card, CardTitle, CardBody, CardFooter } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
-export interface NotFoundCardProps {
-  title: React.ReactNode;
-  bodyText: React.ReactNode;
-  linkText: React.ReactNode;
-  linkPath: string;
-}
-
-export const NotFoundCard: React.FC<NotFoundCardProps> = ({ title, bodyText, linkText, linkPath }) => {
-  return (
-    <Card isFullHeight isCompact isFlat isRounded>
-      <CardTitle>{title}</CardTitle>
-      <CardBody isFilled>{bodyText}</CardBody>
-      <CardFooter>
-        <CryostatLink to={linkPath}>{linkText}</CryostatLink>
-      </CardFooter>
-    </Card>
-  );
+export const CryostatLink: React.FC<{ to: string }> = ({ to, ...props }) => {
+  return <Link to={toPath(to)} {...props}></Link>;
 };

--- a/src/app/Topology/Actions/QuickSearchPanel.tsx
+++ b/src/app/Topology/Actions/QuickSearchPanel.tsx
@@ -16,7 +16,7 @@
 import { NotificationsContext } from '@app/Shared/Services/Notifications.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useFeatureLevel } from '@app/utils/hooks/useFeatureLevel';
-import { portalRoot } from '@app/utils/utils';
+import { portalRoot, toPath } from '@app/utils/utils';
 import {
   Bullseye,
   Button,
@@ -218,7 +218,7 @@ export const QuickSearchModal: React.FC<QuickSearchModalProps> = ({ isOpen, onCl
   const description = React.useMemo(() => {
     return (
       <span>
-        For quickstarts on how to create these entities, visit <Link to={'/quickstarts'}>Quick Starts</Link>.
+        For quickstarts on how to create these entities, visit <Link to={toPath('/quickstarts')}>Quick Starts</Link>.
       </span>
     );
   }, []);

--- a/src/app/Topology/Actions/QuickSearchPanel.tsx
+++ b/src/app/Topology/Actions/QuickSearchPanel.tsx
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 import { NotificationsContext } from '@app/Shared/Services/Notifications.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useFeatureLevel } from '@app/utils/hooks/useFeatureLevel';
-import { portalRoot, toPath } from '@app/utils/utils';
+import { portalRoot } from '@app/utils/utils';
 import {
   Bullseye,
   Button,
@@ -48,11 +49,10 @@ import { css } from '@patternfly/react-styles';
 import { useHover } from '@patternfly/react-topology';
 import _ from 'lodash';
 import * as React from 'react';
-import { Link, useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom-v5-compat';
 import QuickSearchIcon from '../../Shared/Components/QuickSearchIcon';
 import quickSearches, { QuickSearchId, quickSearchIds } from './quicksearches/all-quick-searches';
 import { QuickSearchItem } from './types';
-import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 
 export const QuickSearchTabContent: React.FC<{ item?: QuickSearchItem }> = ({ item, ...props }) => {
   const navigate = useNavigate();

--- a/src/app/Topology/Actions/QuickSearchPanel.tsx
+++ b/src/app/Topology/Actions/QuickSearchPanel.tsx
@@ -52,6 +52,7 @@ import { Link, useNavigate } from 'react-router-dom-v5-compat';
 import QuickSearchIcon from '../../Shared/Components/QuickSearchIcon';
 import quickSearches, { QuickSearchId, quickSearchIds } from './quicksearches/all-quick-searches';
 import { QuickSearchItem } from './types';
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 
 export const QuickSearchTabContent: React.FC<{ item?: QuickSearchItem }> = ({ item, ...props }) => {
   const navigate = useNavigate();
@@ -218,7 +219,8 @@ export const QuickSearchModal: React.FC<QuickSearchModalProps> = ({ isOpen, onCl
   const description = React.useMemo(() => {
     return (
       <span>
-        For quickstarts on how to create these entities, visit <Link to={toPath('/quickstarts')}>Quick Starts</Link>.
+        For quickstarts on how to create these entities, visit{' '}
+        <CryostatLink to={'/quickstarts'}>Quick Starts</CryostatLink>.
       </span>
     );
   }, []);

--- a/src/app/Topology/Shared/Components/TopologyEmptyState.tsx
+++ b/src/app/Topology/Shared/Components/TopologyEmptyState.tsx
@@ -16,6 +16,7 @@
 import { topologyDeleteAllFiltersIntent } from '@app/Shared/Redux/ReduxStore';
 import { getAllLeaves } from '@app/Shared/Services/api.utils';
 import { SearchExprServiceContext } from '@app/Shared/Services/service.utils';
+import { toPath } from '@app/utils/utils';
 import {
   Bullseye,
   Button,
@@ -49,7 +50,7 @@ export const TopologyEmptyState: React.FC<TopologyEmptyStateProps> = ({ ...props
       return (
         <EmptyStateActions>
           Start launching a Java application or define a{' '}
-          <Link to={'/topology/create-custom-target'}>Custom Target</Link>.
+          <Link to={toPath('/topology/create-custom-target')}>Custom Target</Link>.
         </EmptyStateActions>
       );
     }

--- a/src/app/Topology/Shared/Components/TopologyEmptyState.tsx
+++ b/src/app/Topology/Shared/Components/TopologyEmptyState.tsx
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 import { topologyDeleteAllFiltersIntent } from '@app/Shared/Redux/ReduxStore';
 import { getAllLeaves } from '@app/Shared/Services/api.utils';
 import { SearchExprServiceContext } from '@app/Shared/Services/service.utils';
-import { toPath } from '@app/utils/utils';
 import {
   Bullseye,
   Button,
@@ -31,9 +31,7 @@ import {
 import { TopologyIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
-import { Link } from 'react-router-dom-v5-compat';
 import { DiscoveryTreeContext } from '../utils';
-import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 
 export interface TopologyEmptyStateProps {}
 

--- a/src/app/Topology/Shared/Components/TopologyEmptyState.tsx
+++ b/src/app/Topology/Shared/Components/TopologyEmptyState.tsx
@@ -33,6 +33,7 @@ import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom-v5-compat';
 import { DiscoveryTreeContext } from '../utils';
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 
 export interface TopologyEmptyStateProps {}
 
@@ -50,7 +51,7 @@ export const TopologyEmptyState: React.FC<TopologyEmptyStateProps> = ({ ...props
       return (
         <EmptyStateActions>
           Start launching a Java application or define a{' '}
-          <Link to={toPath('/topology/create-custom-target')}>Custom Target</Link>.
+          <CryostatLink to={'/topology/create-custom-target'}>Custom Target</CryostatLink>.
         </EmptyStateActions>
       );
     }


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

This is a follow-up to: https://github.com/cryostatio/cryostat-web/pull/1534

## Description of the change:
The PR listed above made changes to allow setting a base path for routes, but missed instances of `<Link>`, so this PR adds the `toPath()` to those elements.

## Motivation for the change:
Fixes routing using `<Link>` elements when using a custom base path.

