### PR TITLE
fix(links): fix Breadcrumb links and improve CryostatLink

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -82,7 +82,7 @@ import {
 import _ from 'lodash';
 import * as React from 'react';
 import { Trans } from 'react-i18next';
-import { Link, matchPath, NavLink, useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { matchPath, NavLink, useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { map } from 'rxjs/operators';
 import { LogoutIcon } from './LogoutIcon';
 import { ThemeToggle } from './ThemeToggle';
@@ -338,7 +338,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
 
   const helpItems = React.useMemo(() => {
     return [
-      <DropdownItem key={'Quickstarts'} component={(props) => <Link {...props} to="/quickstarts" />}>
+      <DropdownItem key={'Quickstarts'} component={(props) => <CryostatLink {...props} to="/quickstarts" />}>
         {t('AppLayout.APP_LAUNCHER.QUICKSTARTS')}
       </DropdownItem>,
       <DropdownItem key={'Documentation'} onClick={handleOpenDocumentation}>
@@ -423,7 +423,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                     aria-label={t('AppLayout.TOOLBAR.ARIA_LABELS.SETTINGS')}
                     data-tour-id="settings-link"
                     data-quickstart-id="settings-link"
-                    component={(props) => <Link {...props} to="/settings" />}
+                    component={(props) => <CryostatLink {...props} to="/settings" />}
                   >
                     <Icon>
                       <CogIcon />

--- a/src/app/AppLayout/AuthModal.tsx
+++ b/src/app/AppLayout/AuthModal.tsx
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 import { NullableTarget, Target } from '@app/Shared/Services/api.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
+import { toPath } from '@app/utils/utils';
 import { Modal, ModalVariant, Text } from '@patternfly/react-core';
 import * as React from 'react';
-import { Link } from 'react-router-dom-v5-compat';
 import { Observable, filter, first, map, mergeMap } from 'rxjs';
 import { CredentialAuthForm } from './CredentialAuthForm';
 
@@ -69,9 +70,9 @@ export const AuthModal: React.FC<AuthModalProps> = ({ onDismiss, onSave: onProps
         <Text>
           This Target JVM requires authentication. The credentials you provide here will be passed from Cryostat to the
           target when establishing JMX connections. Enter credentials specific to this target, or go to{' '}
-          <Link onClick={onDismiss} to="/security">
+          <CryostatLink onClick={onDismiss} to={toPath('/security')}>
             Security
-          </Link>{' '}
+          </CryostatLink>{' '}
           to add a credential matching multiple targets.
         </Text>
       }

--- a/src/app/BreadcrumbPage/BreadcrumbPage.tsx
+++ b/src/app/BreadcrumbPage/BreadcrumbPage.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 import {
   Breadcrumb,
   BreadcrumbHeading,
@@ -24,6 +23,7 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import * as React from 'react';
+import { Link } from 'react-router-dom-v5-compat';
 import { BreadcrumbTrail } from './types';
 import { isItemFilled } from './utils';
 
@@ -40,7 +40,7 @@ export const BreadcrumbPage: React.FC<BreadcrumbPageProps> = ({ pageTitle, bread
         <Breadcrumb>
           {(breadcrumbs || []).map(({ title, path }) => (
             <BreadcrumbItem key={path}>
-              <CryostatLink to={path}>{title}</CryostatLink>
+              <Link to={path}>{title}</Link>
             </BreadcrumbItem>
           ))}
           <BreadcrumbHeading>{pageTitle}</BreadcrumbHeading>

--- a/src/app/NotFound/NotFound.tsx
+++ b/src/app/NotFound/NotFound.tsx
@@ -15,6 +15,7 @@
  */
 import '@app/app.css';
 import { IAppRoute, routes, flatten } from '@app/routes';
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
@@ -32,7 +33,6 @@ import {
 } from '@patternfly/react-core';
 import { MapMarkedAltIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { Link } from 'react-router-dom-v5-compat';
 import { NotFoundCard } from './NotFoundCard';
 
 export interface NotFoundProps {}
@@ -72,7 +72,7 @@ export const NotFound: React.FC<NotFoundProps> = (_) => {
         <EmptyStateBody>{t('NotFound.DESCRIPTION')}</EmptyStateBody>
         <EmptyStateFooter>
           <EmptyStateActions>
-            <Button variant="primary" component={(props) => <Link {...props} to="/" />}>
+            <Button variant="primary" component={(props) => <CryostatLink {...props} to="/" />}>
               {t('NotFound.HOME_REDIRECT_BUTTON_CONTENT')}
             </Button>
           </EmptyStateActions>

--- a/src/app/Shared/Components/CryostatLink.tsx
+++ b/src/app/Shared/Components/CryostatLink.tsx
@@ -18,6 +18,6 @@ import { toPath } from '@app/utils/utils';
 import React from 'react';
 import { Link } from 'react-router-dom-v5-compat';
 
-export const CryostatLink: React.FC<{ to: string }> = ({ to, ...props }) => {
-  return <Link to={toPath(to)} {...props}></Link>;
+export const CryostatLink: React.FC<{ to: string; onClick? }> = ({ to, onClick, ...props }) => {
+  return <Link to={toPath(to)} onClick={onClick} {...props}></Link>;
 };

--- a/src/app/TargetView/TargetContextSelector.tsx
+++ b/src/app/TargetView/TargetContextSelector.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { CryostatLink } from '@app/Shared/Components/CryostatLink';
 import { LinearDotSpinner } from '@app/Shared/Components/LinearDotSpinner';
 import { ScrollableMenuContent } from '@app/Shared/Components/ScrollableMenuContent';
 import { Target } from '@app/Shared/Services/api.types';
@@ -40,7 +41,6 @@ import {
 } from '@patternfly/react-core';
 import _ from 'lodash';
 import * as React from 'react';
-import { Link } from 'react-router-dom-v5-compat';
 
 export interface TargetContextSelectorProps {
   className?: string;
@@ -209,7 +209,10 @@ export const TargetContextSelector: React.FC<TargetContextSelectorProps> = ({ cl
     () => (
       <ActionList>
         <ActionListItem>
-          <Button variant="secondary" component={(props) => <Link {...props} to={'/topology/create-custom-target'} />}>
+          <Button
+            variant="secondary"
+            component={(props) => <CryostatLink {...props} to={'/topology/create-custom-target'} />}
+          >
             {t('TargetContextSelector.CREATE_TARGET')}
           </Button>
         </ActionListItem>

--- a/src/app/Topology/Shared/utils.tsx
+++ b/src/app/Topology/Shared/utils.tsx
@@ -19,6 +19,7 @@ import { JmxSslDescription } from '@app/Shared/Components/JmxSslDescription';
 import { TopologyFilters } from '@app/Shared/Redux/Filters/TopologyFilterSlice';
 import { NodeType, EnvironmentNode, TargetNode, keyValueToString } from '@app/Shared/Services/api.types';
 import { DEFAULT_EMPTY_UNIVERSE, isTargetNode } from '@app/Shared/Services/api.utils';
+import { toPath } from '@app/utils/utils';
 import {
   Button,
   Text,
@@ -80,7 +81,10 @@ export const getStatusTargetNode = (node: TargetNode | EnvironmentNode): [NodeSt
                   </Popover>
                 </DescriptionListTermHelpText>{' '}
                 for JMX,{' '}
-                <WarningResolverAsLink key={`${node.target.alias}-resolver-as-link-to-security`} to="/security">
+                <WarningResolverAsLink
+                  key={`${node.target.alias}-resolver-as-link-to-security`}
+                  to={toPath('/security')}
+                >
                   check if the SSL/TLS certificate is loaded.
                 </WarningResolverAsLink>
                 .


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

## Description of the change:
Updates the TargetContextSelector and NotFound components to use the CryostatLink intsead of Link, to properly route when using a basepath.

Updates the CryostatLink to optionally handle onClick, so it can be used in a couple more areas.

Fixes the breadcrumb links to just simply use <Link>, because the incoming routes already have a basepath prepended they do not have to use <CryostatLink> (it's added twice).

## Motivation for the change:
Clicking around the console plugin I ran into a 404 on the TargetContextSelector because it was routing to '/topology/create-custom-target' instead of '/cryostat/topology/create-custom-target'. This PR updates that usage, as well as remaining areas involved with Links.
