### PR TITLE
fix(notifications): correctly append query parameters

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1564,7 +1564,6 @@ export class ApiService {
     suppressNotifications = false,
     skipStatusCheck = false,
   ): Observable<XMLHttpResponse> {
-  console.log({ method, apiVersion, path, headers, params });
     const req = () =>
       from(
         new Promise<XMLHttpResponse>((resolve, reject) => {
@@ -1615,7 +1614,6 @@ export class ApiService {
 
               // Populate headers
               headers && Object.keys(headers).forEach((k) => {
-              console.log(`Setting request header: ${k}=${headers[k]}`);
 xhr.setRequestHeader(k, headers[k]);
               });
               xhr.withCredentials = true;

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1564,6 +1564,7 @@ export class ApiService {
     suppressNotifications = false,
     skipStatusCheck = false,
   ): Observable<XMLHttpResponse> {
+  console.log({ method, apiVersion, path, headers, params });
     const req = () =>
       from(
         new Promise<XMLHttpResponse>((resolve, reject) => {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1613,9 +1613,7 @@ export class ApiService {
               });
 
               // Populate headers
-              headers && Object.keys(headers).forEach((k) => {
-xhr.setRequestHeader(k, headers[k]);
-              });
+              headers && Object.keys(headers).forEach((k) => xhr.setRequestHeader(k, headers[k]));
               xhr.withCredentials = true;
 
               // Send request

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1614,7 +1614,10 @@ export class ApiService {
               });
 
               // Populate headers
-              headers && Object.keys(headers).forEach((k) => xhr.setRequestHeader(k, headers[k]));
+              headers && Object.keys(headers).forEach((k) => {
+              console.log(`Setting request header: ${k}=${headers[k]}`);
+xhr.setRequestHeader(k, headers[k]);
+              });
               xhr.withCredentials = true;
 
               // Send request

--- a/src/app/Shared/Services/NotificationChannel.service.tsx
+++ b/src/app/Shared/Services/NotificationChannel.service.tsx
@@ -104,6 +104,10 @@ export class NotificationChannel {
           // parameters instead so that the plugin backend can fall back to finding those.
           return this.ctx.headers().pipe(
             map((headers) => {
+              const u = URL.parse(url);
+              if (!u) {
+                return url;
+              }
               const searchParams = new URLSearchParams();
               if (headers.has('CRYOSTAT-SVC-NS')) {
                 searchParams.append('ns', headers.get('CRYOSTAT-SVC-NS')!);
@@ -112,9 +116,14 @@ export class NotificationChannel {
                 searchParams.append('name', headers.get('CRYOSTAT-SVC-NAME')!);
               }
               if (searchParams.size > 0) {
-                return `${url}?${searchParams}`;
+                if (!u.search) {
+                  u.search = '?';
+                } else {
+                  u.search += '&';
+                }
+                u.search += searchParams.toString();
               }
-              return url;
+              return u.toString();
             }),
           );
         }),


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1544

## Description of the change:
When the request already contains query parameters, for example when originating from the Archives view where a `?tab=foo` query parameter is used for routing to the specific tabbed subview, the previous logic would incorrectly build a query string like `?tab=foo?ns=namespace&name=cryostat`. Note the doubled-up `?`.