### PR TITLE
fix(download): use contextual URL mapping for file downloads

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -859,6 +859,7 @@ export class ApiService {
   downloadRecording(recording: Recording): void {
     this.ctx.url(recording.downloadUrl).subscribe((resourceUrl) => {
       this.downloadFile(resourceUrl, recording.name + (recording.name.endsWith('.jfr') ? '' : '.jfr'));
+
       const metadataUrl = createBlobURL(JSON.stringify(recording.metadata), 'application/json');
       this.downloadFile(metadataUrl, recording.name.replace(/\.jfr$/, '') + '.metadata.json', false);
       setTimeout(() => URL.revokeObjectURL(metadataUrl), 1000);
@@ -871,10 +872,9 @@ export class ApiService {
       .pipe(
         filter((t) => !!t),
         first(),
-        concatMap((target) =>
-          this.ctx.url(
+        map(
+          (target) =>
             `/api/v4/targets/${target!.id}/event_templates/${encodeURIComponent(template.type)}/${encodeURIComponent(template.name)}`,
-          ),
         ),
         concatMap((resourceUrl) => this.ctx.url(resourceUrl)),
       )

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -885,17 +885,12 @@ export class ApiService {
   }
 
   downloadRule(name: string): void {
-    const filename = `${name}.json`;
     this.doGet<Rule>(`rules/${name}`)
-      .pipe(
-        first(),
-        map((rule) => {
-          const file = new File([JSON.stringify(rule)], filename);
-          return URL.createObjectURL(file);
-        }),
-        concatMap((resourceUrl) => this.ctx.url(resourceUrl)),
-      )
-      .subscribe((resourceUrl) => {
+      .pipe(first())
+      .subscribe((rule) => {
+        const filename = `${rule.name}.json`;
+        const file = new File([JSON.stringify(rule)], filename);
+        const resourceUrl = URL.createObjectURL(file);
         this.downloadFile(resourceUrl, filename);
         setTimeout(() => URL.revokeObjectURL(resourceUrl), 1000);
       });

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1459,15 +1459,37 @@ export class ApiService {
   }
 
   private downloadFile(url: string, filename: string, download = true): void {
-    const anchor = document.createElement('a');
-    anchor.setAttribute('style', 'display: none; visibility: hidden;');
-    anchor.target = '_blank';
-    if (download) {
-      anchor.download = filename;
-    }
-    anchor.href = url;
-    anchor.click();
-    anchor.remove();
+    this.ctx.headers().subscribe((headers) => {
+      const anchor = document.createElement('a');
+      anchor.setAttribute('style', 'display: none; visibility: hidden;');
+      anchor.target = '_blank';
+      let href = url;
+      if (download) {
+        anchor.download = filename;
+      }
+
+      let ns: string | undefined;
+      let name: string | undefined;
+      if (headers.has('cryostat-svc-ns')) {
+        ns = headers.get('cryostat-svc-ns')!;
+      }
+      if (headers.has('cryostat-svc-name')) {
+        name = headers.get('cryostat-svc-name')!;
+      }
+      if (ns && name) {
+        const query = new URLSearchParams([
+          ['ns', ns],
+          ['name', name],
+        ]);
+        // TODO more robust processing of the incoming url string. If it already contains
+        // query parameters then this concatenation will result in two ? separators.
+        href += `?${query}`;
+      }
+
+      anchor.href = href;
+      anchor.click();
+      anchor.remove();
+    });
   }
 
   private transformTarget(target: Target): TargetForTest {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1544 #1542
Fixes https://github.com/cryostatio/cryostat-web/issues/1549

## Description of the change:
Similar to the other recent "contextual" changes in support of the OpenShift Console Plugin.

We use a common client-side JavaScript trick to trigger the browser to download files - we create a virtual `<a href="/path/to/download" />` element and trigger a simulated click on it. This way the browser's native file download facilities handle the download, including whatever download stream management may apply etc. This is generally better than trying to use `XMLHttpRequest` or `fetch` APIs directly, since those would require us to use `blob` types and generally download the whole object into browser memory, then `createObjectURL` to save the blob to a file. This does not trigger the typical browser download manager or progress indicator, and even worse means that we cannot handle particularly large files since the entire file will be loaded into memory first, and browsers tend to apply limits to that.

But the problem with the `<a href= />` approach is that this only allows us to set a URL for a `GET` request. If the URL is already on the same Origin as the page then it should include things like `Authorization` headers automatically, but we don't have any control to add any custom headers or anything else like that, which we otherwise would have with `fetch or might have with `XMLHttpRequest` APIs.

"Luckily" we can hack this since #1542 and #1544 and https://github.com/cryostatio/cryostat-openshift-console-plugin/pull/85 . It becomes possible to specify the `CRYOSTAT-SVC-NS` and `CRYOSTAT-SVC-NAME` header values, which are used by the Console Plugin to add Cryostat instance selection metadata for the plugin backend proxy, as either request headers *or* as query parameters. This is because opening a WebSocket connection to the Cryostat server (or plugin backend proxy) has similar restrictions where we cannot add custom headers, but we can add query parameters. So by reusing this same mechanism and technique, we can add query parameters to the `href` attached to the `<a />` and send the Cryostat instance selection metadata to the plugin backend. For the normal Cryostat UI case where the UI is served directly by Cryostat itself and the browser client is talking directly to a Cryostat instance, these headers are defaulted to empty and no query parameters are added.

Using this technique, the following file downloads should be possible both in the normal UI case as well as the plugin case:
- dashboard layout template
- automated rules
- active recordings - JFR file and `.metadata.json`
- archived recordings - JFR file and `.metadata.json`
- event templates