### PR TITLE
fix(archives): add keys to Archive tabs to prevent setExtraStackFrame error

### DIFF
--- a/src/app/Archives/Archives.tsx
+++ b/src/app/Archives/Archives.tsx
@@ -81,19 +81,34 @@ export const Archives: React.FC<ArchivesProps> = ({ ...props }) => {
     const arr: JSX.Element[] = [];
     if (archiveEnabled) {
       arr.push(
-        <Tab id="all-targets" key={ArchiveTab.ALL_TARGETS} eventKey={ArchiveTab.ALL_TARGETS} title={<TabTitleText>All Targets</TabTitleText>}>
+        <Tab
+          id="all-targets"
+          key={ArchiveTab.ALL_TARGETS}
+          eventKey={ArchiveTab.ALL_TARGETS}
+          title={<TabTitleText>All Targets</TabTitleText>}
+        >
           <AllTargetsArchivedRecordingsTable />
         </Tab>,
       );
       arr.push(
-        <Tab id="all-archives" key={ArchiveTab.ALL_ARCHIVES} eventKey={ArchiveTab.ALL_ARCHIVES} title={<TabTitleText>All Archives</TabTitleText>}>
+        <Tab
+          id="all-archives"
+          key={ArchiveTab.ALL_ARCHIVES}
+          eventKey={ArchiveTab.ALL_ARCHIVES}
+          title={<TabTitleText>All Archives</TabTitleText>}
+        >
           <AllArchivedRecordingsTable />
         </Tab>,
       );
 
       if (capabilities.fileUploads) {
         arr.push(
-          <Tab id="uploads" key={ArchiveTab.UPLOADS} eventKey={ArchiveTab.UPLOADS} title={<TabTitleText>Uploads</TabTitleText>}>
+          <Tab
+            id="uploads"
+            key={ArchiveTab.UPLOADS}
+            eventKey={ArchiveTab.UPLOADS}
+            title={<TabTitleText>Uploads</TabTitleText>}
+          >
             <ArchivedRecordingsTable target={uploadTargetAsObs} isUploadsTable={true} isNestedTable={false} />
           </Tab>,
         );

--- a/src/app/Archives/Archives.tsx
+++ b/src/app/Archives/Archives.tsx
@@ -81,19 +81,19 @@ export const Archives: React.FC<ArchivesProps> = ({ ...props }) => {
     const arr: JSX.Element[] = [];
     if (archiveEnabled) {
       arr.push(
-        <Tab id="all-targets" eventKey={ArchiveTab.ALL_TARGETS} title={<TabTitleText>All Targets</TabTitleText>}>
+        <Tab id="all-targets" key={ArchiveTab.ALL_TARGETS} eventKey={ArchiveTab.ALL_TARGETS} title={<TabTitleText>All Targets</TabTitleText>}>
           <AllTargetsArchivedRecordingsTable />
         </Tab>,
       );
       arr.push(
-        <Tab id="all-archives" eventKey={ArchiveTab.ALL_ARCHIVES} title={<TabTitleText>All Archives</TabTitleText>}>
+        <Tab id="all-archives" key={ArchiveTab.ALL_ARCHIVES} eventKey={ArchiveTab.ALL_ARCHIVES} title={<TabTitleText>All Archives</TabTitleText>}>
           <AllArchivedRecordingsTable />
         </Tab>,
       );
 
       if (capabilities.fileUploads) {
         arr.push(
-          <Tab id="uploads" eventKey={ArchiveTab.UPLOADS} title={<TabTitleText>Uploads</TabTitleText>}>
+          <Tab id="uploads" key={ArchiveTab.UPLOADS} eventKey={ArchiveTab.UPLOADS} title={<TabTitleText>Uploads</TabTitleText>}>
             <ArchivedRecordingsTable target={uploadTargetAsObs} isUploadsTable={true} isNestedTable={false} />
           </Tab>,
         );


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat-openshift-console-plugin/issues/102

## Description of the change:
Adds keys to the Tab components generated for the Archives page.

## Motivation for the change:
Without the keys, an error is thrown in the console plugin when running a local console frontend: `Cannot read property 'setExtraStackFrame' of undefined`.