### PR TITLE
fix(api): merge contextual headers

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1541,10 +1541,7 @@ export class ApiService {
               cfg.headers = new Headers();
             }
             const mergedHeaders = new Headers();
-            [headers, cfg.headers].forEach((source) => {
-              const h = new Headers(source);
-              h.forEach((v, k) => mergedHeaders.set(k, v));
-            });
+            [headers, cfg.headers].forEach((source) => new Headers(source).forEach((v, k) => mergedHeaders.set(k, v)));
             cfg.headers = mergedHeaders;
             return cfg;
           }),

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1534,13 +1534,18 @@ export class ApiService {
     const req = () =>
       combineLatest([
         this.ctx.url(`${p}${params ? '?' + params : ''}`),
-        this.ctx.headers((config || {}).headers).pipe(
+        this.ctx.headers(config?.headers).pipe(
           map((headers) => {
-            let cfg = config;
-            if (!cfg) {
-              cfg = {};
+            const cfg = config || {};
+            if (!cfg.headers) {
+              cfg.headers = new Headers();
             }
-            cfg.headers = headers;
+            const mergedHeaders = new Headers();
+            [headers, cfg.headers].forEach((source) => {
+              const h = new Headers(source);
+              h.forEach((v, k) => mergedHeaders.set(k, v));
+            });
+            cfg.headers = mergedHeaders;
             return cfg;
           }),
         ),


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat-openshift-console-plugin/issues/107

## Description of the change:
Fixes up logic where request headers could get overwritten instead of correctly merged.

## Motivation for the change:
See https://github.com/cryostatio/cryostat-openshift-console-plugin/issues/107

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
