### PR TITLE
fix(grafana): Grafana dashboard uses contextual path and parameters and capability to override URL

### DIFF
--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -51,13 +51,18 @@ export const RecordingActions: React.FC<RecordingActionsProps> = ({ recording, u
   const addSubscription = useSubscriptions();
 
   React.useEffect(() => {
-    addSubscription(
-      context.api
-        .grafanaDatasourceUrl()
-        .pipe(first())
-        .subscribe(() => setGrafanaEnabled(true)),
-    );
-  }, [context.api, setGrafanaEnabled, addSubscription]);
+    if (
+      capabilities.openGrafana === true ||
+      (typeof capabilities.openGrafana === 'string' && capabilities.openGrafana)
+    ) {
+      addSubscription(
+        context.api
+          .grafanaDatasourceUrl()
+          .pipe(first())
+          .subscribe(() => setGrafanaEnabled(true)),
+      );
+    }
+  }, [capabilities, context.api, setGrafanaEnabled, addSubscription]);
 
   const grafanaUpload = React.useCallback(() => {
     addSubscription(
@@ -71,7 +76,7 @@ export const RecordingActions: React.FC<RecordingActionsProps> = ({ recording, u
           ),
           tap(() => notifications.success('Upload Success', `Recording ${recording.name} uploaded`)),
         )
-        .subscribe(() => context.api.openGrafanaDashboard(capabilities.openNewTab)),
+        .subscribe(() => context.api.openGrafanaDashboard(capabilities.openGrafana)),
     );
   }, [capabilities, addSubscription, notifications, context.api, context.notificationChannel, recording, uploadFn]);
 

--- a/src/app/Recordings/RecordingActions.tsx
+++ b/src/app/Recordings/RecordingActions.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { NotificationCategory, Recording, Target } from '@app/Shared/Services/api.types';
+import { CapabilitiesContext } from '@app/Shared/Services/Capabilities';
 import { NotificationsContext } from '@app/Shared/Services/Notifications.service';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
@@ -42,6 +43,7 @@ export interface RecordingActionsProps {
 export const RecordingActions: React.FC<RecordingActionsProps> = ({ recording, uploadFn, ...props }) => {
   const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
+  const capabilities = React.useContext(CapabilitiesContext);
   const notifications = React.useContext(NotificationsContext);
   const [grafanaEnabled, setGrafanaEnabled] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
@@ -68,11 +70,10 @@ export const RecordingActions: React.FC<RecordingActionsProps> = ({ recording, u
               .pipe(filter((n) => n.message.jobId === jobId)),
           ),
           tap(() => notifications.success('Upload Success', `Recording ${recording.name} uploaded`)),
-          concatMap(() => context.api.grafanaDashboardUrl()),
         )
-        .subscribe((url) => window.open(url, '_blank')),
+        .subscribe(() => context.api.openGrafanaDashboard(capabilities.openNewTab)),
     );
-  }, [addSubscription, notifications, context.api, context.notificationChannel, recording, uploadFn]);
+  }, [capabilities, addSubscription, notifications, context.api, context.notificationChannel, recording, uploadFn]);
 
   const handleDownloadRecording = React.useCallback(() => {
     context.api.downloadRecording(recording);

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -744,9 +744,9 @@ export class ApiService {
   }
 
   openGrafanaDashboard(newTab = true): void {
-    this.grafanaDashboardUrl().subscribe((u) => {
+    combineLatest([this.grafanaDashboardUrl(), this.headersAsQuery()]).subscribe(([url, query]) => {
       const target = newTab ? '_blank' : '_self';
-      window.open(u, target);
+      window.open(`${url}?${query}`, target);
     });
   }
 
@@ -1461,8 +1461,8 @@ export class ApiService {
     return JSON.stringify(download);
   }
 
-  private downloadFile(url: string, filename: string, headers = true): void {
-    const qs = this.ctx.headers().pipe(
+  private headersAsQuery(): Observable<string> {
+    return this.ctx.headers().pipe(
       map((headers) => {
         let ns: string | undefined;
         let name: string | undefined;
@@ -1482,8 +1482,10 @@ export class ApiService {
         return '';
       }),
     );
+  }
 
-    const o = headers ? qs : of('');
+  private downloadFile(url: string, filename: string, headers = true): void {
+    const o = headers ? this.headersAsQuery() : of('');
     o.subscribe((q) => {
       const anchor = document.createElement('a');
       anchor.setAttribute('style', 'display: none; visibility: hidden;');

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -740,7 +740,7 @@ export class ApiService {
   }
 
   grafanaDashboardUrl(): Observable<string> {
-    return this.grafanaDashboardUrlSubject.asObservable();
+    return this.grafanaDashboardUrlSubject.asObservable().pipe(concatMap((url) => this.ctx.url(url)));
   }
 
   doGet<T>(

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -743,11 +743,18 @@ export class ApiService {
     return this.grafanaDashboardUrlSubject.asObservable().pipe(concatMap((url) => this.ctx.url(url)));
   }
 
-  openGrafanaDashboard(newTab = true): void {
-    combineLatest([this.grafanaDashboardUrl(), this.instanceSelectorHeadersAsQuery()]).subscribe(([url, query]) => {
-      const target = newTab ? '_blank' : '_self';
-      window.open(`${url}?${query}`, target);
-    });
+  openGrafanaDashboard(openGrafana: string | boolean): void {
+    let url: Observable<string>;
+    if (openGrafana === true) {
+      url = combineLatest([this.grafanaDashboardUrl(), this.instanceSelectorHeadersAsQuery()]).pipe(
+        map(([url, query]) => `${url}?${query}`),
+      );
+    } else if (typeof openGrafana === 'string' && openGrafana) {
+      url = of(openGrafana);
+    } else {
+      return;
+    }
+    url.subscribe((u) => window.open(u, '_blank'));
   }
 
   doGet<T>(

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -743,6 +743,13 @@ export class ApiService {
     return this.grafanaDashboardUrlSubject.asObservable().pipe(concatMap((url) => this.ctx.url(url)));
   }
 
+  openGrafanaDashboard(newTab = true): void {
+    this.grafanaDashboardUrl().subscribe((u) => {
+      const target = newTab ? '_blank' : '_self';
+      window.open(u, target);
+    });
+  }
+
   doGet<T>(
     path: string,
     apiVersion: ApiVersion = 'v4',

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -744,7 +744,7 @@ export class ApiService {
   }
 
   openGrafanaDashboard(newTab = true): void {
-    combineLatest([this.grafanaDashboardUrl(), this.headersAsQuery()]).subscribe(([url, query]) => {
+    combineLatest([this.grafanaDashboardUrl(), this.instanceSelectorHeadersAsQuery()]).subscribe(([url, query]) => {
       const target = newTab ? '_blank' : '_self';
       window.open(`${url}?${query}`, target);
     });
@@ -1461,7 +1461,7 @@ export class ApiService {
     return JSON.stringify(download);
   }
 
-  private headersAsQuery(): Observable<string> {
+  private instanceSelectorHeadersAsQuery(): Observable<string> {
     return this.ctx.headers().pipe(
       map((headers) => {
         let ns: string | undefined;
@@ -1485,7 +1485,7 @@ export class ApiService {
   }
 
   private downloadFile(url: string, filename: string, headers = true): void {
-    const o = headers ? this.headersAsQuery() : of('');
+    const o = headers ? this.instanceSelectorHeadersAsQuery() : of('');
     o.subscribe((q) => {
       const anchor = document.createElement('a');
       anchor.setAttribute('style', 'display: none; visibility: hidden;');

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -740,15 +740,13 @@ export class ApiService {
   }
 
   grafanaDashboardUrl(): Observable<string> {
-    return this.grafanaDashboardUrlSubject.asObservable().pipe(concatMap((url) => this.ctx.url(url)));
+    return this.grafanaDashboardUrlSubject.asObservable();
   }
 
   openGrafanaDashboard(openGrafana: string | boolean): void {
     let url: Observable<string>;
     if (openGrafana === true) {
-      url = combineLatest([this.grafanaDashboardUrl(), this.instanceSelectorHeadersAsQuery()]).pipe(
-        map(([url, query]) => `${url}?${query}`),
-      );
+      url = this.grafanaDashboardUrl();
     } else if (typeof openGrafana === 'string' && openGrafana) {
       url = of(openGrafana);
     } else {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -100,18 +100,8 @@ export class ApiService {
   }
 
   private testHealth() {
-    const getDatasourceURL: Observable<GrafanaDashboardUrlGetResponse> = this.ctx
-      .url('/api/v4/grafana_datasource_url')
-      .pipe(
-        concatMap((u) => fromFetch(u)),
-        concatMap((resp) => from(resp.json())),
-      );
-    const getDashboardURL: Observable<GrafanaDashboardUrlGetResponse> = this.ctx
-      .url('/api/v4/grafana_dashboard_url')
-      .pipe(
-        concatMap((u) => fromFetch(u)),
-        concatMap((resp) => from(resp.json())),
-      );
+    const datasourceURL: Observable<GrafanaDashboardUrlGetResponse> = this.doGet('/grafana_datasource_url', 'v4');
+    const dashboardURL: Observable<GrafanaDashboardUrlGetResponse> = this.doGet('/grafana_dashboard_url', 'v4');
     const health: Observable<HealthGetResponse> = this.doGet('/health', 'unversioned');
 
     health
@@ -127,7 +117,7 @@ export class ApiService {
           // if both configured and available then display nothing and just retrieve the URLs
           if (jsonResp.datasourceConfigured) {
             if (jsonResp.datasourceAvailable) {
-              toFetch.push(getDatasourceURL);
+              toFetch.push(datasourceURL);
             } else {
               unavailable.push('datasource URL');
             }
@@ -136,7 +126,7 @@ export class ApiService {
           }
           if (jsonResp.dashboardConfigured) {
             if (jsonResp.dashboardAvailable) {
-              toFetch.push(getDashboardURL);
+              toFetch.push(dashboardURL);
             } else {
               unavailable.push('dashboard URL');
             }

--- a/src/app/Shared/Services/Capabilities.tsx
+++ b/src/app/Shared/Services/Capabilities.tsx
@@ -17,11 +17,11 @@ import * as React from 'react';
 
 interface Capabilities {
   fileUploads: boolean;
-  openNewTab: boolean;
+  openGrafana: string | boolean;
 }
 const defaultCapabilities: Capabilities = {
   fileUploads: true,
-  openNewTab: true,
+  openGrafana: true,
 };
 
 const CapabilitiesContext: React.Context<Capabilities> = React.createContext(defaultCapabilities);

--- a/src/app/Shared/Services/Capabilities.tsx
+++ b/src/app/Shared/Services/Capabilities.tsx
@@ -17,9 +17,11 @@ import * as React from 'react';
 
 interface Capabilities {
   fileUploads: boolean;
+  openNewTab: boolean;
 }
 const defaultCapabilities: Capabilities = {
   fileUploads: true,
+  openNewTab: true,
 };
 
 const CapabilitiesContext: React.Context<Capabilities> = React.createContext(defaultCapabilities);

--- a/src/app/Shared/Services/Capabilities.tsx
+++ b/src/app/Shared/Services/Capabilities.tsx
@@ -17,6 +17,8 @@ import * as React from 'react';
 
 interface Capabilities {
   fileUploads: boolean;
+  // false to disable the feature, true to enable using the default mechanism of
+  // pulling the URL from the Cryostat server, truthy string to override the URL
   openGrafana: string | boolean;
 }
 const defaultCapabilities: Capabilities = {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-openshift-console-plugin/issues/110

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
