### PR TITLE
fix(topology): merge topology elements on update

### DIFF
--- a/src/app/Topology/GraphView/TopologyGraphView.tsx
+++ b/src/app/Topology/GraphView/TopologyGraphView.tsx
@@ -55,6 +55,15 @@ export const MAX_NODE_LIMIT = 100;
 export const DEFAULT_SIZEBAR_SIZE = 500;
 export const MIN_SIZEBAR_SIZE = 400;
 
+export const BASE_MODEL: Model = {
+  graph: {
+    id: TOPOLOGY_GRAPH_ID,
+    type: 'graph',
+    layout: 'Cola',
+    layers: [BOTTOM_LAYER, GROUPS_LAYER, DEFAULT_LAYER, TOP_LAYER],
+  },
+};
+
 export type SavedGraphPosition = {
   id?: string;
   type?: string;
@@ -146,6 +155,9 @@ export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({ transformC
         }
       }, 200),
     );
+
+    _newVisualization.fromModel(BASE_MODEL);
+
     return _newVisualization;
   }, [setSelectedIds, setSelectedEntity]);
 
@@ -171,10 +183,7 @@ export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({ transformC
       }),
       edges: _transformData.edges,
       graph: {
-        id: TOPOLOGY_GRAPH_ID,
-        type: 'graph',
-        layout: 'Cola',
-        layers: [BOTTOM_LAYER, GROUPS_LAYER, DEFAULT_LAYER, TOP_LAYER],
+        ...BASE_MODEL.graph!,
         data: { ...discoveryTree },
         x: graphData.x,
         y: graphData.y,

--- a/src/app/Topology/GraphView/TopologyGraphView.tsx
+++ b/src/app/Topology/GraphView/TopologyGraphView.tsx
@@ -189,7 +189,7 @@ export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({ transformC
     }
 
     // Initialize the controller with model to create nodes
-    visualization.fromModel(model, false);
+    visualization.fromModel(model, true);
   }, [_transformData, visualization, discoveryTree]);
 
   // Note: Do not reorder. Must be called after registering model


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: [#122
](https://github.com/cryostatio/cryostat-openshift-console-plugin/issues/122)

## Description of the change:
This change switches the boolean in `visualization.fromModel()` in TopologyGraphView from false to true, in-order to "merge" the topology elements on update instead of removing and rebuilding them.

## Motivation for the change:
What seems to be the issue is that when the boolean is false the visualization clears out all the old elements before re-creating them. This results in the error because it ends up setting the controller to undefined, but during the process of destroying the colalayout there is a check for that controller.

With merge set to true the old elements are cleaned up after the new elements are created, and we don't run into this issue where the controller doesn't exist.

Before:
![errors](https://github.com/user-attachments/assets/079c309a-4cdf-4ae3-880f-f193d9b92fc3)

After:
![no errors](https://github.com/user-attachments/assets/8b3200cd-0454-40a6-8747-30a938d2260d)

