### PR TITLE
chore(diagnostics): Remove beta label from diagnostics card labels

### DIFF
--- a/src/app/Dashboard/Diagnostics/DiagnosticsCard.tsx
+++ b/src/app/Dashboard/Diagnostics/DiagnosticsCard.tsx
@@ -143,10 +143,6 @@ export const DiagnosticsCardDescriptor: DashboardCardDescriptor = {
   icon: <WrenchIcon />,
   labels: [
     {
-      content: 'Beta',
-      color: 'cyan',
-    },
-    {
       content: 'Diagnostics',
       color: 'blue',
     },


### PR DESCRIPTION
Removes the beta label from the diagnostics card, related to https://github.com/cryostatio/cryostat-web/pull/1563
