### PR TITLE
fix(about): allow alternate build suffix separator characters

### DIFF
--- a/src/app/About/AboutDescription.tsx
+++ b/src/app/About/AboutDescription.tsx
@@ -23,7 +23,7 @@ import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Text, TextContent, TextList, TextListItem, TextVariants } from '@patternfly/react-core';
 import * as React from 'react';
 
-export const VERSION_REGEX = /^(v?[0-9]+\.[0-9]+\.[0-9]+)(?:-(.+))?$/;
+export const VERSION_REGEX = /^(v?[0-9]+\.[0-9]+\.[0-9]+)(?:[-_\.](.+))?$/;
 
 export const AboutDescription: React.FC = () => {
   const serviceContext = React.useContext(ServiceContext);

--- a/src/test/About/AboutDescription.test.tsx
+++ b/src/test/About/AboutDescription.test.tsx
@@ -67,6 +67,7 @@ describe('<AboutDescription />', () => {
     { str: '3.0.0-vendor123', version: '3.0.0', build: 'vendor123' },
     { str: 'v3.0.0-vendor123', version: 'v3.0.0', build: 'vendor123' },
     { str: 'v1.2.3-branch-vendor123', version: 'v1.2.3', build: 'branch-vendor123' },
+    { str: 'v1.2.3.branch-vendor123', version: 'v1.2.3', build: 'branch-vendor123' },
     { str: 'v1.2.3-branch-vendor.tag123_a', version: 'v1.2.3', build: 'branch-vendor.tag123_a' },
     { str: 'v1.2.3-abcd1234', version: 'v1.2.3', build: 'abcd1234' },
   ];

--- a/src/test/About/AboutDescription.test.tsx
+++ b/src/test/About/AboutDescription.test.tsx
@@ -68,6 +68,7 @@ describe('<AboutDescription />', () => {
     { str: 'v3.0.0-vendor123', version: 'v3.0.0', build: 'vendor123' },
     { str: 'v1.2.3-branch-vendor123', version: 'v1.2.3', build: 'branch-vendor123' },
     { str: 'v1.2.3.branch-vendor123', version: 'v1.2.3', build: 'branch-vendor123' },
+    { str: 'v1.2.3_branch-vendor123', version: 'v1.2.3', build: 'branch-vendor123' },
     { str: 'v1.2.3-branch-vendor.tag123_a', version: 'v1.2.3', build: 'branch-vendor.tag123_a' },
     { str: 'v1.2.3-abcd1234', version: 'v1.2.3', build: 'abcd1234' },
   ];


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1524

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
