### PR TITLE
fix(settings): fix feature level assignment

### DIFF
--- a/src/app/Settings/Settings.tsx
+++ b/src/app/Settings/Settings.tsx
@@ -84,7 +84,7 @@ export const Settings: React.FC<SettingsProps> = (_) => {
             category: c.category,
             disabled: c.disabled,
             orderInGroup: c.orderInGroup || -1,
-            featureLevel: c.featureLevel || FeatureLevel.PRODUCTION,
+            featureLevel: c.featureLevel ?? FeatureLevel.PRODUCTION,
           }) as _TransformedUserSetting,
       ),
     [t],

--- a/src/test/Settings/Settings.test.tsx
+++ b/src/test/Settings/Settings.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Language } from '@app/Settings/Config/Language';
 import { Settings } from '@app/Settings/Settings';
 import { UserSetting } from '@app/Settings/types';
 import { FeatureLevel, SessionState } from '@app/Shared/Services/service.types';
@@ -176,6 +177,24 @@ describe('<Settings/>', () => {
 
     const hiddenTab = screen.queryByText(testT('SETTINGS.CATEGORIES.GENERAL'));
     expect(hiddenTab).not.toBeInTheDocument();
+  });
+
+  it('should not display DEVELOPMENT settings when PRODUCTION is selected', async () => {
+    // https://github.com/cryostatio/cryostat-web/issues/1640
+    // Change the feature level of the Language setting to DEVELOPMENT, and ensure the component doesn't display in PRODUCTION
+    Language.featureLevel = FeatureLevel.DEVELOPMENT;
+    jest.spyOn(defaultServices.settings, 'featureLevel').mockReturnValue(of(FeatureLevel.PRODUCTION));
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/settings',
+            element: <Settings />,
+          },
+        ],
+      },
+    });
+    expect(() => screen.getByText('Language Component')).toThrow();
   });
 
   it('should select General tab as default', async () => {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1640

## Description of the change:
I ran into a bug where when working on a development level setting it was still displaying if my target level was production. It had to do with FeatureLevel.DEVELOPMENT being 0 which is a falsy value, which caused the production level number to be used instead.

## Motivation for the change:
Will allow development settings to be restricted to the development feature level.
