### PR TITLE
fix(probetemplate): correct POST request

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -695,9 +695,10 @@ export class ApiService {
     window.onbeforeunload = (event: BeforeUnloadEvent) => event.preventDefault();
     const body = new window.FormData();
     body.append('probeTemplate', file);
+    body.append('name', file.name);
     return this.ctx.headers().pipe(
       concatMap((headers) =>
-        this.sendLegacyRequest('v4', `probes/${file.name}`, 'Custom Probe Template Upload Failed', {
+        this.sendLegacyRequest('v4', 'probes', 'Custom Probe Template Upload Failed', {
           method: 'POST',
           body: body,
           headers,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/pull/927

Noticed a bug when attempting to upload an agent probe template. The POST is incorrect and includes the filename both as a path parameter and a body form field. The backend only expects the form field.
