### PR TITLE
fix(rules): patch Automated Rules with expected body format

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -277,12 +277,6 @@ export class ApiService {
   }
 
   updateRule(rule: Rule, clean = true): Observable<boolean> {
-    const payload = {
-      ...rule,
-      metadata: {
-        labels: this.transformLabelsToObject(rule?.metadata?.labels ?? []),
-      },
-    };
     return this.ctx
       .headers({
         'Content-Type': 'application/json',
@@ -294,7 +288,12 @@ export class ApiService {
             `rules/${rule.name}`,
             {
               method: 'PATCH',
-              body: JSON.stringify(payload),
+              body: JSON.stringify({
+                ...rule,
+                metadata: {
+                  labels: this.transformLabelsToObject(rule?.metadata?.labels ?? []),
+                },
+              }),
               headers,
             },
             new URLSearchParams({ clean: String(clean) }),

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -277,6 +277,12 @@ export class ApiService {
   }
 
   updateRule(rule: Rule, clean = true): Observable<boolean> {
+    const payload = {
+      ...rule,
+      metadata: {
+        labels: this.transformLabelsToObject(rule?.metadata?.labels ?? []),
+      },
+    };
     return this.ctx
       .headers({
         'Content-Type': 'application/json',
@@ -288,7 +294,7 @@ export class ApiService {
             `rules/${rule.name}`,
             {
               method: 'PATCH',
-              body: JSON.stringify(rule),
+              body: JSON.stringify(payload),
               headers,
             },
             new URLSearchParams({ clean: String(clean) }),


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes https://github.com/cryostatio/cryostat/issues/942
See cryostatio/cryostat#888
Related to #1620

## Description of the change:
When updating (`PATCH`ing) an Automated Rule, #1620 would send the update like:

```json
{
    "name": "my_rule",
    "metadata": {
        "labels": [
            {
                "key": "foo",
                "value": "bar"
            }
        ]
    }
}
```

(ie the `KeyValue[]` type used for serialization purposes).

However, the backend actually expects it in the following format, which matches what the backend also accepts when creating a new rule via `POST`:

```json
{
    "name": "my_rule",
    "metadata": {
        "labels": {
            "foo": "bar"
        }
    }
}
```
