### PR TITLE
test(tz): fix sporadic TimezonePicker test failure

### DIFF
--- a/src/test/DateTimePicker/TimezonePicker.test.tsx
+++ b/src/test/DateTimePicker/TimezonePicker.test.tsx
@@ -16,7 +16,7 @@
 import { TimezonePicker } from '@app/DateTimePicker/TimezonePicker';
 import { defaultServices } from '@app/Shared/Services/Services';
 import dayjs, { defaultDatetimeFormat, supportedTimezones, Timezone } from '@i18n/datetime';
-import { act, cleanup, screen, within } from '@testing-library/react';
+import { act, cleanup, screen, waitFor, within } from '@testing-library/react';
 import { of } from 'rxjs';
 import { render, testT } from '../utils';
 
@@ -112,7 +112,7 @@ describe('<TimezonePicker/>', () => {
       await user.click(within(ul).getByText(toSelectText));
     });
 
-    expect(ul).not.toBeVisible();
+    await waitFor(() => expect(ul).not.toBeVisible());
     expect(onTimezoneChange).toHaveBeenCalledTimes(1);
     expect(onTimezoneChange).toHaveBeenCalledWith(toSelect);
   });


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1666

## Description of the change:
Wait for the timezone label to be hidden before continuing on in the test.

## Motivation for the change:
There is a test failure that can happen if the label doesn't disappear by the time the `expect` assertions start to run.

## How to manually test:
1. Run `yarn run test -- TimezonePicker` on main a handful of times, it's likely you'll hit a test failure
2. Check out this PR and verify the test failure doesn't occur
