### PR TITLE
feat(archives): combine target-specific and all-targets archives tabs

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -461,6 +461,10 @@
       "LISTBOX": "Select AM or PM"
     }
   },
+  "NoTargetSelected": {
+    "TITLE": "<0/> No target selected",
+    "BODY": "To view this content, select a JVM target."
+  },
   "NotFound": {
     "DESCRIPTION": "The page you're trying to find was either removed, moved or maybe the URL isn't quite right. Try returning home or visit one of the following pages below.",
     "HOME_REDIRECT_BUTTON_CONTENT": "Return to home page",

--- a/src/app/Archives/Archives.tsx
+++ b/src/app/Archives/Archives.tsx
@@ -97,7 +97,7 @@ export const Archives: React.FC<ArchivesProps> = ({ ...props }) => {
           data-quickstart-id="nav-archives-per-target"
           key={ArchiveTab.PER_TARGET}
           eventKey={ArchiveTab.PER_TARGET}
-          title={<TabTitleText>Target</TabTitleText>}
+          title={<TabTitleText>Targets</TabTitleText>}
         >
           <Stack hasGutter>
             <StackItem>
@@ -107,21 +107,10 @@ export const Archives: React.FC<ArchivesProps> = ({ ...props }) => {
               {target ? (
                 <ArchivedRecordingsTable target={targetAsObs} isUploadsTable={false} isNestedTable={false} />
               ) : (
-                <NoTargetSelected />
+                <AllTargetsArchivedRecordingsTable />
               )}
             </StackItem>
           </Stack>
-        </Tab>,
-      );
-      arr.push(
-        <Tab
-          id="all-targets"
-          data-quickstart-id="nav-archives-all-targets"
-          key={ArchiveTab.ALL_TARGETS}
-          eventKey={ArchiveTab.ALL_TARGETS}
-          title={<TabTitleText>All Targets</TabTitleText>}
-        >
-          <AllTargetsArchivedRecordingsTable />
         </Tab>,
       );
       arr.push(

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -82,7 +82,7 @@ import { UploadIcon, EllipsisVIcon } from '@patternfly/react-icons';
 import { Tbody, Tr, Td, ExpandableRowContent, Table, SortByDirection } from '@patternfly/react-table';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Observable, forkJoin, merge, combineLatest } from 'rxjs';
+import { Observable, forkJoin, merge, combineLatest, of } from 'rxjs';
 import { concatMap, filter, first } from 'rxjs/operators';
 import { LabelCell } from '../RecordingMetadata/LabelCell';
 import { RecordingActions } from './RecordingActions';
@@ -214,9 +214,15 @@ export const ArchivedRecordingsTable: React.FC<ArchivedRecordingsTableProps> = (
       addSubscription(
         propsTarget
           .pipe(
-            filter((target) => !!target),
             first(),
-            concatMap((target: Target) => queryTargetRecordings(target)),
+            concatMap((target: Target | undefined) => {
+              if (target) {
+                return queryTargetRecordings(target);
+              } else {
+                setIsLoading(false);
+                return of([]);
+              }
+            }),
           )
           .subscribe({
             next: handleRecordings,

--- a/src/app/TargetView/NoTargetSelected.tsx
+++ b/src/app/TargetView/NoTargetSelected.tsx
@@ -13,20 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import { Card, CardBody, CardTitle, Text, TextVariants } from '@patternfly/react-core';
 import { DisconnectedIcon } from '@patternfly/react-icons';
 import * as React from 'react';
+import { Trans } from 'react-i18next';
 
 export const NoTargetSelected: React.FC = () => {
+  const { t } = useCryostatTranslation();
+
   return (
     <>
       <Card>
         <CardTitle>
-          <DisconnectedIcon />
-          &nbsp; No target selected
+          <Trans t={t} components={[<DisconnectedIcon />]}>
+            NoTargetSelected.TITLE
+          </Trans>
         </CardTitle>
         <CardBody>
-          <Text component={TextVariants.p}>To view this content, select a JVM target.</Text>
+          <Text component={TextVariants.p}>{t('NoTargetSelected.BODY')}</Text>
         </CardBody>
       </Card>
     </>

--- a/src/test/Archives/Archives.test.tsx
+++ b/src/test/Archives/Archives.test.tsx
@@ -19,6 +19,7 @@ import { cleanup, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { of } from 'rxjs';
 import { render, renderSnapshot } from '../utils';
+import { Target } from '@app/Shared/Services/api.types';
 
 jest.mock('@app/TargetView/TargetContextSelector', () => {
   return {
@@ -57,6 +58,21 @@ jest
   .mockReturnValueOnce(of(false)) // Test archives disabled case
   .mockReturnValue(of(true));
 
+const mockTarget: Target = {
+  agent: false,
+  connectUrl: 'http://localhost',
+  alias: 'fakeTarget',
+  labels: [],
+  annotations: {
+    cryostat: [],
+    platform: [],
+  },
+};
+jest.spyOn(defaultServices.target, 'target')
+  .mockReturnValueOnce(of(mockTarget)) // Test archives disabled case
+  .mockReturnValueOnce(of(undefined)) // Test no target selection case
+  .mockReturnValue(of(mockTarget));
+
 describe('<Archives />', () => {
   afterEach(cleanup);
 
@@ -66,6 +82,12 @@ describe('<Archives />', () => {
     expect(screen.queryByText('All Targets')).not.toBeInTheDocument();
     expect(screen.queryByText('Uploads')).not.toBeInTheDocument();
     expect(screen.getByText('Archives Unavailable')).toBeInTheDocument();
+  });
+
+  it('handles no target selection', async () => {
+    render({ routerConfigs: { routes: [{ path: '/archives', element: <Archives /> }] } });
+
+    expect(screen.getByText('To view this content, select a JVM target.')).toBeInTheDocument();
   });
 
   it('has the correct page title', async () => {

--- a/src/test/Archives/Archives.test.tsx
+++ b/src/test/Archives/Archives.test.tsx
@@ -68,7 +68,8 @@ const mockTarget: Target = {
     platform: [],
   },
 };
-jest.spyOn(defaultServices.target, 'target')
+jest
+  .spyOn(defaultServices.target, 'target')
   .mockReturnValueOnce(of(mockTarget)) // Test archives disabled case
   .mockReturnValueOnce(of(undefined)) // Test no target selection case
   .mockReturnValue(of(mockTarget));

--- a/src/test/Archives/__snapshots__/Archives.test.tsx.snap
+++ b/src/test/Archives/__snapshots__/Archives.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`<Archives /> renders correctly 1`] = `
       >
         <div
           className="pf-v5-c-card pf-m-compact"
-          data-ouia-component-id="OUIA-Generated-Card-6"
+          data-ouia-component-id="OUIA-Generated-Card-5"
           data-ouia-component-type="PF5/Card"
           data-ouia-safe={true}
           id=""
@@ -77,29 +77,7 @@ exports[`<Archives /> renders correctly 1`] = `
                     <span
                       className="pf-v5-c-tabs__item-text"
                     >
-                      Target
-                    </span>
-                  </button>
-                </li>
-                <li
-                  className="pf-v5-c-tabs__item"
-                  role="presentation"
-                >
-                  <button
-                    aria-selected={false}
-                    className="pf-v5-c-tabs__link"
-                    data-ouia-component-type="PF5/TabButton"
-                    data-ouia-safe={true}
-                    data-quickstart-id="nav-archives-all-targets"
-                    id="pf-tab-all-targets-all-targets"
-                    onClick={[Function]}
-                    role="tab"
-                    type="button"
-                  >
-                    <span
-                      className="pf-v5-c-tabs__item-text"
-                    >
-                      All Targets
+                      Targets
                     </span>
                   </button>
                 </li>

--- a/src/test/Archives/__snapshots__/Archives.test.tsx.snap
+++ b/src/test/Archives/__snapshots__/Archives.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`<Archives /> renders correctly 1`] = `
     <nav
       aria-label="Breadcrumb"
       className="pf-v5-c-breadcrumb"
-      data-ouia-component-id="OUIA-Generated-Breadcrumb-4"
+      data-ouia-component-id="OUIA-Generated-Breadcrumb-5"
       data-ouia-component-type="PF5/Breadcrumb"
       data-ouia-safe={true}
     >
@@ -37,7 +37,7 @@ exports[`<Archives /> renders correctly 1`] = `
       >
         <div
           className="pf-v5-c-card pf-m-compact"
-          data-ouia-component-id="OUIA-Generated-Card-4"
+          data-ouia-component-id="OUIA-Generated-Card-6"
           data-ouia-component-type="PF5/Card"
           data-ouia-safe={true}
           id=""
@@ -47,7 +47,7 @@ exports[`<Archives /> renders correctly 1`] = `
           >
             <div
               className="pf-v5-c-tabs"
-              data-ouia-component-id="OUIA-Generated-Tabs-3"
+              data-ouia-component-id="OUIA-Generated-Tabs-4"
               data-ouia-component-type="PF5/Tabs"
               data-ouia-safe={true}
               id="archives"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to #1637

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
