### PR TITLE
fix(topology): correct action menu style for dark theme

### DIFF
--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -116,9 +116,7 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
             badge={nodeTypeToAbbr(data.nodeType)}
             badgeTooltipContent={data.nodeType}
             status={isTarget ? getStatusTargetNode(data) : []}
-            actionDropdown={
-              _actions.length ? <ActionDropdown actions={_actions} className={'entity-overview__action-menu'} /> : null
-            }
+            actionDropdown={_actions.length ? <ActionDropdown actions={_actions} /> : null}
           />
           <Divider />
           <Tabs activeKey={activeTab} onSelect={(_, tab: string) => setActiveTab(tab as EntityTab)}>

--- a/src/app/Topology/ListView/utils.tsx
+++ b/src/app/Topology/ListView/utils.tsx
@@ -91,10 +91,7 @@ const _transformDataGroupedByTopLevel = (
               <Badge>{base.children.length}</Badge>
             </FlexItem>
             <FlexItem>
-              <ActionDropdown
-                className="entity-overview__action-menu"
-                actions={actionFactory({ getData: () => realm }, 'dropdownItem')}
-              />
+              <ActionDropdown actions={actionFactory({ getData: () => realm }, 'dropdownItem')} />
             </FlexItem>
           </Flex>
         ),
@@ -175,10 +172,7 @@ const _buildFullData = (
             <Badge>{children.length}</Badge>
           </FlexItem>
           <FlexItem>
-            <ActionDropdown
-              className="entity-overview__action-menu"
-              actions={actionFactory({ getData: () => node }, 'dropdownItem')}
-            />
+            <ActionDropdown actions={actionFactory({ getData: () => node }, 'dropdownItem')} />
           </FlexItem>
         </Flex>
       ),

--- a/src/app/Topology/styles/base.css
+++ b/src/app/Topology/styles/base.css
@@ -182,10 +182,6 @@ Below CSS rules only apply to Topology components
   margin: 0em 0em 1em 1em;
 }
 
-.entity-overview__action-menu {
-  background-color: var(--pf-v5-global--palette--white);
-}
-
 .topology-listview__realm-title {
   font-size: 1.2em;
   color: var(--pf-v5-global--palette--blue-500);
@@ -211,7 +207,7 @@ Below CSS rules only apply to Topology components
   color: var(--pf-v5-global--palette--black-600);
 }
 
-:where(.pf-v5-theme-dark) .topology__shortcut-command  {
+:where(.pf-v5-theme-dark) .topology__shortcut-command {
   color: var(--pf-v5-global--palette--white);
 }
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1665 

## Description of the change:

The PR introduces a correction to the css style for the topology action menu when in dark theme. Previously, the menu background has a bright white color instead of the dimmer black/grey color, making it a bit hard to read the options.

~With this change, we rely on Patternfly to select the right color for us based on theme by setting `background-color: var(--pf-v5-c-menu--BackgroundColor)`. We can optionally remove that `entity-overview__action-menu` but I opted to keep it for safety (not sure all the places it is/will be referenced).~

Updated: Remove the css rule completely as it is safe to do so :D

## Motivation for the change:

See discussion in #1665.
