### PR TITLE
feat(target-selector): add info button to summon target details modal

### DIFF
--- a/src/app/SecurityPanel/ImportCertificate.tsx
+++ b/src/app/SecurityPanel/ImportCertificate.tsx
@@ -23,8 +23,8 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateVariant,
-  List,
-  ListItem,
+  Label,
+  LabelGroup,
   Panel,
   PanelMain,
   PanelMainBody,
@@ -38,10 +38,10 @@ import {
 import { FileIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { TFunction } from 'i18next';
 import * as React from 'react';
-import { tap } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 import { SecurityCard } from './types';
 
-export const CertificateImport: React.FC = () => {
+const TrustedCertificates: React.FC = () => {
   const { t } = useCryostatTranslation();
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
@@ -53,7 +53,10 @@ export const CertificateImport: React.FC = () => {
     addSubscription(
       context.api
         .doGet('tls/certs')
-        .pipe(tap((_) => setLoading(false)))
+        .pipe(
+          tap((_) => setLoading(false)),
+          map((a: string[]) => a.sort()),
+        )
         .subscribe(setCerts),
     );
   }, [setLoading, addSubscription, context.api, setCerts]);
@@ -65,13 +68,13 @@ export const CertificateImport: React.FC = () => {
           {loading ? (
             <Spinner />
           ) : certs.length ? (
-            <List isPlain>
+            <LabelGroup>
               {certs.map((cert) => (
-                <ListItem key={cert} icon={<FileIcon />}>
+                <Label key={cert} icon={<FileIcon />}>
                   {cert}
-                </ListItem>
+                </Label>
               ))}
-            </List>
+            </LabelGroup>
           ) : (
             <EmptyState variant={EmptyStateVariant.xs}>
               <Title headingLevel="h4" size="md">
@@ -107,5 +110,5 @@ export const ListCertificates: SecurityCard = {
       <Text component={TextVariants.small}>{t('ImportCertificate.CARD_DESCRIPTION')}</Text>
     </TextContent>
   ),
-  content: CertificateImport,
+  content: TrustedCertificates,
 };

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1782,8 +1782,8 @@ export class ApiService {
       out.labels[l.key] = l.value;
     }
     for (const s of ['cryostat', 'platform']) {
-      for (const e of out.annotations[s]) {
-        target.annotations[s][e.key] = e.value;
+      for (const [key, value] of Object.entries(out.annotations[s])) {
+        target.annotations[s][key] = value;
       }
     }
     return out;

--- a/src/app/TargetView/TargetContextSelector.tsx
+++ b/src/app/TargetView/TargetContextSelector.tsx
@@ -38,9 +38,13 @@ import {
   MenuSearchInput,
   ActionList,
   ActionListItem,
+  SplitItem,
+  Split,
 } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import _ from 'lodash';
 import * as React from 'react';
+import { TargetDetailsModal } from './TargetDetailsModal';
 
 export interface TargetContextSelectorProps {
   className?: string;
@@ -57,6 +61,7 @@ export const TargetContextSelector: React.FC<TargetContextSelectorProps> = ({ cl
   const [searchTerm, setSearchTerm] = React.useState<string>('');
   const [isTargetOpen, setIsTargetOpen] = React.useState(false);
   const [isLoading, setLoading] = React.useState(false);
+  const [showDetailsModal, setShowDetailsModal] = React.useState(false);
 
   const onToggleClick = React.useCallback(() => {
     setIsTargetOpen((v) => !v);
@@ -121,6 +126,14 @@ export const TargetContextSelector: React.FC<TargetContextSelectorProps> = ({ cl
     );
     return () => window.clearInterval(id);
   }, [context.settings, refreshTargetList]);
+
+  const handleTargetInfoClick = React.useCallback(() => {
+    setShowDetailsModal(true);
+  }, [setShowDetailsModal]);
+
+  const handleDismissDetailsModal = React.useCallback(() => {
+    setShowDetailsModal(false);
+  }, [setShowDetailsModal]);
 
   const selectOptions = React.useMemo(() => {
     const matchExp = new RegExp(_.escapeRegExp(searchTerm), 'i');
@@ -232,51 +245,59 @@ export const TargetContextSelector: React.FC<TargetContextSelectorProps> = ({ cl
         {isLoading ? (
           <LinearDotSpinner className="target-context-selector__linear-dot-spinner" />
         ) : (
-          <Dropdown
-            className={className}
-            placeholder={t('TargetContextSelector.TOGGLE_PLACEHOLDER')}
-            isOpen={isTargetOpen}
-            onOpenChange={setIsTargetOpen}
-            onOpenChangeKeys={['Escape']}
-            onSelect={onSelect}
-            onActionClick={onFavoriteClick}
-            toggle={(toggleRef) => (
-              <MenuToggle
-                aria-label={t('TargetContextSelector.TOGGLE_LABEL')}
-                ref={toggleRef}
-                onClick={onToggleClick}
-                isExpanded={isTargetOpen}
-                variant="plainText"
-                icon={selectionPrefix}
+          <Split>
+            <SplitItem>
+              <Dropdown
+                className={className}
+                placeholder={t('TargetContextSelector.TOGGLE_PLACEHOLDER')}
+                isOpen={isTargetOpen}
+                onOpenChange={setIsTargetOpen}
+                onOpenChangeKeys={['Escape']}
+                onSelect={onSelect}
+                onActionClick={onFavoriteClick}
+                toggle={(toggleRef) => (
+                  <MenuToggle
+                    aria-label={t('TargetContextSelector.TOGGLE_LABEL')}
+                    ref={toggleRef}
+                    onClick={onToggleClick}
+                    isExpanded={isTargetOpen}
+                    variant="plainText"
+                    icon={selectionPrefix}
+                  >
+                    {!selectedTarget
+                      ? t('TargetContextSelector.TOGGLE_PLACEHOLDER')
+                      : getTargetRepresentation(selectedTarget)}
+                  </MenuToggle>
+                )}
+                popperProps={{
+                  enableFlip: true,
+                  appendTo: portalRoot,
+                }}
               >
-                {!selectedTarget
-                  ? t('TargetContextSelector.TOGGLE_PLACEHOLDER')
-                  : getTargetRepresentation(selectedTarget)}
-              </MenuToggle>
-            )}
-            popperProps={{
-              enableFlip: true,
-              appendTo: portalRoot,
-            }}
-          >
-            <ScrollableMenuContent maxHeight="50vh">
-              <MenuSearch>
-                <MenuSearchInput>
-                  <SearchInput
-                    placeholder={t('TargetContextSelector.SEARCH_PLACEHOLDER')}
-                    value={searchTerm}
-                    onChange={(_, v) => setSearchTerm(v)}
-                  />
-                </MenuSearchInput>
-              </MenuSearch>
-              <Divider />
-              <DropdownList>{selectOptions}</DropdownList>
-            </ScrollableMenuContent>
-            <MenuFooter>{selectFooter}</MenuFooter>
-          </Dropdown>
+                <ScrollableMenuContent maxHeight="50vh">
+                  <MenuSearch>
+                    <MenuSearchInput>
+                      <SearchInput
+                        placeholder={t('TargetContextSelector.SEARCH_PLACEHOLDER')}
+                        value={searchTerm}
+                        onChange={(_, v) => setSearchTerm(v)}
+                      />
+                    </MenuSearchInput>
+                  </MenuSearch>
+                  <Divider />
+                  <DropdownList>{selectOptions}</DropdownList>
+                </ScrollableMenuContent>
+                <MenuFooter>{selectFooter}</MenuFooter>
+              </Dropdown>
+            </SplitItem>
+            <SplitItem>
+              <Button variant="plain" icon={<InfoCircleIcon />} onClick={handleTargetInfoClick} />
+            </SplitItem>
+          </Split>
         )}
       </div>
       <Divider />
+      <TargetDetailsModal target={selectedTarget} visible={showDetailsModal} onDismiss={handleDismissDetailsModal} />
     </>
   );
 };

--- a/src/app/TargetView/TargetDetailsModal.tsx
+++ b/src/app/TargetView/TargetDetailsModal.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NodeType, NullableTarget } from '@app/Shared/Services/api.types';
+import EntityDetails from '@app/Topology/Entity/EntityDetails';
+import { Modal, ModalVariant } from '@patternfly/react-core';
+import * as React from 'react';
+
+export interface TargetDetailsModalProps {
+  visible: boolean;
+  onDismiss: () => void;
+  target: NullableTarget;
+}
+
+export const TargetDetailsModal: React.FC<TargetDetailsModalProps> = ({ visible, onDismiss, target }) => {
+  const wrappedTarget = React.useMemo(() => {
+    if (!target) {
+      return undefined;
+    }
+    return {
+      getData: () => ({
+        name: target.alias,
+        target,
+        nodeType: NodeType.JVM,
+        labels: target.labels,
+      }),
+    };
+  }, [target]);
+
+  return (
+    <Modal
+      isOpen={visible}
+      variant={ModalVariant.large}
+      showClose={true}
+      className="target-details-modal"
+      onClose={onDismiss}
+    >
+      <EntityDetails entity={wrappedTarget} className={'target-details-modal'} />
+    </Modal>
+  );
+};

--- a/src/app/Topology/styles/base.css
+++ b/src/app/Topology/styles/base.css
@@ -354,3 +354,7 @@ Below CSS rules only apply to Topology components
 .topology__treeview-container .pf-v5-c-tree-view__node-content {
   width: 100%;
 }
+
+.target-details-modal {
+  min-height: 36em;
+}


### PR DESCRIPTION
- **correct iteration over target object annotations**
- **feat(target-selector): add info button to summon target details modal**
- **render trusted certificates as LabelGroup to handle large list overflow**

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #976

## Description of the change:
1. render the list of additional imported SSL/TLS certificates under Security as a `LabelGroup` and `Labels` rather than a plain `List`. This is a little more modern-looking, but it is also more compact and takes up less screen space for what is not usually critical information.
2. fixes a bug that prevented the Match Expression Visualizer (see Automated Rules or Stored Credentials, the Graph icon) from listing targets correctly in the list view mode
3. adds an Info icon button to the top bar with the target selector. Clicking this button brings up a modal displaying the `EntityDetails` for the currently selected target. This is the same as the Topology view's sidebar, the Dashboard card for Target Details, and the left side split of cards in the Automated Reports view. It's just one more place where users can get information about the target they're looking at, without needing to navigate away from the current view (ex. the Active Recordings table) and lose context.

## Motivation for the change:
See #976

## How to manually test:
1. Check out PR
2. Run Cryostat smoketest: `smoketest.bash -t quarkus-cryostat-agent` (in another terminal)
3. Run PR in dev mode connected to smoketest: `yarn start:dev`
4. Click around UI and test changes described above
