### PR TITLE
fix(rules): upload Automated Rules using form endpoint

### DIFF
--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -69,7 +69,7 @@ import {
   BuildInfo,
   AggregateReport,
   HeapDump,
-  ThreadDump
+  ThreadDump,
 } from './api.types';
 import {
   isHttpError,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1789
Depends on https://github.com/cryostatio/cryostat/pull/1031

## Description of the change:
Sends `POST` requests to upload Automated Rules as form data rather than raw JSON. This causes the browser to correctly set the `Content-Type` request header as form data. Previously, the attempt to manually set it to `application/json` was ignored by the browser, and the request ended up using `Content-Type: text/plain` - the backend does not accept this content-type on this endpoint, resulting in the HTTP 415 error seen in the bug report. Since the backend already implements both JSON and form handling, and other upload-type endpoints (ex. custom event templates, archived recordings) are using form data uploads without issue, it makes sense for automated rule upload to follow the same pattern.
