### PR TITLE
fix(diagnostics): thread dump ID field name change

### DIFF
--- a/src/app/Diagnostics/ThreadDumpsTable.tsx
+++ b/src/app/Diagnostics/ThreadDumpsTable.tsx
@@ -140,8 +140,8 @@ export const ThreadDumpsTable: React.FC<ThreadDumpsProps> = ({}) => {
   const handleDelete = React.useCallback(
     (threadDump: ThreadDump) => {
       addSubscription(
-        context.api.deleteThreadDump(threadDump.uuid).subscribe(() => {
-          setThreadDumps((old) => old.filter((t) => t.uuid !== threadDump.uuid));
+        context.api.deleteThreadDump(threadDump.threadDumpId).subscribe(() => {
+          setThreadDumps((old) => old.filter((t) => t.threadDumpId !== threadDump.threadDumpId));
         }),
       );
     },
@@ -199,7 +199,7 @@ export const ThreadDumpsTable: React.FC<ThreadDumpsProps> = ({}) => {
       filtered = threadDumps;
     } else {
       const reg = new RegExp(_.escapeRegExp(filterText), 'i');
-      filtered = threadDumps.filter((t: ThreadDump) => reg.test(t.uuid));
+      filtered = threadDumps.filter((t: ThreadDump) => reg.test(t.threadDumpId));
     }
 
     setFilteredThreadDumps(
@@ -250,7 +250,7 @@ export const ThreadDumpsTable: React.FC<ThreadDumpsProps> = ({}) => {
         return (
           <Tr key={`thread-dump-${index}`}>
             <Td key={`thread-dump-id-${index}`} dataLabel={tableColumns[0].title}>
-              {t.uuid}
+              {t.threadDumpId}
             </Td>
             <Td key={`thread-dump-lastModified-${index}`} dataLabel={tableColumns[1].title}>
               <Timestamp

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1099,7 +1099,7 @@ export class ApiService {
     this.ctx.url(threadDump.downloadUrl).subscribe((resourceUrl) => {
       let filename = this.target.target().pipe(
         filter((t) => !!t),
-        map((t) => `${t?.alias}_${threadDump.uuid}.thread_dump`),
+        map((t) => `${t?.alias}_${threadDump.threadDumpId}.thread_dump`),
         first(),
       );
       filename.subscribe((name) => {

--- a/src/app/Shared/Services/api.types.ts
+++ b/src/app/Shared/Services/api.types.ts
@@ -243,7 +243,7 @@ export interface Recording {
 
 export interface ThreadDump {
   downloadUrl: string;
-  uuid: string;
+  threadDumpId: string;
   jvmId?: string;
   lastModified?: number;
   size?: number;

--- a/src/test/Diagnostics/ThreadDumpsTable.test.tsx
+++ b/src/test/Diagnostics/ThreadDumpsTable.test.tsx
@@ -34,7 +34,7 @@ const mockMessageType = { type: 'application', subtype: 'json' } as MessageType;
 
 const mockThreadDump: ThreadDump = {
   downloadUrl: 'someDownloadUrl',
-  uuid: 'someUuid',
+  threadDumpId: 'someUuid',
   jvmId: 'someJvmId',
 };
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See cryostatio/cryostat#1037

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
