### PR TITLE
fix(diagnostics): add tooltip when heap dump disabled, separate running states

### DIFF
--- a/locales/en/public.json
+++ b/locales/en/public.json
@@ -385,6 +385,7 @@
     "DIAGNOSTICS_CARD_TITLE": "Diagnostics",
     "DIAGNOSTICS_GC_BUTTON": "Invoke Garbage Collection",
     "DIAGNOSTICS_HEAP_DUMP_BUTTON": "Invoke Heap Dump",
+    "DIAGNOSTICS_HEAP_DUMP_BUTTON_DISABLED": "Heap Dump collection requires the Cryostat Agent",
     "DIAGNOSTICS_HEAP_REDIRECT_BUTTON": "View collected Heap Dumps",
     "DIAGNOSTICS_THREAD_DUMP_BUTTON": "Invoke Thread Dump",
     "DIAGNOSTICS_THREAD_DUMP_TABLE_TOOLTIP": "View captured Thread Dumps",

--- a/src/app/Dashboard/Diagnostics/DiagnosticsCard.tsx
+++ b/src/app/Dashboard/Diagnostics/DiagnosticsCard.tsx
@@ -231,16 +231,21 @@ export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) =>
                   <StackItem>
                     <FeatureFlag level={FeatureLevel.BETA}>
                       <ActionList>
-                        <Button
-                          variant="primary"
-                          onClick={handleHeapDump}
-                          isAriaDisabled={!controlEnabled}
-                          spinnerAriaValueText="Invoke Heap Dump"
-                          spinnerAriaLabel="invoke-heap-dump"
-                          isLoading={running}
+                        <Tooltip
+                          trigger={controlEnabled ? 'manual' : 'mouseenter focus'}
+                          content={t('DiagnosticsCard.DIAGNOSTICS_HEAP_DUMP_BUTTON_DISABLED')}
                         >
-                          {t('DiagnosticsCard.DIAGNOSTICS_HEAP_DUMP_BUTTON')}
-                        </Button>
+                          <Button
+                            variant="primary"
+                            onClick={handleHeapDump}
+                            isAriaDisabled={!controlEnabled}
+                            spinnerAriaValueText="Invoke Heap Dump"
+                            spinnerAriaLabel="invoke-heap-dump"
+                            isLoading={running}
+                          >
+                            {t('DiagnosticsCard.DIAGNOSTICS_HEAP_DUMP_BUTTON')}
+                          </Button>
+                        </Tooltip>
                         <Tooltip content={t('DiagnosticsCard.DIAGNOSTICS_HEAP_REDIRECT_BUTTON')}>
                           <Button
                             variant="primary"

--- a/src/app/Dashboard/Diagnostics/DiagnosticsCard.tsx
+++ b/src/app/Dashboard/Diagnostics/DiagnosticsCard.tsx
@@ -57,7 +57,9 @@ export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) =>
   const serviceContext = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const addSubscription = useSubscriptions();
-  const [running, setRunning] = React.useState(false);
+  const [runningGc, setRunningGc] = React.useState(false);
+  const [runningThreadDump, setRunningThreadDump] = React.useState(false);
+  const [runningHeapDump, setRunningHeapDump] = React.useState(false);
   const [heapDumpReady, setHeapDumpReady] = React.useState(false);
   const [threadDumpReady, setThreadDumpReady] = React.useState(false);
   const [controlEnabled, setControlEnabled] = React.useState(false);
@@ -127,39 +129,39 @@ export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) =>
   }, [addSubscription, serviceContext.notificationChannel, setThreadDumpReady]);
 
   const handleGC = React.useCallback(() => {
-    setRunning(true);
+    setRunningGc(true);
     addSubscription(
       serviceContext.api.runGC(true).subscribe({
         error: (err) => handleError(t('DiagnosticsCard.KINDS.GC'), err),
-        complete: () => setRunning(false),
+        complete: () => setRunningGc(false),
       }),
     );
-  }, [addSubscription, serviceContext.api, handleError, setRunning, t]);
+  }, [addSubscription, serviceContext.api, handleError, setRunningGc, t]);
 
   const handleThreadDump = React.useCallback(() => {
-    setRunning(true);
+    setRunningThreadDump(true);
     addSubscription(
       serviceContext.api.runThreadDump(true).subscribe({
         error: (err) => handleError(t('DiagnosticsCard.KINDS.THREADS'), err),
         complete: () => {
-          setRunning(false);
+          setRunningThreadDump(false);
           setThreadDumpReady(true);
         },
       }),
     );
-  }, [addSubscription, serviceContext.api, handleError, setRunning, t]);
+  }, [addSubscription, serviceContext.api, handleError, setRunningThreadDump, t]);
 
   const handleHeapDump = React.useCallback(() => {
-    setRunning(true);
+    setRunningHeapDump(true);
     addSubscription(
       serviceContext.api.runHeapDump(true).subscribe({
         error: (err) => handleError(t('DiagnosticsCard.KINDS.HEAP_DUMP'), err),
         complete: () => {
-          setRunning(false);
+          setRunningHeapDump(false);
         },
       }),
     );
-  }, [addSubscription, serviceContext.api, handleError, setRunning, t]);
+  }, [addSubscription, serviceContext.api, handleError, setRunningHeapDump, t]);
 
   const header = React.useMemo(() => {
     return (
@@ -199,7 +201,7 @@ export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) =>
                         onClick={handleGC}
                         spinnerAriaValueText="Invoke GC"
                         spinnerAriaLabel="invoke-gc"
-                        isLoading={running}
+                        isLoading={runningGc}
                       >
                         {t('DiagnosticsCard.DIAGNOSTICS_GC_BUTTON')}
                       </Button>
@@ -213,7 +215,7 @@ export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) =>
                           onClick={handleThreadDump}
                           spinnerAriaValueText="Invoke Thread Dump"
                           spinnerAriaLabel="invoke-thread-dump"
-                          isLoading={running}
+                          isLoading={runningThreadDump}
                         >
                           {t('DiagnosticsCard.DIAGNOSTICS_THREAD_DUMP_BUTTON')}
                         </Button>
@@ -241,7 +243,7 @@ export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) =>
                             isAriaDisabled={!controlEnabled}
                             spinnerAriaValueText="Invoke Heap Dump"
                             spinnerAriaLabel="invoke-heap-dump"
-                            isLoading={running}
+                            isLoading={runningHeapDump}
                           >
                             {t('DiagnosticsCard.DIAGNOSTICS_HEAP_DUMP_BUTTON')}
                           </Button>

--- a/src/app/Diagnostics/CaptureDiagnostics.tsx
+++ b/src/app/Diagnostics/CaptureDiagnostics.tsx
@@ -44,7 +44,9 @@ export const CaptureDiagnostics: React.FC<CaptureDiagnosticsProps> = ({ ...props
   const serviceContext = React.useContext(ServiceContext);
   const notifications = React.useContext(NotificationsContext);
   const addSubscription = useSubscriptions();
-  const [running, setRunning] = React.useState(false);
+  const [runningGc, setRunningGc] = React.useState(false);
+  const [runningThreadDump, setRunningThreadDump] = React.useState(false);
+  const [runningHeapDump, setRunningHeapDump] = React.useState(false);
   const [threadDumpReady, setThreadDumpReady] = React.useState(false);
   const [heapDumpReady, setHeapDumpReady] = React.useState(false);
   const [controlEnabled, setControlEnabled] = React.useState(false);
@@ -107,40 +109,40 @@ export const CaptureDiagnostics: React.FC<CaptureDiagnosticsProps> = ({ ...props
   }, [addSubscription, serviceContext.notificationChannel, setThreadDumpReady]);
 
   const handleGC = React.useCallback(() => {
-    setRunning(true);
+    setRunningGc(true);
     addSubscription(
       serviceContext.api.runGC(true).subscribe({
         error: (err) => handleError(t('DiagnosticsCard.KINDS.GC'), err),
-        complete: () => setRunning(false),
+        complete: () => setRunningGc(false),
       }),
     );
-  }, [addSubscription, serviceContext.api, handleError, setRunning, t]);
+  }, [addSubscription, serviceContext.api, handleError, setRunningGc, t]);
 
   const handleThreadDump = React.useCallback(() => {
-    setRunning(true);
+    setRunningThreadDump(true);
     addSubscription(
       serviceContext.api.runThreadDump(true).subscribe({
         error: (err) => handleError(t('DiagnosticsCard.KINDS.THREADS'), err),
         complete: () => {
-          setRunning(false);
+          setRunningThreadDump(false);
           setThreadDumpReady(true);
         },
       }),
     );
-  }, [addSubscription, serviceContext.api, handleError, setRunning, t]);
+  }, [addSubscription, serviceContext.api, handleError, setRunningThreadDump, t]);
 
   const handleHeapDump = React.useCallback(() => {
-    setRunning(true);
+    setRunningHeapDump(true);
     addSubscription(
       serviceContext.api.runHeapDump(true).subscribe({
         error: (err) => handleError(t('DiagnosticsCard.KINDS.HEAP_DUMP'), err),
         complete: () => {
-          setRunning(false);
+          setRunningHeapDump(false);
           setHeapDumpReady(true);
         },
       }),
     );
-  }, [addSubscription, serviceContext.api, handleError, setRunning, t]);
+  }, [addSubscription, serviceContext.api, handleError, setRunningHeapDump, t]);
 
   return (
     <TargetView {...props} pageTitle="Diagnostics">
@@ -157,7 +159,7 @@ export const CaptureDiagnostics: React.FC<CaptureDiagnosticsProps> = ({ ...props
                         onClick={handleGC}
                         spinnerAriaValueText="Invoke GC"
                         spinnerAriaLabel="invoke-gc"
-                        isLoading={running}
+                        isLoading={runningGc}
                       >
                         {t('DiagnosticsCard.DIAGNOSTICS_GC_BUTTON')}
                       </Button>
@@ -170,7 +172,7 @@ export const CaptureDiagnostics: React.FC<CaptureDiagnosticsProps> = ({ ...props
                         onClick={handleThreadDump}
                         spinnerAriaValueText="Invoke Thread Dump"
                         spinnerAriaLabel="invoke-thread-dump"
-                        isLoading={running}
+                        isLoading={runningThreadDump}
                       >
                         {t('DiagnosticsCard.DIAGNOSTICS_THREAD_DUMP_BUTTON')}
                       </Button>
@@ -196,7 +198,7 @@ export const CaptureDiagnostics: React.FC<CaptureDiagnosticsProps> = ({ ...props
                           onClick={handleHeapDump}
                           spinnerAriaValueText="Invoke Heap Dump"
                           spinnerAriaLabel="invoke-heap-dump"
-                          isLoading={running}
+                          isLoading={runningHeapDump}
                         >
                           {t('DiagnosticsCard.DIAGNOSTICS_HEAP_DUMP_BUTTON')}
                         </Button>

--- a/src/app/Diagnostics/CaptureDiagnostics.tsx
+++ b/src/app/Diagnostics/CaptureDiagnostics.tsx
@@ -186,16 +186,21 @@ export const CaptureDiagnostics: React.FC<CaptureDiagnosticsProps> = ({ ...props
                   </StackItem>
                   <StackItem>
                     <ActionList>
-                      <Button
-                        variant="primary"
-                        isAriaDisabled={!controlEnabled}
-                        onClick={handleHeapDump}
-                        spinnerAriaValueText="Invoke Heap Dump"
-                        spinnerAriaLabel="invoke-heap-dump"
-                        isLoading={running}
+                      <Tooltip
+                        trigger={controlEnabled ? 'manual' : 'mouseenter focus'}
+                        content={t('DiagnosticsCard.DIAGNOSTICS_HEAP_DUMP_BUTTON_DISABLED')}
                       >
-                        {t('DiagnosticsCard.DIAGNOSTICS_HEAP_DUMP_BUTTON')}
-                      </Button>
+                        <Button
+                          variant="primary"
+                          isAriaDisabled={!controlEnabled}
+                          onClick={handleHeapDump}
+                          spinnerAriaValueText="Invoke Heap Dump"
+                          spinnerAriaLabel="invoke-heap-dump"
+                          isLoading={running}
+                        >
+                          {t('DiagnosticsCard.DIAGNOSTICS_HEAP_DUMP_BUTTON')}
+                        </Button>
+                      </Tooltip>
                       <Tooltip content={t('DiagnosticsCard.DIAGNOSTICS_HEAP_REDIRECT_BUTTON')}>
                         <Button
                           variant="primary"


### PR DESCRIPTION
- **fix(diagnostics): add tooltip to heap dump invocation button when disabled**
- **fix(diagnostics): separate running states for each action**

# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #1730
