### PR TITLE
fix(nav): fix collision of nav collapse state keys

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -611,15 +611,16 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
         } else if (!renderables.length) {
           items = [];
         } else {
+          const navKey = `${group}.${k}`;
           const anyActive = rs.some((r) => isActiveRoute(r));
           items = [
             <NavExpandable
-              key={k}
+              key={navKey}
               title={t(k)}
-              groupId={k}
+              groupId={navKey}
               isActive={anyActive}
-              isExpanded={navExpandedStates[k] ?? true}
-              onExpand={handleNavExpand(k)}
+              isExpanded={navExpandedStates[navKey] ?? true}
+              onExpand={handleNavExpand(navKey)}
             >
               {renderables}
             </NavExpandable>,


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1916

## Description of the change:
Prefixes the nav items' keys with the nav group name, so that collisions of subgroup names (ex. `Analyze`) do not occur and the states are correctly treated independently.