### PR TITLE
fix(i18n): correct translation usage in heap and thread dump pages

### DIFF
--- a/src/app/Diagnostics/AnalyzeHeapDumps.tsx
+++ b/src/app/Diagnostics/AnalyzeHeapDumps.tsx
@@ -87,7 +87,7 @@ export const AnalyzeHeapDumps: React.FC<AnalyzeHeapDumpsProps> = ({ ...props }) 
         </Tab>
       </Tabs>
     ),
-    [activeTab, onTabSelect, target, targetAsObs],
+    [activeTab, onTabSelect, t, target, targetAsObs],
   );
 
   return (

--- a/src/app/Diagnostics/AnalyzeThreadDumps.tsx
+++ b/src/app/Diagnostics/AnalyzeThreadDumps.tsx
@@ -91,7 +91,7 @@ export const AnalyzeThreadDumps: React.FC<AnalyzeThreadDumpsProps> = ({ ...props
         </Tab>
       </Tabs>
     ),
-    [activeTab, onTabSelect, target, targetAsObs],
+    [activeTab, onTabSelect, t, target, targetAsObs],
   );
 
   return (


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: [#561
](https://github.com/cryostatio/cryostat-openshift-console-plugin/issues/561)

## Description of the change:
This change corrects the usage of `import { t } from 'i18next';` to instead use the `useCryostatTranslation()`

## Motivation for the change:
The console plugin sets it's i18n namespace using an environment variable, that gets picked up in `@i18n/i18nextUtil` and used/exported by `useCryostatTranslation()`. At the moment because the dump pages use `t` from `i18next` the console plugin isn't able to substitute the strings properly.

## How to manually test:
- Apply these changes to cryostat-web within the console-plugin, and run it

## Screenshot (with this PR applied)
<img width="1073" height="834" alt="Screenshot From 2025-12-01 12-30-02" src="https://github.com/user-attachments/assets/81d45f30-f980-4108-bd26-097df2ca4265" />

