### PR TITLE
fix(jmcagent): Allow probe template uploads without target selected

### DIFF
--- a/src/app/Instrumentation/Instrumentation.tsx
+++ b/src/app/Instrumentation/Instrumentation.tsx
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 import { ServiceContext } from '@app/Shared/Services/Services';
-import { TargetView } from '@app/TargetView/TargetView';
+import { TargetContextSelector } from '@app/TargetView/TargetContextSelector';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { getActiveTab, switchTab } from '@app/utils/utils';
 import { Card, CardBody, Tab, Tabs, Tooltip } from '@patternfly/react-core';
@@ -23,8 +24,6 @@ import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { concatMap, filter, tap } from 'rxjs';
 import { AgentLiveProbes } from './AgentLiveProbes';
 import { AgentProbeTemplates } from './AgentProbeTemplates';
-import { TargetContextSelector } from '@app/TargetView/TargetContextSelector';
-import { BreadcrumbPage } from '@app/BreadcrumbPage/BreadcrumbPage';
 
 export const JMCAgent: React.FC = ({ ...props }) => {
   return (


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat-web/issues/1941

## Description of the change:
Brings the Instrumentation view in line with the Event Templates view, no longer requiring a target selection to upload a probe template. Moves the component over to use TargetContextSelector rather than TargetView

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1.Pull and Build the PR
2. Verify a probe template can be uploaded with no target selected.
