### PR TITLE
fix(diagnostics): Wrap diagnostic button text in Truncate component

### DIFF
--- a/src/app/Dashboard/DashboardCard.tsx
+++ b/src/app/Dashboard/DashboardCard.tsx
@@ -80,13 +80,13 @@ export const DashboardCard: React.FC<DashboardCardProps> = ({
           </div>
         </DraggableRef>
       ) : (
-        <>
-          <Card isRounded {...props}>
+        <div className={'dashboard-card-resizable-wrapper'} ref={cardRef}>
+          <Card className="dashboard-card" isRounded {...props}>
             {cardHeader}
             {children}
           </Card>
           {resizeBar}
-        </>
+        </div>
       ),
     [cardRef, props, onMouseEnter, onMouseLeave, cardHeader, children, isDraggable, dashboardId, resizeBar],
   );

--- a/src/app/Dashboard/Diagnostics/DiagnosticsCard.tsx
+++ b/src/app/Dashboard/Diagnostics/DiagnosticsCard.tsx
@@ -52,7 +52,7 @@ import { concatMap, filter, first } from 'rxjs/operators';
 import { DashboardCard } from '../DashboardCard';
 
 export interface DiagnosticsCardProps extends DashboardCardTypeProps {
-  isCompact: boolean;
+  headerDisabled: boolean;
 }
 
 export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) => {
@@ -190,17 +190,17 @@ export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) =>
         id={'diagnostics-card'}
         dashboardId={props.dashboardId}
         cardSizes={DiagnosticsCardSizes}
-        isCompact
-        cardHeader={!props.isCompact ? header : null}
+        isCompact={props.headerDisabled}
+        cardHeader={!props.headerDisabled ? header : null}
         isDraggable={props.isDraggable}
         isResizable={props.isResizable}
         isFullHeight={props.isFullHeight}
       >
         <CardBody>
           <Bullseye>
-            <EmptyState variant={EmptyStateVariant.lg}>
-              {!props.isCompact ? stateHeader : null}
-              {!props.isCompact ? (
+            <EmptyState variant={!props.headerDisabled ? EmptyStateVariant.lg : EmptyStateVariant.xs}>
+              {!props.headerDisabled ? stateHeader : null}
+              {!props.headerDisabled ? (
                 <EmptyStateBody>{t('DiagnosticsCard.DIAGNOSTICS_CARD_DESCRIPTION')}</EmptyStateBody>
               ) : null}
               <EmptyStateFooter>
@@ -215,7 +215,7 @@ export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) =>
                           spinnerAriaLabel="invoke-gc"
                           isLoading={runningGc}
                         >
-                          <Truncate content={t('DiagnosticsCard.DIAGNOSTICS_GC_BUTTON')}/>
+                          <Truncate content={t('DiagnosticsCard.DIAGNOSTICS_GC_BUTTON')} />
                         </Button>
                       </ActionListItem>
                     </ActionList>
@@ -230,7 +230,7 @@ export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) =>
                           spinnerAriaLabel="invoke-thread-dump"
                           isLoading={runningThreadDump}
                         >
-                          <Truncate content={t('DiagnosticsCard.DIAGNOSTICS_THREAD_DUMP_BUTTON')}/>
+                          <Truncate content={t('DiagnosticsCard.DIAGNOSTICS_THREAD_DUMP_BUTTON')} />
                         </Button>
                       </ActionListItem>
                       <ActionListItem data-quickstart-id="thread-dumps-archive-btn">
@@ -260,7 +260,7 @@ export const DiagnosticsCard: DashboardCardFC<DiagnosticsCardProps> = (props) =>
                             spinnerAriaLabel="invoke-heap-dump"
                             isLoading={runningHeapDump}
                           >
-                            <Truncate content={t('DiagnosticsCard.DIAGNOSTICS_HEAP_DUMP_BUTTON')}/>
+                            <Truncate content={t('DiagnosticsCard.DIAGNOSTICS_HEAP_DUMP_BUTTON')} />
                           </Button>
                         </Tooltip>
                       </ActionListItem>

--- a/src/app/Diagnostics/CaptureDiagnostics.tsx
+++ b/src/app/Diagnostics/CaptureDiagnostics.tsx
@@ -26,7 +26,7 @@ export const CaptureDiagnostics: React.FC<CaptureDiagnosticsProps> = ({ ...props
     <TargetView {...props} pageTitle="Diagnostics">
       <Grid hasGutter>
         <GridItem span={3}>
-          <DiagnosticsCard span={0} dashboardId={0} isCompact={true} />
+          <DiagnosticsCard span={3} dashboardId={0} headerDisabled={true} isResizable={false} isDraggable={false} />
         </GridItem>
         <GridItem span={9}>
           <MBeanMetricsChartCard


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: https://github.com/cryostatio/cryostat-web/issues/1869

## Description of the change:
Wraps the text for the diagnostics buttons in a Truncate component so they will get truncated if the screen gets resized to prevent overflowing the component and help wth the issues found in the linked issue.

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
