### PR TITLE
feat(discovery): handle merged Realms and query for this by default

### DIFF
--- a/src/app/Shared/Redux/Configurations/TopologyConfigSlice.tsx
+++ b/src/app/Shared/Redux/Configurations/TopologyConfigSlice.tsx
@@ -41,7 +41,7 @@ export interface DisplayOptions {
   };
   groupings: {
     collapseSingles: boolean;
-    realmOnly: boolean;
+    flattenIntermediates: boolean;
   };
 }
 
@@ -118,7 +118,7 @@ export const defaultTopologyConfig: TopologyConfig = {
       icon: true,
     },
     groupings: {
-      realmOnly: false,
+      flattenIntermediates: false,
       collapseSingles: false,
     },
   },
@@ -156,8 +156,8 @@ export const topologyConfigReducer: ReducerWithInitialState<TopologyConfig> = cr
       }
 
       // Special case for groupings
-      // If realmOnly is true, singleGroups should also be true
-      if (category === 'groupings' && key === 'realmOnly') {
+      // If flattenIntermediates is true, singleGroups should also be true
+      if (category === 'groupings' && key === 'flattenIntermediates') {
         if (value) {
           state.displayOptions.groupings.collapseSingles = true;
         }

--- a/src/app/Shared/Redux/Configurations/TopologyConfigSlice.tsx
+++ b/src/app/Shared/Redux/Configurations/TopologyConfigSlice.tsx
@@ -42,6 +42,7 @@ export interface DisplayOptions {
   groupings: {
     collapseSingles: boolean;
     flattenIntermediates: boolean;
+    mergeRealms: boolean;
   };
 }
 
@@ -120,6 +121,7 @@ export const defaultTopologyConfig: TopologyConfig = {
     groupings: {
       flattenIntermediates: false,
       collapseSingles: false,
+      mergeRealms: true,
     },
   },
   reportFilter: {

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1626,10 +1626,16 @@ export class ApiService {
     );
   }
 
-  getDiscoveryTree(): Observable<EnvironmentNode> {
-    return this.sendRequest('v4', 'discovery', {
-      method: 'GET',
-    }).pipe(
+  getDiscoveryTree(mergeRealms = true): Observable<EnvironmentNode> {
+    const params = new URLSearchParams([['mergeRealms', `${mergeRealms}`]]);
+    return this.sendRequest(
+      'v4',
+      'discovery',
+      {
+        method: 'GET',
+      },
+      params,
+    ).pipe(
       concatMap((resp) => resp.json()),
       first(),
     );

--- a/src/app/Topology/Toolbar/DisplayOptions.tsx
+++ b/src/app/Topology/Toolbar/DisplayOptions.tsx
@@ -73,7 +73,7 @@ export const DisplayOptions: React.FC<DisplayOptionsProps> = ({ isDisabled = fal
         <Switch
           id={`${option.toLowerCase()}-mode`}
           label={option}
-          isDisabled={key === 'collapseSingles' && groupings.realmOnly}
+          isDisabled={key === 'collapseSingles' && groupings.flattenIntermediates}
           isChecked={groupings[key]}
           onChange={getToggleHandler('groupings', key, groupings)}
         />

--- a/src/app/Topology/Topology.tsx
+++ b/src/app/Topology/Topology.tsx
@@ -48,6 +48,7 @@ export const Topology: React.FC<TopologyProps> = ({ ..._props }) => {
     () => ({ showOnlyTopGroup: groupings.flattenIntermediates, expandMode: !groupings.collapseSingles }),
     [groupings],
   );
+  const mergeRealms = React.useMemo(() => groupings.mergeRealms, [groupings]);
 
   const [discoveryTree, setDiscoveryTree] = React.useState(DEFAULT_EMPTY_UNIVERSE);
 
@@ -61,7 +62,7 @@ export const Topology: React.FC<TopologyProps> = ({ ..._props }) => {
   const _refreshDiscoveryTree = React.useCallback(
     (onSuccess?: () => void) => {
       addSubscription(
-        context.api.getDiscoveryTree().subscribe({
+        context.api.getDiscoveryTree(mergeRealms).subscribe({
           next: (tree) => {
             onSuccess && onSuccess();
             setError(undefined);
@@ -73,7 +74,7 @@ export const Topology: React.FC<TopologyProps> = ({ ..._props }) => {
         }),
       );
     },
-    [addSubscription, context.api, setDiscoveryTree, setError],
+    [addSubscription, context.api, mergeRealms, setDiscoveryTree, setError],
   );
 
   React.useEffect(() => {

--- a/src/app/Topology/Topology.tsx
+++ b/src/app/Topology/Topology.tsx
@@ -45,7 +45,7 @@ export const Topology: React.FC<TopologyProps> = ({ ..._props }) => {
   const displayOptions = useSelector((state: RootState) => state.topologyConfigs.displayOptions);
   const { groupings } = displayOptions;
   const transformConfig = React.useMemo(
-    () => ({ showOnlyTopGroup: groupings.realmOnly, expandMode: !groupings.collapseSingles }),
+    () => ({ showOnlyTopGroup: groupings.flattenIntermediates, expandMode: !groupings.collapseSingles }),
     [groupings],
   );
 


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat-agent/issues/381

## Description of the change:
1. Renames "realmOnly" Topology control to "flatten intermediates". In a k8s EndpointSlices context, for example, this control had the client-side effect of removing the Namespace, Deployment, ReplicaSet, etc. nodes from the view, leaving only the KubeEndpoints discovery Realm node with its direct children being the discovered targets.
2. Adds a new "mergeRealms" control, which is enabled by default, and controls the `?mergeRealms` query parameter on the `GET /api/v4/discovery` Cryostat API request. See cryostatio/cryostat#1249

## How to manually test:
See Cryostat backend PR
