### PR TITLE
feat(archives): enable audit querying for archived recording source lookup

### DIFF
--- a/src/app/Archives/AllArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllArchivedRecordingsTable.tsx
@@ -131,13 +131,12 @@ export const AllArchivedRecordingsTable: React.FC<AllArchivedRecordingsTableProp
     setLoadingLineage(true);
     setLineageRoot(undefined);
     addSubscription(
-      context.api.doGet<EnvironmentNode>(`audit/target_lineage/${selectedJvmId}`, 'beta').subscribe({
+      context.api.getTargetLineage(selectedJvmId).subscribe({
         next: (root) => {
           setLineageRoot(root);
           setLoadingLineage(false);
         },
-        error: (err) => {
-          console.warn('Target lineage unavailable:', err);
+        error: (_) => {
           setLineageRoot(undefined);
           setLoadingLineage(false);
         },

--- a/src/app/Archives/AllArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllArchivedRecordingsTable.tsx
@@ -447,7 +447,7 @@ export const AllArchivedRecordingsTable: React.FC<AllArchivedRecordingsTableProp
             <Spinner />
           </Bullseye>
         ) : wrappedTarget ? (
-          <EntityDetails entity={wrappedTarget} className="target-details-modal" />
+          <EntityDetails entity={wrappedTarget} className="target-details-modal" hideActions={true} />
         ) : (
           <EmptyState>
             <EmptyStateHeader

--- a/src/app/Archives/AllArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllArchivedRecordingsTable.tsx
@@ -39,6 +39,8 @@ import {
   Button,
   Icon,
   Bullseye,
+  Stack,
+  StackItem,
 } from '@patternfly/react-core';
 import { FileIcon, HelpIcon, SearchIcon } from '@patternfly/react-icons';
 import {
@@ -57,6 +59,7 @@ import _ from 'lodash';
 import * as React from 'react';
 import { Observable, of } from 'rxjs';
 import { getTargetFromDirectory, includesDirectory, indexOfDirectory } from './utils';
+import { TargetLineage } from '@app/Topology/TargetLineage';
 
 const tableColumns: TableColumn[] = [
   {
@@ -250,7 +253,7 @@ export const AllArchivedRecordingsTable: React.FC<AllArchivedRecordingsTableProp
                 <Text>{dir.connectUrl}</Text>
               </SplitItem>
               <SplitItem>
-                <Tooltip hidden={!dir.jvmId} content={`JVM hash ID: ${dir.jvmId}`} appendTo={portalRoot}>
+                <Tooltip hidden={!dir.jvmId} content={<TargetLineage jvmId={dir.jvmId} />} appendTo={portalRoot}>
                   <HelpIcon />
                 </Tooltip>
               </SplitItem>

--- a/src/app/Shared/Components/MatchExpression/MatchExpressionVisualizer.tsx
+++ b/src/app/Shared/Components/MatchExpression/MatchExpressionVisualizer.tsx
@@ -278,7 +278,7 @@ const GraphView: React.FC<{ alertOptions?: AlertOptions }> = ({ alertOptions, ..
     }
     return (
       <TopologySideBar onClose={handleDrawerClose}>
-        <EntityDetails entity={selectedEntity} alertOptions={alertOptions} />
+        <EntityDetails entity={selectedEntity} alertOptions={alertOptions} hideLineageTab={true} />
       </TopologySideBar>
     );
   }, [handleDrawerClose, selectedEntity, alertOptions]);

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1641,6 +1641,10 @@ export class ApiService {
     );
   }
 
+  getTargetLineage(jvmId: string): Observable<EnvironmentNode> {
+    return this.doGet<EnvironmentNode>(`audit/target_lineage/${jvmId}`, 'beta');
+  }
+
   // Filter targets that the expression matches
   matchTargetsWithExpr(matchExpression: string, targets: Target[]): Observable<Target[]> {
     const body = JSON.stringify({

--- a/src/app/Shared/Services/Api.service.tsx
+++ b/src/app/Shared/Services/Api.service.tsx
@@ -1642,7 +1642,7 @@ export class ApiService {
   }
 
   getTargetLineage(jvmId: string): Observable<EnvironmentNode> {
-    return this.doGet<EnvironmentNode>(`audit/target_lineage/${jvmId}`, 'beta');
+    return this.doGet<EnvironmentNode>(`audit/target_lineage/${jvmId}`, 'beta', undefined, true);
   }
 
   // Filter targets that the expression matches

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -140,7 +140,7 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
             </Tab>
             {isTarget && !hideLineageTab && data.target.jvmId ? (
               <Tab eventKey={EntityTab.LINEAGE} title={<TabTitleText>Lineage</TabTitleText>}>
-                <div className="entity-overview__wrapper">
+                <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
                   <TargetLineage jvmId={data.target.jvmId} />
                 </div>
               </Tab>

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -150,7 +150,7 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
       );
     }
     return null;
-  }, [entity, setActiveTab, activeTab, columnModifier, actionFilter, alertOptions]);
+  }, [entity, setActiveTab, activeTab, columnModifier, actionFilter, alertOptions, hideLineageTab]);
   return (
     <div {...props} className={css('entity-overview', className)}>
       {viewContent}

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -152,7 +152,7 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
       );
     }
     return null;
-  }, [entity, setActiveTab, activeTab, columnModifier, actionFilter, alertOptions, hideLineageTab]);
+  }, [entity, setActiveTab, activeTab, columnModifier, actionFilter, alertOptions, hideActions, hideLineageTab]);
   return (
     <div {...props} className={css('entity-overview', className)}>
       {viewContent}

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -20,6 +20,7 @@ import { EnvironmentNode, MBeanMetrics, MBeanMetricsResponse, TargetNode } from 
 import { isTargetNode } from '@app/Shared/Services/api.utils';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { ActionDropdown } from '@app/Topology/Actions/NodeActions';
+import { TargetLineage } from '@app/Topology/TargetLineage';
 import useDayjs from '@app/utils/hooks/useDayjs';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { formatBytes, hashCode, portalRoot, splitWordsOnUppercase } from '@app/utils/utils';
@@ -84,11 +85,13 @@ export interface EntityDetailsProps {
   className?: string;
   alertOptions?: AlertOptions;
   actionFilter?: (_: NodeAction) => boolean;
+  hideLineageTab?: boolean;
 }
 
 enum EntityTab {
   DETAIL = 'detail',
   RESOURCE = 'resource',
+  LINEAGE = 'lineage',
 }
 
 export const EntityDetails: React.FC<EntityDetailsProps> = ({
@@ -97,6 +100,7 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
   columnModifier,
   actionFilter,
   alertOptions,
+  hideLineageTab = false,
   ...props
 }) => {
   const [activeTab, setActiveTab] = React.useState(EntityTab.DETAIL);
@@ -129,11 +133,18 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
                 )}
               </div>
             </Tab>
-            <Tab eventKey={EntityTab.RESOURCE} title={<TabTitleText>{'Resources'}</TabTitleText>}>
+            <Tab eventKey={EntityTab.RESOURCE} title={<TabTitleText>Resources</TabTitleText>}>
               <div className="entity-overview__wrapper">
                 {isTarget ? <TargetResources targetNode={data} /> : <GroupResources envNode={data} />}
               </div>
             </Tab>
+            {isTarget && !hideLineageTab && data.target.jvmId ? (
+              <Tab eventKey={EntityTab.LINEAGE} title={<TabTitleText>Lineage</TabTitleText>}>
+                <div className="entity-overview__wrapper">
+                  <TargetLineage jvmId={data.target.jvmId} />
+                </div>
+              </Tab>
+            ) : null}
           </Tabs>
         </>
       );

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -86,6 +86,7 @@ export interface EntityDetailsProps {
   alertOptions?: AlertOptions;
   actionFilter?: (_: NodeAction) => boolean;
   hideLineageTab?: boolean;
+  hideActions?: boolean;
 }
 
 enum EntityTab {
@@ -101,6 +102,7 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
   actionFilter,
   alertOptions,
   hideLineageTab = false,
+  hideActions = false,
   ...props
 }) => {
   const [activeTab, setActiveTab] = React.useState(EntityTab.DETAIL);
@@ -120,7 +122,7 @@ export const EntityDetails: React.FC<EntityDetailsProps> = ({
             badge={nodeTypeToAbbr(data.nodeType)}
             badgeTooltipContent={data.nodeType}
             status={isTarget ? getStatusTargetNode(data) : []}
-            actionDropdown={_actions.length ? <ActionDropdown actions={_actions} /> : null}
+            actionDropdown={!hideActions && _actions.length ? <ActionDropdown actions={_actions} /> : null}
           />
           <Divider />
           <Tabs activeKey={activeTab} onSelect={(_, tab: string) => setActiveTab(tab as EntityTab)}>

--- a/src/app/Topology/GraphView/TopologyGraphView.tsx
+++ b/src/app/Topology/GraphView/TopologyGraphView.tsx
@@ -83,11 +83,13 @@ export type SavedNodePosition = {
 export interface TopologyGraphViewProps {
   transformConfig?: TransformConfig;
   hideToolbar?: boolean;
+  hideActions?: boolean;
 }
 
 export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({
   transformConfig,
   hideToolbar = false,
+  hideActions = false,
   ...props
 }) => {
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]); // selectedIds is exactly matched by VisualizationSurface
@@ -260,7 +262,7 @@ export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({
   const sidebar = React.useMemo(
     () => (
       <TopologySideBar onClose={handleDrawerClose}>
-        <EntityDetails entity={selectedEntity} hideLineageTab={true} />
+        <EntityDetails entity={selectedEntity} hideLineageTab={true} hideActions={hideActions} />
       </TopologySideBar>
     ),
     [handleDrawerClose, selectedEntity],

--- a/src/app/Topology/GraphView/TopologyGraphView.tsx
+++ b/src/app/Topology/GraphView/TopologyGraphView.tsx
@@ -265,7 +265,7 @@ export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({
         <EntityDetails entity={selectedEntity} hideLineageTab={true} hideActions={hideActions} />
       </TopologySideBar>
     ),
-    [handleDrawerClose, selectedEntity],
+    [handleDrawerClose, selectedEntity, hideActions],
   );
 
   return (

--- a/src/app/Topology/GraphView/TopologyGraphView.tsx
+++ b/src/app/Topology/GraphView/TopologyGraphView.tsx
@@ -255,7 +255,7 @@ export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({ transformC
   const sidebar = React.useMemo(
     () => (
       <TopologySideBar onClose={handleDrawerClose}>
-        <EntityDetails entity={selectedEntity} />
+        <EntityDetails entity={selectedEntity} hideLineageTab={true} />
       </TopologySideBar>
     ),
     [handleDrawerClose, selectedEntity],

--- a/src/app/Topology/GraphView/TopologyGraphView.tsx
+++ b/src/app/Topology/GraphView/TopologyGraphView.tsx
@@ -82,9 +82,14 @@ export type SavedNodePosition = {
 
 export interface TopologyGraphViewProps {
   transformConfig?: TransformConfig;
+  hideToolbar?: boolean;
 }
 
-export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({ transformConfig, ...props }) => {
+export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({
+  transformConfig,
+  hideToolbar = false,
+  ...props
+}) => {
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]); // selectedIds is exactly matched by VisualizationSurface
   const [selectedEntity, setSelectedEntity] = React.useState<GraphElement>();
   const [showGraphAnyway, setShowGraphAnyway] = React.useState(false);
@@ -264,17 +269,21 @@ export const TopologyGraphView: React.FC<TopologyGraphViewProps> = ({ transformC
   return (
     <>
       <Stack>
-        <StackItem>
-          <TopologyToolbar
-            variant={TopologyToolbarVariant.Graph}
-            visualization={visualization}
-            isDisabled={exceedLimit && !showGraphAnyway}
-          />
-        </StackItem>
-        <StackItem>
-          <Divider />
-        </StackItem>
-        <StackItem isFilled>
+        {!hideToolbar && (
+          <>
+            <StackItem>
+              <TopologyToolbar
+                variant={TopologyToolbarVariant.Graph}
+                visualization={visualization}
+                isDisabled={exceedLimit && !showGraphAnyway}
+              />
+            </StackItem>
+            <StackItem>
+              <Divider />
+            </StackItem>
+          </>
+        )}
+        <StackItem isFilled className={hideToolbar ? 'topology__graph-view--full-height' : ''}>
           {isEmptyGraph ? (
             <TopologyEmptyState />
           ) : exceedLimit && !showGraphAnyway ? (

--- a/src/app/Topology/ListView/utils.tsx
+++ b/src/app/Topology/ListView/utils.tsx
@@ -67,6 +67,7 @@ const _transformDataGroupedByTopLevel = (
                     className="topology__list-view__entity-details"
                     entity={{ getData: () => child }}
                     columnModifier={{ default: '3Col' }}
+                    hideLineageTab={true}
                   />
                 ),
               },
@@ -127,6 +128,7 @@ const _buildFullData = (
                 className="topology__list-view__entity-details"
                 entity={{ getData: () => node }}
                 columnModifier={{ default: '3Col' }}
+                hideLineageTab={true}
               />
             ),
           },

--- a/src/app/Topology/TargetLineage.tsx
+++ b/src/app/Topology/TargetLineage.tsx
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { RootState } from '@app/Shared/Redux/ReduxStore';
 import { EnvironmentNode } from '@app/Shared/Services/api.types';
 import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
-import * as React from 'react';
-import { DiscoveryTreeContext } from './Shared/utils';
-import { useSelector } from 'react-redux';
-import { RootState } from '@app/Shared/Redux/ReduxStore';
-import { TopologyGraphView } from './GraphView/TopologyGraphView';
 import { EmptyState, EmptyStateHeader, EmptyStateIcon } from '@patternfly/react-core';
 import { TopologyIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+import { useSelector } from 'react-redux';
+import { TopologyGraphView } from './GraphView/TopologyGraphView';
+import { DiscoveryTreeContext } from './Shared/utils';
 
 interface TargetLineageProps {
   jvmId: string;
@@ -44,19 +44,17 @@ export const TargetLineage: React.FC<TargetLineageProps> = ({ jvmId }) => {
 
   React.useEffect(() => {
     addSubscription(
-      context.api
-        .doGet<EnvironmentNode>(`audit/target_lineage/${jvmId}`, 'beta')
-        .subscribe({
-          next: (v) => {
-            setRoot(v);
-            setHasError(false);
-          },
-          error: (err) => {
-            console.warn('Target lineage unavailable:', err);
-            setHasError(true);
-            setRoot(undefined);
-          },
-        }),
+      context.api.doGet<EnvironmentNode>(`audit/target_lineage/${jvmId}`, 'beta').subscribe({
+        next: (v) => {
+          setRoot(v);
+          setHasError(false);
+        },
+        error: (err) => {
+          console.warn('Target lineage unavailable:', err);
+          setHasError(true);
+          setRoot(undefined);
+        },
+      }),
     );
   }, [jvmId, context, context.api, addSubscription]);
 
@@ -73,9 +71,11 @@ export const TargetLineage: React.FC<TargetLineageProps> = ({ jvmId }) => {
   }
 
   return root ? (
-    <DiscoveryTreeContext.Provider value={root}>
-      <TopologyGraphView transformConfig={transformConfig} />
-    </DiscoveryTreeContext.Provider>
+    <div style={{ height: '100%', width: '100%' }}>
+      <DiscoveryTreeContext.Provider value={root}>
+        <TopologyGraphView transformConfig={transformConfig} hideToolbar={true} />
+      </DiscoveryTreeContext.Provider>
+    </div>
   ) : (
     <></>
   );

--- a/src/app/Topology/TargetLineage.tsx
+++ b/src/app/Topology/TargetLineage.tsx
@@ -26,9 +26,10 @@ import { DiscoveryTreeContext } from './Shared/utils';
 
 interface TargetLineageProps {
   jvmId: string;
+  hideActions?: boolean;
 }
 
-export const TargetLineage: React.FC<TargetLineageProps> = ({ jvmId }) => {
+export const TargetLineage: React.FC<TargetLineageProps> = ({ jvmId, hideActions = false }) => {
   const context = React.useContext(ServiceContext);
   const addSubscription = useSubscriptions();
 
@@ -73,7 +74,7 @@ export const TargetLineage: React.FC<TargetLineageProps> = ({ jvmId }) => {
   return root ? (
     <div style={{ height: '100%', width: '100%' }}>
       <DiscoveryTreeContext.Provider value={root}>
-        <TopologyGraphView transformConfig={transformConfig} hideToolbar={true} />
+        <TopologyGraphView transformConfig={transformConfig} hideToolbar={true} hideActions={hideActions} />
       </DiscoveryTreeContext.Provider>
     </div>
   ) : (

--- a/src/app/Topology/TargetLineage.tsx
+++ b/src/app/Topology/TargetLineage.tsx
@@ -44,7 +44,7 @@ export const TargetLineage: React.FC<TargetLineageProps> = ({ jvmId }) => {
 
   React.useEffect(() => {
     addSubscription(
-      context.api.doGet<EnvironmentNode>(`audit/target_lineage/${jvmId}`, 'beta').subscribe({
+      context.api.getTargetLineage(jvmId).subscribe({
         next: (v) => {
           setRoot(v);
           setHasError(false);

--- a/src/app/Topology/TargetLineage.tsx
+++ b/src/app/Topology/TargetLineage.tsx
@@ -50,8 +50,7 @@ export const TargetLineage: React.FC<TargetLineageProps> = ({ jvmId, hideActions
           setRoot(v);
           setHasError(false);
         },
-        error: (err) => {
-          console.warn('Target lineage unavailable:', err);
+        error: (_) => {
           setHasError(true);
           setRoot(undefined);
         },

--- a/src/app/Topology/TargetLineage.tsx
+++ b/src/app/Topology/TargetLineage.tsx
@@ -36,7 +36,7 @@ export const TargetLineage: React.FC<TargetLineageProps> = ({ jvmId, hideActions
   const displayOptions = useSelector((state: RootState) => state.topologyConfigs.displayOptions);
   const { groupings } = displayOptions;
   const transformConfig = React.useMemo(
-    () => ({ showOnlyTopGroup: groupings.realmOnly, expandMode: !groupings.collapseSingles }),
+    () => ({ showOnlyTopGroup: groupings.flattenIntermediates, expandMode: !groupings.collapseSingles }),
     [groupings],
   );
 

--- a/src/app/Topology/styles/base.css
+++ b/src/app/Topology/styles/base.css
@@ -358,3 +358,23 @@ Below CSS rules only apply to Topology components
 .target-details-modal {
   min-height: 36em;
 }
+
+.target-details-modal .pf-v5-c-modal-box__body {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.target-details-modal .pf-v5-c-modal-box__body > div {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.topology__graph-view--full-height {
+  height: 100%;
+}
+
+.topology__graph-view--full-height .topology__main-container {
+  height: 100%;
+}

--- a/src/mirage/index.ts
+++ b/src/mirage/index.ts
@@ -1110,6 +1110,8 @@ export const startMirage = ({ environment = 'development' } = {}) => {
         );
         return new Response(200);
       });
+      this.get('api/beta/audit/targets/:jvmId', () => new Response(404));
+      this.get('api/beta/audit/target_lineage/:jvmId', () => new Response(404));
     },
   });
 };

--- a/src/test/Topology/TargetLineage.test.tsx
+++ b/src/test/Topology/TargetLineage.test.tsx
@@ -53,15 +53,8 @@ jest.mock('@app/Topology/GraphView/TopologyGraphView', () => ({
 }));
 
 describe('<TargetLineage />', () => {
-  let consoleWarnSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-  });
-
   afterEach(() => {
     cleanup();
-    consoleWarnSpy.mockRestore();
   });
 
   it('should display topology graph when lineage data is successfully fetched', async () => {
@@ -99,7 +92,6 @@ describe('<TargetLineage />', () => {
 
     expect(await screen.findByText('Target Lineage Unavailable')).toBeInTheDocument();
     expect(screen.queryByText('Topology Graph View')).not.toBeInTheDocument();
-    expect(consoleWarnSpy).toHaveBeenCalledWith('Target lineage unavailable:', error404);
   });
 
   it('should display empty state when 403 error occurs (auditing disabled)', async () => {
@@ -119,7 +111,6 @@ describe('<TargetLineage />', () => {
 
     expect(await screen.findByText('Target Lineage Unavailable')).toBeInTheDocument();
     expect(screen.queryByText('Topology Graph View')).not.toBeInTheDocument();
-    expect(consoleWarnSpy).toHaveBeenCalledWith('Target lineage unavailable:', error403);
   });
 
   it('should display empty state when network error occurs', async () => {
@@ -139,7 +130,6 @@ describe('<TargetLineage />', () => {
 
     expect(await screen.findByText('Target Lineage Unavailable')).toBeInTheDocument();
     expect(screen.queryByText('Topology Graph View')).not.toBeInTheDocument();
-    expect(consoleWarnSpy).toHaveBeenCalledWith('Target lineage unavailable:', networkError);
   });
 
   it('should display empty state with correct icon and heading level', async () => {
@@ -172,7 +162,7 @@ describe('<TargetLineage />', () => {
     expect(icon).toBeInTheDocument();
   });
 
-  it('should log console warning on error', async () => {
+  it('should display empty state on error', async () => {
     const testError = { status: 500, message: 'Internal Server Error' };
     jest.spyOn(defaultServices.api, 'getTargetLineage').mockReturnValue(throwError(() => testError));
 
@@ -187,9 +177,7 @@ describe('<TargetLineage />', () => {
       },
     });
 
-    await screen.findByText('Target Lineage Unavailable');
-
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-    expect(consoleWarnSpy).toHaveBeenCalledWith('Target lineage unavailable:', testError);
+    expect(await screen.findByText('Target Lineage Unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Topology Graph View')).not.toBeInTheDocument();
   });
 });

--- a/src/test/Topology/TargetLineage.test.tsx
+++ b/src/test/Topology/TargetLineage.test.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { TargetLineage } from '@app/Topology/TargetLineage';
 import { EnvironmentNode, NodeType } from '@app/Shared/Services/api.types';
 import { defaultServices } from '@app/Shared/Services/Services';
+import { TargetLineage } from '@app/Topology/TargetLineage';
 import '@testing-library/jest-dom';
 import { cleanup, screen, within } from '@testing-library/react';
 import { of, throwError } from 'rxjs';

--- a/src/test/Topology/TargetLineage.test.tsx
+++ b/src/test/Topology/TargetLineage.test.tsx
@@ -1,0 +1,195 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TargetLineage } from '@app/Topology/TargetLineage';
+import { EnvironmentNode, NodeType } from '@app/Shared/Services/api.types';
+import { defaultServices } from '@app/Shared/Services/Services';
+import '@testing-library/jest-dom';
+import { cleanup, screen, within } from '@testing-library/react';
+import { of, throwError } from 'rxjs';
+import { render } from '../utils';
+
+const mockJvmId = 'test-jvm-id';
+
+const mockLineageData: EnvironmentNode = {
+  id: 0,
+  name: 'JDP',
+  nodeType: NodeType.REALM,
+  labels: [],
+  children: [
+    {
+      id: 1,
+      name: 'test-target',
+      nodeType: NodeType.JVM,
+      labels: [],
+      target: {
+        id: 1,
+        connectUrl: 'service:jmx:rmi:///jndi/rmi://test:9091/jmxrmi',
+        alias: 'test-target',
+        jvmId: mockJvmId,
+        labels: [],
+        annotations: { cryostat: [], platform: [] },
+        agent: false,
+      },
+    },
+  ],
+};
+
+jest.mock('@app/Topology/GraphView/TopologyGraphView', () => ({
+  TopologyGraphView: jest.fn(() => <div>Topology Graph View</div>),
+}));
+
+describe('<TargetLineage />', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('should display topology graph when lineage data is successfully fetched', async () => {
+    jest.spyOn(defaultServices.api, 'getTargetLineage').mockReturnValue(of(mockLineageData));
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/lineage',
+            element: <TargetLineage jvmId={mockJvmId} />,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByText('Topology Graph View')).toBeInTheDocument();
+    expect(screen.queryByText('Target Lineage Unavailable')).not.toBeInTheDocument();
+  });
+
+  it('should display empty state when 404 error occurs', async () => {
+    const error404 = { status: 404, message: 'Not Found' };
+    jest.spyOn(defaultServices.api, 'getTargetLineage').mockReturnValue(throwError(() => error404));
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/lineage',
+            element: <TargetLineage jvmId={mockJvmId} />,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByText('Target Lineage Unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Topology Graph View')).not.toBeInTheDocument();
+    expect(consoleWarnSpy).toHaveBeenCalledWith('Target lineage unavailable:', error404);
+  });
+
+  it('should display empty state when 403 error occurs (auditing disabled)', async () => {
+    const error403 = { status: 403, message: 'Forbidden' };
+    jest.spyOn(defaultServices.api, 'getTargetLineage').mockReturnValue(throwError(() => error403));
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/lineage',
+            element: <TargetLineage jvmId={mockJvmId} />,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByText('Target Lineage Unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Topology Graph View')).not.toBeInTheDocument();
+    expect(consoleWarnSpy).toHaveBeenCalledWith('Target lineage unavailable:', error403);
+  });
+
+  it('should display empty state when network error occurs', async () => {
+    const networkError = new Error('Network error');
+    jest.spyOn(defaultServices.api, 'getTargetLineage').mockReturnValue(throwError(() => networkError));
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/lineage',
+            element: <TargetLineage jvmId={mockJvmId} />,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByText('Target Lineage Unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Topology Graph View')).not.toBeInTheDocument();
+    expect(consoleWarnSpy).toHaveBeenCalledWith('Target lineage unavailable:', networkError);
+  });
+
+  it('should display empty state with correct icon and heading level', async () => {
+    const error = new Error('Test error');
+    jest.spyOn(defaultServices.api, 'getTargetLineage').mockReturnValue(throwError(() => error));
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/lineage',
+            element: <TargetLineage jvmId={mockJvmId} />,
+          },
+        ],
+      },
+    });
+
+    const emptyState = await screen.findByText('Target Lineage Unavailable');
+    expect(emptyState).toBeInTheDocument();
+
+    const heading = emptyState.closest('h4');
+    expect(heading).toBeInTheDocument();
+
+    const emptyStateContainer = screen
+      .getByText('Target Lineage Unavailable')
+      .closest('.pf-v5-c-empty-state') as HTMLElement;
+    expect(emptyStateContainer).toBeInTheDocument();
+
+    const icon = within(emptyStateContainer).getByRole('img', { hidden: true });
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('should log console warning on error', async () => {
+    const testError = { status: 500, message: 'Internal Server Error' };
+    jest.spyOn(defaultServices.api, 'getTargetLineage').mockReturnValue(throwError(() => testError));
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/lineage',
+            element: <TargetLineage jvmId={mockJvmId} />,
+          },
+        ],
+      },
+    });
+
+    await screen.findByText('Target Lineage Unavailable');
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).toHaveBeenCalledWith('Target lineage unavailable:', testError);
+  });
+});


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Related to https://github.com/cryostatio/cryostat/issues/1292
Depends on https://github.com/cryostatio/cryostat/pull/1297

## Description of the change:
1. Updates the target info modal (ex. Archives > All Targets, or Recordings, anywhere the target context selector appears) to include a new Lineage tab, which shows an embedded Topology graph view isolating the selected Target itself, the Discovery Node it's attached to, that Node's parent Node, up to the Realm level. This currently always calls into the backend's new audit endpoint to determine the target's lineage based on historical audit records, but for currently available/discovered targets this information is also present in the regular discovery tree, which should be a more performant query when it's available. Once a target is lost then it is removed from the regular discovery tree and the tree is pruned so its ancestors will also be removed (unless they have other children), so the information becomes only available via the audit log. (see cryostatio/cryostat#860 for the soft-deletion implementation attempt, which hasn't worked out)
2. Replaces the Archives > All Archives question mark tooltip button with the same target info modal
3. Hides the entity details component's Actions dropdown menu when looking at an audit-sourced target entity

## How to manually test:
1. See https://github.com/cryostatio/cryostat/pull/1297