### PR TITLE
fix(webpack): use absolute public path for static assets

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -18,6 +18,7 @@ module.exports = (env) => {
       new HtmlWebpackPlugin({
         template: path.resolve(__dirname, 'src', 'index.html'),
         favicon: './src/app/assets/favicon.ico',
+        publicPath: '/',
       })
     ],
     // https://medium.com/hackernoon/the-100-correct-way-to-split-your-chunks-with-webpack-f8a9df5b7758


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1284 

## Description of the change:
Adds `publicPath: '/'` to `HtmlWebpackPlugin` in `webpack.common.js`, making all script and link tags in the generated
 `index.html` use absolute paths (e.g., `/app.xxx.bundle.js`) instead of relative paths.

## Motivation for the change:
When directly visiting subview routes like `/recordings/create`, the `<base href="./">` in `index.html` causes the
browser to resolve asset paths relative to the current URL path. This results in the browser requesting
`/recordings/app.xxx.bundle.js` instead of `/app.xxx.bundle.js`. The server doesn't recognize these paths and responds
 with `index.html`, causing MIME type and SyntaxError console errors and a blank page.

As discussed in #1284, several approaches were considered (backing out #1175, flattening
routes, modals). In this case, setting `publicPath: '/'` on `HtmlWebpackPlugin` makes script and link
tags use absolute paths while leaving the base href and `output.publicPath: 'auto'` intact
for API calls and dynamically loaded chunks.

## How to manually test:
1. Run `yarn build:notests` and serve the `dist/` folder with a static server with SPA fallback (e.g., `npx serve dist
 -s`)
2. Directly visit each subview URL in the browser:
   - `/recordings/create`
   - `/rules/create`
   - `/topology/create-custom-target`
3. Verify each page renders correctly with no blank page and no MIME type or SyntaxError errors in the browser console
4. Verify normal navigation still works (e.g., `/recordings` → click Create)
