### PR TITLE
ci(submodule): open PRs rather than directly pushing

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -44,8 +44,12 @@ jobs:
       run: |
         git add --all
         git_hash="$(git rev-parse --short :src/main/webui)"
-        git commit -S -m "build(webui): update submodule to $git_hash" || echo "No changes to commit"
-        git push
+        export msg="build(webui): update submodule to $git_hash"
+        export branch="ci-update-${git_hash}"
+        git checkout -b "${branch}"
+        git commit -S -m "${msg}" \
+          && git push --set-upstream origin "${branch}" \
+          && gh pr create --repo cryostatio/cryostat --base "${{ github.ref_name }}" --title "${msg}" --body 'automatic update' --label chore --reviewer '@cryostatio/maintainers'
 
   update-console-plugin-submodule:
     if: ${{ github.repository_owner == 'cryostatio' }}
@@ -77,6 +81,10 @@ jobs:
     - name: Commit and push submodule
       run: |
         git add --all
-        git_hash="$(git rev-parse --short :src/cryostat-web)"
-        git commit -S -m "build(cryostat-web): update submodule to $git_hash" || echo "No changes to commit"
-        git push
+        git_hash="$(git rev-parse --short :src/main/webui)"
+        export msg="build(webui): update submodule to $git_hash"
+        export branch="ci-update-${git_hash}"
+        git checkout -b "${branch}"
+        git commit -S -m "${msg}" \
+          && git push --set-upstream origin "${branch}" \
+          && gh pr create --repo cryostatio/cryostat-openshift-console-plugin --base "${{ github.ref_name }}" --title "${msg}" --body 'automatic update' --label chore --reviewer '@cryostatio/maintainers'


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #2075
