### PR TITLE
ci(submodule): remove broken reviewer assignment

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -51,7 +51,7 @@ jobs:
         git checkout -b "${branch}"
         git commit -S -m "${msg}" \
           && git push --set-upstream origin "${branch}" \
-          && gh pr create --repo cryostatio/cryostat --base "${{ github.ref_name }}" --title "${msg}" --body 'automatic update' --label chore --reviewer '@cryostatio/maintainers'
+          && gh pr create --repo cryostatio/cryostat --base "${{ github.ref_name }}" --title "${msg}" --body 'automatic update' --label chore
 
   update-console-plugin-submodule:
     if: ${{ github.repository_owner == 'cryostatio' }}
@@ -91,4 +91,4 @@ jobs:
         git checkout -b "${branch}"
         git commit -S -m "${msg}" \
           && git push --set-upstream origin "${branch}" \
-          && gh pr create --repo cryostatio/cryostat-openshift-console-plugin --base "${{ github.ref_name }}" --title "${msg}" --body 'automatic update' --label chore --reviewer '@cryostatio/maintainers'
+          && gh pr create --repo cryostatio/cryostat-openshift-console-plugin --base "${{ github.ref_name }}" --title "${msg}" --body 'automatic update' --label chore


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #2078

See https://github.com/orgs/community/discussions/113519

https://github.com/cryostatio/cryostat-web/actions/runs/21842241847/job/63029302124

The default token is not able to query for organization teams, so it cannot assign our `maintainers` group as reviewer. Better to just leave it blank than to hardcode any individuals into the workflow, in that case.
