### PR TITLE
ci(submodule): use PAT rather than default token

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -42,7 +42,7 @@ jobs:
         git submodule update --remote
     - name: Commit and push submodule
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.SUBMODULE_TOKEN }}
       run: |
         git add --all
         git_hash="$(git rev-parse --short :src/main/webui)"
@@ -82,7 +82,7 @@ jobs:
         git submodule update --remote
     - name: Commit and push submodule
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.SUBMODULE_TOKEN }}
       run: |
         git add --all
         git_hash="$(git rev-parse --short :src/cryostat-web)"


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #2079
https://github.com/cryostatio/cryostat-web/actions/runs/21842504207/job/63030207071
