### PR TITLE
ci(submodule): open PRs rather than directly pushing

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -146,7 +146,7 @@ jobs:
       with:
         title: ${{ env.PR_TITLE }}
         branch: ${{ env.PR_BRANCH }}
-        branch-token: ${{ secrets.SUBMODULE_TOKEN }}
+        token: ${{ secrets.SUBMODULE_TOKEN }}
         push-to-fork: cryostat-bot/cryostat-openshift-console-plugin
         maintainer-can-modify: false
         delete-branch: true


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Manual backport of:
https://github.com/cryostatio/cryostat-web/pull/2068
https://github.com/cryostatio/cryostat-web/pull/2076
https://github.com/cryostatio/cryostat-web/pull/2078
https://github.com/cryostatio/cryostat-web/pull/2079
https://github.com/cryostatio/cryostat-web/pull/2080
https://github.com/cryostatio/cryostat-web/pull/2083
https://github.com/cryostatio/cryostat-web/pull/2107
https://github.com/cryostatio/cryostat-web/pull/2108
https://github.com/cryostatio/cryostat-web/pull/2110
#2112