### PR TITLE
ci(submodule): use standard remote name for fork

### DIFF
--- a/.github/workflows/submodule.yaml
+++ b/.github/workflows/submodule.yaml
@@ -68,9 +68,9 @@ jobs:
         export body="see cryostatio/cryostat-web#${{ steps.get_issue_number.outputs.result }}"
         export branch="ci-update-${git_hash}"
         git checkout -b "${branch}"
-        gh repo fork --remote-name fork
+        gh repo fork
         git commit -S -m "${title}"
-        git push --set-upstream fork "${branch}"
+        git push --set-upstream origin "${branch}"
         gh pr create --repo cryostatio/cryostat --base "${{ github.ref_name }}" --title "${title}" --body "${body}" --label chore
 
   update-console-plugin-submodule:
@@ -128,7 +128,7 @@ jobs:
         export body="see cryostatio/cryostat-web#${{ steps.get_issue_number.outputs.result }}"
         export branch="ci-update-${git_hash}"
         git checkout -b "${branch}"
-        gh repo fork --remote-name fork
+        gh repo fork
         git commit -S -m "${title}"
-        git push --set-upstream fork "${branch}"
+        git push --set-upstream origin "${branch}"
         gh pr create --repo cryostatio/cryostat-openshift-console-plugin --base "${{ github.ref_name }}" --title "${title}" --body "${body}" --label chore


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See #2104
