### PR TITLE
feat: reuse analysis UI controls in archived recordings table

### DIFF
--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -15,16 +15,33 @@
  */
 
 import { ArchiveUploadModal } from '@app/Archives/ArchiveUploadModal';
+import { AutomatedAnalysisCardList } from '@app/Dashboard/AutomatedAnalysis/AutomatedAnalysisCardList';
+import {
+  AutomatedAnalysisFilters,
+  AutomatedAnalysisFiltersCategories,
+  AutomatedAnalysisGlobalFiltersCategories,
+  filterAutomatedAnalysis,
+} from '@app/Dashboard/AutomatedAnalysis/AutomatedAnalysisFilters';
 import {
   ClickableAutomatedAnalysisLabel,
   clickableAutomatedAnalysisKey,
 } from '@app/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel';
+import { AutomatedAnalysisScoreFilter } from '@app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter';
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
 import { DeleteOrDisableWarningType } from '@app/Modal/types';
 import { LoadingProps } from '@app/Shared/Components/types';
 import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
+import {
+  emptyAutomatedAnalysisFilters,
+  TargetAutomatedAnalysisFilters,
+} from '@app/Shared/Redux/Filters/AutomatedAnalysisFilterSlice';
 import { emptyArchivedRecordingFilters, TargetRecordingFilters } from '@app/Shared/Redux/Filters/RecordingFilterSlice';
 import {
+  automatedAnalysisAddFilterIntent,
+  automatedAnalysisAddGlobalFilterIntent,
+  automatedAnalysisDeleteAllFiltersIntent,
+  automatedAnalysisDeleteCategoryFiltersIntent,
+  automatedAnalysisDeleteFilterIntent,
   recordingAddFilterIntent,
   recordingDeleteFilterIntent,
   recordingAddTargetIntent,
@@ -46,13 +63,19 @@ import { ServiceContext } from '@app/Shared/Services/Services';
 import { useSort } from '@app/utils/hooks/useSort';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { formatBytes, hashCode, portalRoot, sortResources, TableColumn } from '@app/utils/utils';
+import { useCryostatTranslation } from '@i18n/i18nextUtil';
 import {
   Bullseye,
   Button,
   Checkbox,
+  Content,
   Drawer,
   DrawerContent,
   DrawerContentBody,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
   Grid,
   GridItem,
   LabelGroup,
@@ -77,8 +100,12 @@ import {
   Panel,
   PanelMain,
   PanelMainBody,
+  Stack,
+  StackItem,
+  ToggleGroup,
+  ToggleGroupItem,
 } from '@patternfly/react-core';
-import { UploadIcon, EllipsisVIcon } from '@patternfly/react-icons';
+import { UploadIcon, EllipsisVIcon, SearchIcon } from '@patternfly/react-icons';
 import { Tbody, Tr, Td, ExpandableRowContent, Table, SortByDirection } from '@patternfly/react-table';
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -778,6 +805,238 @@ export interface ArchivedRecordingRowProps {
   updateFilters: (target: string, updateFilterOptions: UpdateFilterOptions) => void;
 }
 
+interface ArchivedRecordingAnalysisProps {
+  analysisTarget: string;
+  analyses: CategorizedRuleEvaluations[];
+  loadingAnalysis: boolean;
+  useCompactLabels: boolean;
+  idPrefix: string;
+}
+
+const ArchivedRecordingAnalysis: React.FC<ArchivedRecordingAnalysisProps> = ({
+  analysisTarget,
+  analyses,
+  loadingAnalysis,
+  useCompactLabels,
+  idPrefix,
+}) => {
+  const dispatch = useDispatch<StateDispatch>();
+  const { t } = useCryostatTranslation();
+  const [showListView, setShowListView] = React.useState(false);
+  const [showNAScores, setShowNAScores] = React.useState<boolean>(false);
+  const [filteredCategorizedEvaluation, setFilteredCategorizedEvaluation] = React.useState<
+    CategorizedRuleEvaluations[]
+  >([]);
+
+  const targetAutomatedAnalysisFilters = useSelector((state: RootState) => {
+    const filters = state.automatedAnalysisFilters.targetFilters.filter(
+      (targetFilter: TargetAutomatedAnalysisFilters) => targetFilter.target === analysisTarget,
+    );
+    return filters.length > 0 ? filters[0].filters : emptyAutomatedAnalysisFilters;
+  }) as AutomatedAnalysisFiltersCategories;
+
+  const targetAutomatedAnalysisGlobalFilters = useSelector((state: RootState) => {
+    return state.automatedAnalysisFilters.globalFilters.filters;
+  }) as AutomatedAnalysisGlobalFiltersCategories;
+
+  const updateAutomatedAnalysisFilters = React.useCallback(
+    (target, { filterValue, filterKey, deleted = false, deleteOptions }: UpdateFilterOptions) => {
+      if (deleted) {
+        if (deleteOptions?.all) {
+          dispatch(automatedAnalysisDeleteCategoryFiltersIntent(target, filterKey));
+        } else {
+          dispatch(automatedAnalysisDeleteFilterIntent(target, filterKey, filterValue));
+        }
+      } else {
+        dispatch(automatedAnalysisAddFilterIntent(target, filterKey, filterValue));
+      }
+    },
+    [dispatch],
+  );
+
+  const handleClearFilters = React.useCallback(() => {
+    dispatch(automatedAnalysisDeleteAllFiltersIntent(analysisTarget));
+  }, [dispatch, analysisTarget]);
+
+  const handleResetScoreFilter = React.useCallback(() => {
+    dispatch(automatedAnalysisAddGlobalFilterIntent('Score', 0));
+  }, [dispatch]);
+
+  const showUnavailableScores = React.useCallback(() => {
+    setShowNAScores(true);
+  }, []);
+
+  React.useEffect(() => {
+    setFilteredCategorizedEvaluation(
+      filterAutomatedAnalysis(
+        analyses,
+        targetAutomatedAnalysisFilters,
+        targetAutomatedAnalysisGlobalFilters,
+        showNAScores,
+      ),
+    );
+  }, [
+    analyses,
+    targetAutomatedAnalysisFilters,
+    targetAutomatedAnalysisGlobalFilters,
+    showNAScores,
+    setFilteredCategorizedEvaluation,
+  ]);
+
+  const toolbar = React.useMemo(() => {
+    return (
+      <Toolbar
+        id={`${idPrefix}-automated-analysis-toolbar`}
+        aria-label={t('AutomatedAnalysisCard.TOOLBAR.LABEL')}
+        clearAllFilters={handleClearFilters}
+        clearFiltersButtonText={t('CLEAR_FILTERS')}
+        isFullHeight
+      >
+        <ToolbarContent>
+          <AutomatedAnalysisFilters
+            target={analysisTarget}
+            evaluations={analyses}
+            filters={targetAutomatedAnalysisFilters}
+            updateFilters={updateAutomatedAnalysisFilters}
+          />
+          <ToolbarItem>
+            <Checkbox
+              label={t('AutomatedAnalysisCard.TOOLBAR.CHECKBOX.SHOW_NA.LABEL')}
+              isChecked={showNAScores}
+              onChange={(_, checked: boolean) => setShowNAScores(checked)}
+              id={`${idPrefix}-show-na-scores`}
+              name={`${idPrefix}-show-na-scores`}
+              style={{ alignSelf: 'center' }}
+            />
+          </ToolbarItem>
+          <ToolbarItem variant="separator" />
+          <ToolbarItem>
+            <ToggleGroup>
+              <ToggleGroupItem
+                aria-label={t('AutomatedAnalysisCard.TOOLBAR.ARIA_LABELS.GRID_VIEW')}
+                text="Grid view"
+                buttonId={`${idPrefix}-grid-view-btn`}
+                isSelected={!showListView}
+                onClick={() => setShowListView(false)}
+              />
+              <ToggleGroupItem
+                aria-label={t('AutomatedAnalysisCard.TOOLBAR.ARIA_LABELS.LIST_VIEW')}
+                text="List view"
+                buttonId={`${idPrefix}-list-view-btn`}
+                isSelected={showListView}
+                onClick={() => setShowListView(true)}
+              />
+            </ToggleGroup>
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+    );
+  }, [
+    t,
+    idPrefix,
+    handleClearFilters,
+    analysisTarget,
+    analyses,
+    targetAutomatedAnalysisFilters,
+    updateAutomatedAnalysisFilters,
+    showNAScores,
+    showListView,
+  ]);
+
+  const filteredCategorizedLabels = React.useMemo(() => {
+    const filtered = filteredCategorizedEvaluation.filter(([_, evaluations]) => evaluations.length > 0);
+
+    if (filtered.length === 0) {
+      return (
+        <EmptyState headingLevel="h4" icon={SearchIcon} titleText={<>{t('AutomatedAnalysisCard.NO_RESULTS')}</>}>
+          <EmptyStateBody>{t('AutomatedAnalysisCard.NO_RESULTS_BODY')}</EmptyStateBody>
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <Button variant="link" onClick={handleClearFilters}>
+                {t('CLEAR_FILTERS')}
+              </Button>
+              <Button variant="link" onClick={showUnavailableScores}>
+                {t('AutomatedAnalysisCard.TOOLBAR.CHECKBOX.SHOW_NA.LABEL')}
+              </Button>
+              <Button variant="link" onClick={handleResetScoreFilter}>
+                {t('AutomatedAnalysisScoreFilter.SLIDER.RESET0.LABEL')}
+              </Button>
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        </EmptyState>
+      );
+    }
+
+    if (showListView) {
+      return <AutomatedAnalysisCardList evaluations={filtered} />;
+    }
+
+    return (
+      <Grid>
+        {filtered.map(([topic, evaluations]) => {
+          return (
+            <GridItem className="automated-analysis-grid-item" span={2} key={`gridItem-${topic}`}>
+              <LabelGroup
+                className="automated-analysis-topic-label-groups"
+                categoryName={topic}
+                isVertical
+                numLabels={2}
+                isCompact={useCompactLabels}
+                key={topic}
+              >
+                {evaluations.map((evaluation) => {
+                  return (
+                    <ClickableAutomatedAnalysisLabel
+                      result={evaluation}
+                      key={`${clickableAutomatedAnalysisKey}-${topic}-${evaluation.name}-${evaluation.score}`}
+                    />
+                  );
+                })}
+              </LabelGroup>
+            </GridItem>
+          );
+        })}
+      </Grid>
+    );
+  }, [
+    t,
+    handleClearFilters,
+    showUnavailableScores,
+    handleResetScoreFilter,
+    filteredCategorizedEvaluation,
+    showListView,
+    useCompactLabels,
+  ]);
+
+  if (loadingAnalysis) {
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
+  }
+
+  if (!analyses.length) {
+    return (
+      <EmptyState headingLevel="h4" icon={SearchIcon} titleText={t('TargetAnalysis.REPORT_UNAVAILABLE')}>
+        <EmptyStateBody>
+          <Content component="p">{t('AutomatedAnalysisCard.NO_RESULTS_BODY')}</Content>
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
+
+  return (
+    <Stack hasGutter>
+      <StackItem>{toolbar}</StackItem>
+      <StackItem>
+        <AutomatedAnalysisScoreFilter />
+      </StackItem>
+      <StackItem isFilled>{filteredCategorizedLabels}</StackItem>
+    </Stack>
+  );
+};
+
 export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
   recording,
   index,
@@ -798,6 +1057,10 @@ export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
   const [useCompactLabels, setUseCompactLabels] = React.useState(true);
 
   const expandedRowId = React.useMemo(() => `archived-table-row-${index}-exp`, [index]);
+  const analysisTarget = React.useMemo(
+    () => `${currentSelectedTargetURL}:archived-recording-analysis:${recording.name}`,
+    [currentSelectedTargetURL, recording.name],
+  );
 
   React.useEffect(() => {
     addSubscription(context.settings.largeUi().subscribe((v) => setUseCompactLabels(!v)));
@@ -924,37 +1187,13 @@ export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
               <Divider />
               <PanelMain>
                 <PanelMainBody>
-                  <Grid>
-                    {loadingAnalysis ? (
-                      <Bullseye>
-                        <Spinner />
-                      </Bullseye>
-                    ) : (
-                      analyses.map(([topic, evaluations]) => {
-                        return (
-                          <GridItem className="automated-analysis-grid-item" span={2} key={`gridItem-${topic}`}>
-                            <LabelGroup
-                              className="automated-analysis-topic-label-groups"
-                              categoryName={topic}
-                              isVertical
-                              numLabels={2}
-                              isCompact={useCompactLabels}
-                              key={topic}
-                            >
-                              {evaluations.map((evaluation) => {
-                                return (
-                                  <ClickableAutomatedAnalysisLabel
-                                    result={evaluation}
-                                    key={clickableAutomatedAnalysisKey}
-                                  />
-                                );
-                              })}
-                            </LabelGroup>
-                          </GridItem>
-                        );
-                      })
-                    )}
-                  </Grid>
+                  <ArchivedRecordingAnalysis
+                    analysisTarget={analysisTarget}
+                    analyses={analyses}
+                    loadingAnalysis={loadingAnalysis}
+                    useCompactLabels={useCompactLabels}
+                    idPrefix={`archived-recording-analysis-${index}`}
+                  />
                 </PanelMainBody>
               </PanelMain>
             </Panel>
@@ -962,7 +1201,7 @@ export const ArchivedRecordingRow: React.FC<ArchivedRecordingRowProps> = ({
         </Td>
       </Tr>
     );
-  }, [index, isExpanded, analyses, loadingAnalysis, useCompactLabels]);
+  }, [index, isExpanded, analyses, loadingAnalysis, useCompactLabels, analysisTarget]);
 
   return (
     <Tbody key={index} isExpanded={isExpanded}>

--- a/src/app/Recordings/ArchivedRecordingsTable.tsx
+++ b/src/app/Recordings/ArchivedRecordingsTable.tsx
@@ -30,11 +30,11 @@ import { AutomatedAnalysisScoreFilter } from '@app/Dashboard/AutomatedAnalysis/F
 import { DeleteWarningModal } from '@app/Modal/DeleteWarningModal';
 import { DeleteOrDisableWarningType } from '@app/Modal/types';
 import { LoadingProps } from '@app/Shared/Components/types';
-import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 import {
   emptyAutomatedAnalysisFilters,
   TargetAutomatedAnalysisFilters,
 } from '@app/Shared/Redux/Filters/AutomatedAnalysisFilterSlice';
+import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 import { emptyArchivedRecordingFilters, TargetRecordingFilters } from '@app/Shared/Redux/Filters/RecordingFilterSlice';
 import {
   automatedAnalysisAddFilterIntent,

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -25,6 +25,7 @@ import { RootState } from '@app/Shared/Redux/ReduxStore';
 import {
   UPLOADS_SUBDIRECTORY,
   ArchivedRecording,
+  AnalysisResult,
   NotificationMessage,
   Target,
   KeyValue,
@@ -96,6 +97,20 @@ const mockRecording: ArchivedRecording = {
   archivedTime: 2048,
 };
 
+const mockAnalysisResults: AnalysisResult[] = [
+  {
+    evaluation: {
+      explanation: 'because of test',
+      solution: 'nothing',
+      suggestions: [],
+      summary: 'we found something',
+    },
+    name: 'tests',
+    topic: 'testsuite',
+    score: 50.0,
+  },
+];
+
 const mockAllArchivedRecordingsResponse = {
   data: {
     archivedRecordings: {
@@ -150,6 +165,7 @@ jest.spyOn(defaultServices.api, 'grafanaDatasourceUrl').mockReturnValue(of('/dat
 jest.spyOn(defaultServices.api, 'grafanaDashboardUrl').mockReturnValue(of('/grafanaUrl'));
 jest.spyOn(defaultServices.api, 'getTargetArchivedRecordings').mockReturnValue(of([mockRecording]));
 jest.spyOn(defaultServices.api, 'getUploadedRecordings').mockReturnValue(of([mockRecording]));
+jest.spyOn(defaultServices.reports, 'reportJson').mockReturnValue(of(mockAnalysisResults));
 jest.spyOn(defaultServices.api, 'graphql').mockImplementation((query: string) => {
   if (query.includes('AllTargetsArchives')) {
     return of(mockAllArchivedRecordingsResponse);
@@ -895,6 +911,55 @@ describe('<ArchivedRecordingsTable />', () => {
       expect(invalidFileText).toBeInTheDocument();
       expect(invalidFileText).toBeVisible();
     });
+  });
+
+  it('should show automated analysis filter controls and list view when an archived recording is expanded', async () => {
+    const { user } = render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/recordings',
+            element: (
+              <ArchivedRecordingsTable
+                target={of(mockTarget)}
+                isUploadsTable={false}
+                isNestedTable={false}
+                toolbarBreakReference={document.body}
+              />
+            ),
+          },
+        ],
+      },
+      preloadedState: preloadedState,
+    });
+
+    const recordingRow = screen.getAllByRole('row').find((row) => within(row).queryByText(mockRecording.name) !== null);
+    expect(recordingRow).toBeDefined();
+
+    await act(async () => {
+      await user.click(within(recordingRow!).getByLabelText('Details'));
+    });
+
+    const expandedRow = await screen.findByText('Automated analysis');
+    const analysisPanel = within(expandedRow.closest('tr')!);
+
+    expect(await analysisPanel.findByRole('button', { name: testT('FILTER_NAME') })).toBeInTheDocument();
+    expect(analysisPanel.getByLabelText(testT('AutomatedAnalysisScoreFilter.SLIDER.RESET0.LABEL'))).toBeInTheDocument();
+    expect(
+      analysisPanel.getByRole('button', {
+        name: testT('AutomatedAnalysisCard.TOOLBAR.ARIA_LABELS.GRID_VIEW'),
+      }),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(
+        analysisPanel.getByRole('button', {
+          name: testT('AutomatedAnalysisCard.TOOLBAR.ARIA_LABELS.LIST_VIEW'),
+        }),
+      );
+    });
+
+    expect(analysisPanel.getByRole('grid', { name: 'Automated analysis data list' })).toBeInTheDocument();
   });
 
   it('should show error view if failing to retrieve Recordings', async () => {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: #1604

## Description of the change:

Reuse the Automated Analysis filter, score, and grid/list view controls
(from #1589) in the panel shown when expanding an Archived Recordings row.

## Motivation for the change:

The Archived Recordings panel previously showed a plain grid, while the
Dashboard card and Active Recordings Analyze drawer already had these
controls. This PR makes the three interfaces consistent.

## How to manually test:

1. Run webui server against cryostat backend
2. Create an Active Recording and archive it.
3. Expand the archived row.
4. Verify the Automated Analysis panel shows the filter, score slider, and
   grid/list view toggle, and that each control works.