### PR TITLE
fix(css): move modal portalRoot inside of cryostat-app container

### DIFF
--- a/src/app/About/AboutCryostatModal.tsx
+++ b/src/app/About/AboutCryostatModal.tsx
@@ -31,7 +31,7 @@ export const AboutCryostatModal: React.FC<AboutCryostatModalProps> = ({ isOpen, 
   const { t } = useCryostatTranslation();
   return (
     <AboutModal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       productName={`${build.productName} ${build.version}`}
       brandImageSrc={cryostatLogo}
       brandImageAlt="Cryostat Logo"

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -688,7 +688,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
     <GlobalQuickStartDrawer>
       <CryostatJoyride>
         <AlertGroup
-          appendTo={portalRoot}
+          appendTo={portalRoot()}
           isToast
           isLiveRegion
           overflowMessage={overflowMessage}

--- a/src/app/AppLayout/SslErrorModal.tsx
+++ b/src/app/AppLayout/SslErrorModal.tsx
@@ -34,7 +34,7 @@ export const SslErrorModal: React.FC<SslErrorModalProps> = ({ visible, onDismiss
 
   return (
     <Modal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       isOpen={visible}
       variant={ModalVariant.medium}
       showClose={true}

--- a/src/app/Archives/AllArchivedRecordingsTable.tsx
+++ b/src/app/Archives/AllArchivedRecordingsTable.tsx
@@ -410,7 +410,7 @@ export const AllArchivedRecordingsTable: React.FC<AllArchivedRecordingsTableProp
         title="Target Details"
         variant={ModalVariant.large}
         className="target-details-modal"
-        appendTo={portalRoot}
+        appendTo={portalRoot()}
       >
         {loadingLineage ? (
           <Bullseye>

--- a/src/app/Archives/ArchiveUploadModal.tsx
+++ b/src/app/Archives/ArchiveUploadModal.tsx
@@ -164,7 +164,7 @@ export const ArchiveUploadModal: React.FC<ArchiveUploadModalProps> = ({ onClose,
                 For example: io-cryostat-Cryostat_profiling_timestamp.jfr
               </Content>
             }
-            appendTo={portalRoot}
+            appendTo={portalRoot()}
           >
             <sup style={{ cursor: 'pointer' }}>
               <b>[?]</b>
@@ -197,7 +197,7 @@ export const ArchiveUploadModal: React.FC<ArchiveUploadModalProps> = ({ onClose,
                 content={
                   <Content component="p">Unique key-value pairs containing information about the recording.</Content>
                 }
-                appendTo={portalRoot}
+                appendTo={portalRoot()}
               >
                 <Icon>
                   <HelpIcon />

--- a/src/app/CreateRecording/CustomRecordingForm.tsx
+++ b/src/app/CreateRecording/CustomRecordingForm.tsx
@@ -546,7 +546,7 @@ export const CustomRecordingForm: React.FC<CustomRecordingFormProps> = ({ onExit
             labelHelp={
               <Tooltip
                 content={<Content component="p">{t('CustomRecordingForm.LABELS_TOOLTIP')}</Content>}
-                appendTo={portalRoot}
+                appendTo={portalRoot()}
               >
                 <Icon>
                   <HelpIcon />

--- a/src/app/Dashboard/AddCard.tsx
+++ b/src/app/Dashboard/AddCard.tsx
@@ -219,7 +219,7 @@ export const AddCard: React.FC<AddCardProps> = ({ variant }) => {
         className="card-catalog__wizard-modal"
         hasNoBodyWrapper
         showClose={false}
-        appendTo={portalRoot}
+        appendTo={portalRoot()}
       >
         <Wizard
           id={'card-catalog-wizard'}

--- a/src/app/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/ClickableAutomatedAnalysisLabel.tsx
@@ -118,7 +118,7 @@ export const ClickableAutomatedAnalysisLabel: React.FC<ClickableAutomatedAnalysi
           {transformAADescription(result)}
         </div>
       }
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       className={`${clickableAutomatedAnalysisKey}-popover`}
     >
       <Label

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisNameFilter.tsx
@@ -123,7 +123,7 @@ export const AutomatedAnalysisNameFilter: React.FC<AutomatedAnalysisNameFilterPr
       aria-label="Filter by name"
       popperProps={{
         enableFlip: true,
-        appendTo: () => document.getElementById('dashboard-grid') || portalRoot,
+        appendTo: () => document.getElementById('dashboard-grid') || portalRoot(),
       }}
       onOpenChange={setIsExpanded}
       onOpenChangeKeys={['Escape']}

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisScoreFilter.tsx
@@ -95,7 +95,7 @@ export const AutomatedAnalysisScoreFilter: React.FC<AutomatedAnalysisScoreFilter
 
   return (
     <>
-      <Tooltip content={t('AutomatedAnalysisScoreFilter.TOOLTIP.CONTENT')} appendTo={portalRoot}>
+      <Tooltip content={t('AutomatedAnalysisScoreFilter.TOOLTIP.CONTENT')} appendTo={portalRoot()}>
         <Content component={ContentVariants.small}>
           {t('AutomatedAnalysisScoreFilter.CURRENT_SCORE_TEXT', { val: currentScore })}
         </Content>

--- a/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.tsx
+++ b/src/app/Dashboard/AutomatedAnalysis/Filters/AutomatedAnalysisTopicFilter.tsx
@@ -112,7 +112,7 @@ export const AutomatedAnalysisTopicFilter: React.FC<AutomatedAnalysisTopicFilter
       isOpen={isExpanded}
       aria-label="Filter by topic"
       popperProps={{
-        appendTo: () => document.getElementById('dashboard-grid') || portalRoot,
+        appendTo: () => document.getElementById('dashboard-grid') || portalRoot(),
       }}
       onOpenChange={setIsExpanded}
       onOpenChangeKeys={['Escape']}

--- a/src/app/Dashboard/DashboardCardActionMenu.tsx
+++ b/src/app/Dashboard/DashboardCardActionMenu.tsx
@@ -53,7 +53,7 @@ export const DashboardCardActionMenu: React.FC<DashboardCardActionProps> = ({ on
     <Dropdown
       popperProps={{
         enableFlip: true,
-        appendTo: () => document.getElementById('dashboard-grid') || portalRoot,
+        appendTo: () => document.getElementById('dashboard-grid') || portalRoot(),
         position: 'right',
       }}
       isOpen={isOpen}

--- a/src/app/Dashboard/DashboardLayoutCreateModal.tsx
+++ b/src/app/Dashboard/DashboardLayoutCreateModal.tsx
@@ -210,7 +210,7 @@ export const DashboardLayoutCreateModal: React.FC<DashboardLayoutCreateModalProp
     <Modal
       aria-label={t('DashboardLayoutCreateModal.LABEL')}
       width={isCreateModal ? '80%' : '40%'}
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       isOpen={props.visible}
       showClose={false}
       header={header}

--- a/src/app/Dashboard/DashboardLayoutSetAsTemplateModal.tsx
+++ b/src/app/Dashboard/DashboardLayoutSetAsTemplateModal.tsx
@@ -147,7 +147,7 @@ export const DashboardLayoutSetAsTemplateModal: React.FC<DashboardLayoutSetAsTem
 
   return (
     <Modal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       isOpen={props.visible}
       variant={ModalVariant.medium}
       showClose={true}

--- a/src/app/Dashboard/LayoutTemplateUploadModal.tsx
+++ b/src/app/Dashboard/LayoutTemplateUploadModal.tsx
@@ -231,7 +231,7 @@ export const LayoutTemplateUploadModal: React.FC<LayoutTemplateUploadModalProps>
 
   return (
     <Modal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       isOpen={props.visible}
       variant={ModalVariant.large}
       showClose={true}
@@ -242,7 +242,7 @@ export const LayoutTemplateUploadModal: React.FC<LayoutTemplateUploadModalProps>
         <Popover
           headerContent={<div>{t('WHATS_THIS')}</div>}
           bodyContent={<div>{t(`LayoutTemplateUploadModal.HELP.CONTENT`)}</div>}
-          appendTo={portalRoot}
+          appendTo={portalRoot()}
         >
           <Button icon={<HelpIcon />} variant="plain" aria-label={t('HELP')} />
         </Popover>

--- a/src/app/Dashboard/SearchAutocomplete.tsx
+++ b/src/app/Dashboard/SearchAutocomplete.tsx
@@ -181,7 +181,7 @@ export const SearchAutocomplete: React.FC<SearchAutocompleteProps> = ({ onChange
       isVisible={isAutocompleteOpen}
       enableFlip={false}
       // append the autocomplete menu to the search input in the DOM for the sake of the keyboard navigation experience
-      appendTo={() => document.querySelector('#cryostat-autocomplete-search') || portalRoot}
+      appendTo={() => document.querySelector('#cryostat-autocomplete-search') || portalRoot()}
     />
   );
 };

--- a/src/app/Diagnostics/AllArchivedHeapDumpsTable.tsx
+++ b/src/app/Diagnostics/AllArchivedHeapDumpsTable.tsx
@@ -402,7 +402,7 @@ export const AllArchivedHeapDumpsTable: React.FC<AllArchivedHeapDumpsTableProps>
         title="Target Details"
         variant={ModalVariant.large}
         className="target-details-modal"
-        appendTo={portalRoot}
+        appendTo={portalRoot()}
       >
         {loadingLineage ? (
           <Bullseye>

--- a/src/app/Diagnostics/AllArchivedThreadDumpsTable.tsx
+++ b/src/app/Diagnostics/AllArchivedThreadDumpsTable.tsx
@@ -403,7 +403,7 @@ export const AllArchivedThreadDumpsTable: React.FC<AllArchivedThreadDumpsTablePr
         title="Target Details"
         variant={ModalVariant.large}
         className="target-details-modal"
-        appendTo={portalRoot}
+        appendTo={portalRoot()}
       >
         {loadingLineage ? (
           <Bullseye>

--- a/src/app/Events/EventTemplates.tsx
+++ b/src/app/Events/EventTemplates.tsx
@@ -510,7 +510,7 @@ export const EventTemplatesUploadModal: React.FC<EventTemplatesUploadModalProps>
 
   return (
     <Modal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       isOpen={props.isOpen}
       variant={ModalVariant.large}
       showClose={true}

--- a/src/app/Instrumentation/AgentProbeTemplates.tsx
+++ b/src/app/Instrumentation/AgentProbeTemplates.tsx
@@ -466,7 +466,7 @@ export const AgentProbeTemplateUploadModal: React.FC<AgentProbeTemplateUploadMod
 
   return (
     <Modal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       isOpen={isOpen}
       variant={ModalVariant.large}
       showClose={true}

--- a/src/app/Modal/CancelUploadModal.tsx
+++ b/src/app/Modal/CancelUploadModal.tsx
@@ -30,7 +30,7 @@ export interface CancelUploadModalProps {
 export const CancelUploadModal: React.FC<CancelUploadModalProps> = ({ visible, onYes, onNo, title, message }) => {
   return (
     <Modal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       width={'40%'}
       isOpen={visible}
       showClose={true}

--- a/src/app/Modal/DeleteWarningModal.tsx
+++ b/src/app/Modal/DeleteWarningModal.tsx
@@ -64,7 +64,7 @@ export const DeleteWarningModal: React.FC<DeleteWarningProps> = ({
 
   return (
     <Modal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       title={`${realWarningType?.title}`}
       description={realWarningType?.description}
       aria-label={realWarningType?.ariaLabel}

--- a/src/app/RecordingMetadata/RecordingLabelFields.tsx
+++ b/src/app/RecordingMetadata/RecordingLabelFields.tsx
@@ -144,7 +144,7 @@ export const RecordingLabelFields: React.FC<RecordingLabelFieldsProps> = ({
           <ActionList style={{ marginBottom: '1em' }}>
             <ActionListItem>
               <Popover
-                appendTo={portalRoot}
+                appendTo={portalRoot()}
                 isVisible={!!invalidUploads.length}
                 aria-label="uploading warning"
                 alertSeverityVariant="danger"

--- a/src/app/Recordings/Filters/DatetimeFilter.tsx
+++ b/src/app/Recordings/Filters/DatetimeFilter.tsx
@@ -225,7 +225,7 @@ export const DateTimeInput: React.FC<DateTimeInputProps> = ({ selectedDateTime, 
     <>
       <InputGroupItem isFill>
         <Popover
-          appendTo={portalRoot}
+          appendTo={portalRoot()}
           bodyContent={
             <DateTimePicker
               onSelect={handleDatetimeSelect}

--- a/src/app/Recordings/Recordings.tsx
+++ b/src/app/Recordings/Recordings.tsx
@@ -42,7 +42,7 @@ export const Recordings: React.FC = () => {
         </CardBody>
       </Card>
       <Modal
-        appendTo={portalRoot}
+        appendTo={portalRoot()}
         isOpen={createRecordingModalOpen}
         variant={ModalVariant.large}
         title="Create Recording"

--- a/src/app/Rules/CreateRule.tsx
+++ b/src/app/Rules/CreateRule.tsx
@@ -480,7 +480,7 @@ export const CreateRuleForm: React.FC<CreateRuleFormProps> = ({ onExit }) => {
         label={t('MATCH_EXPRESSION')}
         labelHelp={
           <Popover
-            appendTo={portalRoot}
+            appendTo={portalRoot()}
             headerContent={t('CreateRule.MATCH_EXPRESSION_HINT_MODAL_HEADER')}
             bodyContent={
               <>

--- a/src/app/Rules/RuleDeleteWarningModal.tsx
+++ b/src/app/Rules/RuleDeleteWarningModal.tsx
@@ -54,7 +54,7 @@ export const RuleDeleteWarningModal = ({
 
   return (
     <Modal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       title={warningContents?.title}
       description={warningContents?.description}
       aria-label={warningContents?.ariaLabel}

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -31,7 +31,6 @@ import {
   formatDuration,
   sortResources,
   portalRoot,
-  appRoot,
   LABEL_TEXT_MAXWIDTH,
   toPath,
 } from '@app/utils/utils';

--- a/src/app/Rules/Rules.tsx
+++ b/src/app/Rules/Rules.tsx
@@ -31,6 +31,7 @@ import {
   formatDuration,
   sortResources,
   portalRoot,
+  appRoot,
   LABEL_TEXT_MAXWIDTH,
   toPath,
 } from '@app/utils/utils';
@@ -580,7 +581,7 @@ export const RulesTable: React.FC<RulesTableProps> = () => {
         <></>
       </BreadcrumbPage>
       <Modal
-        appendTo={portalRoot}
+        appendTo={portalRoot()}
         isOpen={createRuleModalOpen}
         variant={ModalVariant.large}
         width="90vw"

--- a/src/app/Rules/RulesUploadModal.tsx
+++ b/src/app/Rules/RulesUploadModal.tsx
@@ -141,7 +141,7 @@ export const RuleUploadModal: React.FC<RuleUploadModalProps> = ({ onClose, ...pr
 
   return (
     <Modal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       isOpen={props.visible}
       variant={ModalVariant.large}
       showClose={true}
@@ -150,7 +150,7 @@ export const RuleUploadModal: React.FC<RuleUploadModalProps> = ({ onClose, ...pr
       description={t('RulesUploadModal.DESCRIPTION')}
       help={
         <Popover
-          appendTo={portalRoot}
+          appendTo={portalRoot()}
           headerContent={<div>{t('RulesUploadModal.HEADER_CONTENT')}</div>}
           bodyContent={<div>{t('CreateRule.ABOUT')}</div>}
         >

--- a/src/app/Security/Credentials/CreateCredentialModal.tsx
+++ b/src/app/Security/Credentials/CreateCredentialModal.tsx
@@ -84,6 +84,7 @@ export const CreateCredentialModal: React.FC<CreateCredentialModalProps> = ({
       variant={ModalVariant.large}
       showClose={!inProgress}
       className="add-credential-modal"
+      appendTo={portalRoot()}
       onClose={onDismiss}
       title={t('CreateCredentialModal.MODAL_TITLE')}
       description={t('CreateCredentialModal.MODAL_DESCRIPTION')}
@@ -227,7 +228,7 @@ export const AuthForm: React.FC<AuthFormProps> = ({ onDismiss, onPropsSave, prog
         label={t('MATCH_EXPRESSION')}
         labelHelp={
           <Popover
-            appendTo={portalRoot}
+            appendTo={portalRoot()}
             headerContent={t('CreateCredentialModal.MATCH_EXPRESSION_HINT_MODAL_HEADER')}
             bodyContent={
               <>

--- a/src/app/Security/Credentials/CredentialTestTable.tsx
+++ b/src/app/Security/Credentials/CredentialTestTable.tsx
@@ -279,7 +279,7 @@ export const CredentialTestRow: React.FC<CredentialTestRowProps> = ({
               </div>
             }
             bodyContent={<div>{status.error?.message || t('UNKNOWN_ERROR')}</div>}
-            appendTo={portalRoot}
+            appendTo={portalRoot()}
           >
             <Label style={{ cursor: 'pointer' }} color={getColor(status.state)}>
               {status.state}
@@ -362,7 +362,7 @@ const CredentialToolbar: React.FC<CredentialToolbarProps> = ({
         </ToolbarGroup>
         <ToolbarItem variant="separator" />
         <ToolbarItem>
-          <Tooltip content={t('CredentialTestTable.TEST_ALL_TOOLTIP')} appendTo={portalRoot}>
+          <Tooltip content={t('CredentialTestTable.TEST_ALL_TOOLTIP')} appendTo={portalRoot()}>
             <Button variant="primary" onClick={handleTestAll} isAriaDisabled={disableTest}>
               {t('CredentialTestTable.TEST_ALL')}
             </Button>

--- a/src/app/Shared/Components/MatchExpression/MatchExpressionVisualizer.tsx
+++ b/src/app/Shared/Components/MatchExpression/MatchExpressionVisualizer.tsx
@@ -27,6 +27,7 @@ import { useMatchExpressionSvc } from '@app/utils/hooks/useMatchExpressionSvc';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { getFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
 import { hashCode } from '@app/utils/utils';
+import { css } from '@patternfly/react-styles';
 import {
   Bullseye,
   DataList,
@@ -48,7 +49,6 @@ import {
   EmptyStateFooter,
 } from '@patternfly/react-core';
 import { ContainerNodeIcon, SearchIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import {
   action,
   GraphElement,

--- a/src/app/Shared/Components/MatchExpression/MatchExpressionVisualizer.tsx
+++ b/src/app/Shared/Components/MatchExpression/MatchExpressionVisualizer.tsx
@@ -27,7 +27,6 @@ import { useMatchExpressionSvc } from '@app/utils/hooks/useMatchExpressionSvc';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
 import { getFromLocalStorage, saveToLocalStorage } from '@app/utils/LocalStorage';
 import { hashCode } from '@app/utils/utils';
-import { css } from '@patternfly/react-styles';
 import {
   Bullseye,
   DataList,
@@ -49,6 +48,7 @@ import {
   EmptyStateFooter,
 } from '@patternfly/react-core';
 import { ContainerNodeIcon, SearchIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
 import {
   action,
   GraphElement,

--- a/src/app/Topology/Actions/CreateTarget.tsx
+++ b/src/app/Topology/Actions/CreateTarget.tsx
@@ -498,7 +498,7 @@ export const SampleNodeDonut: React.FC<SampleNodeDonutProps> = ({
         >
           <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
             <Tooltip
-              appendTo={portalRoot}
+              appendTo={portalRoot()}
               content={
                 _actionEnabled
                   ? `Click to test${validation.option !== ValidatedOptions.default ? ' again' : ''}.`
@@ -524,7 +524,7 @@ export const SampleNodeDonut: React.FC<SampleNodeDonutProps> = ({
           </FlexItem>
           <FlexItem alignSelf={{ default: 'alignSelfCenter' }}>
             <div className={css('sample-node-donut__node-label')}>
-              <Tooltip content={'Custom Target'} appendTo={portalRoot}>
+              <Tooltip content={'Custom Target'} appendTo={portalRoot()}>
                 <span className="sample-node-donut__node-label-badge">{'CT'}</span>
               </Tooltip>
               {_transformedTarget.alias || '<Name>'}

--- a/src/app/Topology/Actions/QuickSearchPanel.tsx
+++ b/src/app/Topology/Actions/QuickSearchPanel.tsx
@@ -222,7 +222,7 @@ export const QuickSearchModal: React.FC<QuickSearchModalProps> = ({ isOpen, onCl
 
   return (
     <Modal
-      appendTo={portalRoot}
+      appendTo={portalRoot()}
       isOpen={isOpen}
       onClose={onClose}
       variant={variant}

--- a/src/app/Topology/Entity/EntityDetails.tsx
+++ b/src/app/Topology/Entity/EntityDetails.tsx
@@ -589,7 +589,7 @@ export const TargetResourceItem: React.FC<{
               <LinearDotSpinner />
             </Bullseye>
           ) : error ? (
-            <Tooltip content={error.message} appendTo={portalRoot}>
+            <Tooltip content={error.message} appendTo={portalRoot()}>
               <WarningTriangleIcon color="var(--pf-global--warning-color--100)" />
             </Tooltip>
           ) : (
@@ -619,7 +619,7 @@ export const GroupResources: React.FC<{ envNode: EnvironmentNode }> = ({ envNode
           <CardBody>
             <Flex>
               <FlexItem flex={{ default: 'flex_1' }}>
-                <Tooltip content={isTarget ? child.target.connectUrl : child.name} appendTo={portalRoot}>
+                <Tooltip content={isTarget ? child.target.connectUrl : child.name} appendTo={portalRoot()}>
                   <div>
                     <Badge>{nodeTypeToAbbr(child.nodeType)}</Badge>
                     <span style={{ marginLeft: '0.5em' }}>{isTarget ? child.target.alias : child.name}</span>
@@ -628,7 +628,7 @@ export const GroupResources: React.FC<{ envNode: EnvironmentNode }> = ({ envNode
               </FlexItem>
               {status === NodeStatus.warning ? (
                 <FlexItem>
-                  <Tooltip content={extra?.title} appendTo={portalRoot}>
+                  <Tooltip content={extra?.title} appendTo={portalRoot()}>
                     <WarningTriangleIcon color="var(--pf-global--warning-color--100)" />
                   </Tooltip>
                 </FlexItem>

--- a/src/app/Topology/Entity/EntityTitle.tsx
+++ b/src/app/Topology/Entity/EntityTitle.tsx
@@ -26,7 +26,7 @@ export const EntityTitle: React.FC<{
   return (
     <div className={css('entity-overview__entity-title-wrapper')} {...props}>
       {badge ? (
-        <Tooltip content={badgeTooltipContent} appendTo={portalRoot}>
+        <Tooltip content={badgeTooltipContent} appendTo={portalRoot()}>
           <Badge style={{ marginRight: '0.5em' }}>{badge}</Badge>
         </Tooltip>
       ) : (

--- a/src/app/Topology/GraphView/CustomNode.tsx
+++ b/src/app/Topology/GraphView/CustomNode.tsx
@@ -21,8 +21,8 @@ import { TargetNode } from '@app/Shared/Services/api.types';
 import { includesTarget } from '@app/Shared/Services/api.utils';
 import { useMatchedTargetsSvc } from '@app/utils/hooks/useMatchedTargetsSvc';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
-import { ContainerNodeIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
+import { ContainerNodeIcon } from '@patternfly/react-icons';
 import {
   DefaultNode,
   DEFAULT_LAYER,
@@ -42,6 +42,7 @@ import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { map } from 'rxjs';
 import { getStatusTargetNode, nodeTypeToAbbr, TOPOLOGY_GRAPH_ID } from '../Shared/utils';
+import { MATCH_EXPRES_VIS_GRAPH_ID } from '@app/Shared/Components/MatchExpression/MatchExpressionVisualizer';
 import { NODE_ICON_PADDING, RESOURCE_NAME_TRUNCATE_LENGTH } from './const';
 import { getNodeDecorators } from './NodeDecorator';
 
@@ -101,14 +102,23 @@ const CustomNode: React.FC<CustomNodeProps> = ({
 
   const graphId = React.useMemo(() => element.getGraph().getId(), [element]);
 
-  const classNames = React.useMemo(() => css('topology__target-node', matched ? '' : 'search-inactive'), [matched]);
+  const classNames = React.useMemo(
+    () => css('topology__target-node', !matched && 'search-inactive'),
+    [matched],
+  );
 
   const nodeDecorators = React.useMemo(() => (showStatus ? getNodeDecorators(element) : null), [element, showStatus]);
 
   React.useEffect(() => {
     addSubscription(
       matchedTargetSvc
-        .pipe(map((ts) => (ts ? includesTarget(ts, data.target) : graphId === TOPOLOGY_GRAPH_ID)))
+        .pipe(
+          map((ts) =>
+            ts
+              ? includesTarget(ts, data.target)
+              : graphId === TOPOLOGY_GRAPH_ID || graphId === MATCH_EXPRES_VIS_GRAPH_ID,
+          ),
+        )
         .subscribe(setMatched),
     );
   }, [graphId, addSubscription, setMatched, matchedTargetSvc, data.target]);

--- a/src/app/Topology/GraphView/CustomNode.tsx
+++ b/src/app/Topology/GraphView/CustomNode.tsx
@@ -16,13 +16,14 @@
 
 import cryostatSvg from '@app/assets/cryostat_icon_rgb_default.svg';
 import openjdkSvg from '@app/assets/openjdk.svg';
+import { MATCH_EXPRES_VIS_GRAPH_ID } from '@app/Shared/Components/MatchExpression/MatchExpressionVisualizer';
 import { RootState } from '@app/Shared/Redux/ReduxStore';
 import { TargetNode } from '@app/Shared/Services/api.types';
 import { includesTarget } from '@app/Shared/Services/api.utils';
 import { useMatchedTargetsSvc } from '@app/utils/hooks/useMatchedTargetsSvc';
 import { useSubscriptions } from '@app/utils/hooks/useSubscriptions';
-import { css } from '@patternfly/react-styles';
 import { ContainerNodeIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
 import {
   DefaultNode,
   DEFAULT_LAYER,
@@ -42,7 +43,6 @@ import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { map } from 'rxjs';
 import { getStatusTargetNode, nodeTypeToAbbr, TOPOLOGY_GRAPH_ID } from '../Shared/utils';
-import { MATCH_EXPRES_VIS_GRAPH_ID } from '@app/Shared/Components/MatchExpression/MatchExpressionVisualizer';
 import { NODE_ICON_PADDING, RESOURCE_NAME_TRUNCATE_LENGTH } from './const';
 import { getNodeDecorators } from './NodeDecorator';
 
@@ -102,10 +102,7 @@ const CustomNode: React.FC<CustomNodeProps> = ({
 
   const graphId = React.useMemo(() => element.getGraph().getId(), [element]);
 
-  const classNames = React.useMemo(
-    () => css('topology__target-node', !matched && 'search-inactive'),
-    [matched],
-  );
+  const classNames = React.useMemo(() => css('topology__target-node', !matched && 'search-inactive'), [matched]);
 
   const nodeDecorators = React.useMemo(() => (showStatus ? getNodeDecorators(element) : null), [element, showStatus]);
 

--- a/src/app/Topology/GraphView/NodeDecorator.tsx
+++ b/src/app/Topology/GraphView/NodeDecorator.tsx
@@ -114,7 +114,7 @@ export const ReportDecorator: React.FC<DecoratorProps> = ({ element, quadrant, .
   }, [t, dayjs, dateTimeFormat, error, loading, report, palette]);
 
   return iconConfig ? (
-    <Tooltip content={iconConfig.tooltip} triggerRef={decoratorRef} appendTo={portalRoot}>
+    <Tooltip content={iconConfig.tooltip} triggerRef={decoratorRef} appendTo={portalRoot()}>
       <Decorator
         innerRef={decoratorRef}
         {...props}
@@ -162,7 +162,7 @@ export const ActiveRecordingDecorator: React.FC<DecoratorProps> = ({ element, qu
   }, [error, loading, runningRecs, palette]);
 
   return iconConfig ? (
-    <Tooltip content={iconConfig.tooltip} triggerRef={decoratorRef} appendTo={portalRoot}>
+    <Tooltip content={iconConfig.tooltip} triggerRef={decoratorRef} appendTo={portalRoot()}>
       <Decorator
         innerRef={decoratorRef}
         {...props}
@@ -182,7 +182,7 @@ export const ConnectionStatusDecorator: React.FC<DecoratorProps> = ({ element, q
   const [nodeStatus, extra] = getStatusTargetNode(data);
   const { x, y } = getDefaultShapeDecoratorCenter(quadrant, element);
   return nodeStatus ? (
-    <Tooltip content={extra?.title} triggerRef={decoratorRef} appendTo={portalRoot}>
+    <Tooltip content={extra?.title} triggerRef={decoratorRef} appendTo={portalRoot()}>
       <Decorator
         {...props}
         innerRef={decoratorRef}

--- a/src/app/Topology/Toolbar/TopologyToolbar.tsx
+++ b/src/app/Topology/Toolbar/TopologyToolbar.tsx
@@ -72,7 +72,7 @@ export const TopologyToolbar: React.FC<TopologyToolbarProps> = ({ variant, visua
         content={isGraphView ? t('Topology.LIST_VIEW') : t('Topology.GRAPH_VIEW')}
         aria="none"
         aria-live="polite"
-        appendTo={portalRoot}
+        appendTo={portalRoot()}
       >
         <Button
           icon={<Icon size="lg">{isGraphView ? <ListIcon /> : <TopologyIcon />}</Icon>}

--- a/src/app/Topology/Topology.tsx
+++ b/src/app/Topology/Topology.tsx
@@ -164,7 +164,7 @@ export const Topology: React.FC<TopologyProps> = ({ ..._props }) => {
         <></>
       </BreadcrumbPage>
       <Modal
-        appendTo={portalRoot}
+        appendTo={portalRoot()}
         isOpen={createTargetModalOpen}
         variant={ModalVariant.large}
         title="Create Custom Target"

--- a/src/app/Topology/styles/base.css
+++ b/src/app/Topology/styles/base.css
@@ -89,17 +89,22 @@ Below CSS rules only apply to Topology components
   font-weight: 700;
   word-break: break-all;
   background-color: var(--pf-t--global--background--color--primary--default);
+  color: var(--pf-t--global--text--color--regular);
 }
 
 
 .cryostat-app .sample-node-donut__node-label-badge {
   position: relative;
   background-color: var(--pf-t--global--background--color--brand--default);
-  color: var(--pf-t--global--text--color--on-brand--default);
+  color: #000000;
   padding: 2px 12px 2px 12px;
   margin-right: 8px;
   text-align: center;
   border-radius: 500px;
+}
+
+:where(.pf-v6-theme-dark) .cryostat-app .sample-node-donut__node-label-badge {
+  color: #ffffff;
 }
 
 .cryostat-app .empty-text {

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -48,5 +48,6 @@ export const App: React.FC = () => (
         </NotificationsContext.Provider>
       </ServiceContext.Provider>
     </CapabilitiesContext.Provider>
+    <div id="portal-root"></div>
   </div>
 );

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -161,7 +161,7 @@ export const getDisplayFieldName = (fieldName: string): string => {
     .join(' ');
 };
 
-export const portalRoot = document.getElementById('portal-root') || document.body;
+export const portalRoot = () => document.getElementById('portal-root') || document.body;
 
 export const cleanDataId = (key: string): string => {
   return key.toLocaleLowerCase().replace(/\s+/g, '');

--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,6 @@ limitations under the License.
 <body>
   <noscript>Enabling JavaScript is required to run this app.</noscript>
   <div id="root"></div>
-  <div id="portal-root"></div>
 </body>
 
 </html>


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Replaces #2219
Fixes #2214
Fixes #2218

## Description of the change:
Moves the `portalRoot` container inside of the `cryostat-app` container. These were previously siblings since the introduction of the `cryostat-app` container. `cryostat-app` was introduced to allow css scoping so that we can ensure that cryostat-web's styles don't leak out and affect the rest of the OpenShift Console when deployed as part of the cryostat-openshift-console-plugin, but a side effect of this is that our various modal components were now outside of the hierarchy and our css rules did not apply to them. Moving the `portalRoot` to be a child of the `cryostat-app` allows the modals to be mounted at a very high position in the DOM still, while still being within the scope of our css.

This fixes the Duke icon styling in the Custom Target creation form as well as the behaviour of the Match Expression Visualizers as a consequence of the css selectors re-applying.

This PR also contains a fixup for PF6 light/dark theming so that the `CT` label under the Duke icon correctly inverts with the light/dark theme of the application.
