### PR TITLE
fix(diagnostics): prefill selected thread dump for analysis

### DIFF
--- a/src/app/Diagnostics/Analysis/ThreadDumpAnalysis.tsx
+++ b/src/app/Diagnostics/Analysis/ThreadDumpAnalysis.tsx
@@ -62,6 +62,9 @@ import { ThreadDumpSelector } from './ThreadDumpSelector';
 
 export interface ThreadDumpAnalysisProps {}
 
+const isSameTarget = (a: NullableTarget, b: NullableTarget): boolean =>
+  a?.connectUrl === b?.connectUrl && a?.jvmId === b?.jvmId;
+
 interface ThreadRowData {
   threadInfo: ThreadInfo;
   isExpanded: boolean;
@@ -247,9 +250,13 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
   React.useEffect(() => {
     addSubscription(
       context.target.target().subscribe((t) => {
-        setTarget(t);
-        setAnalysisResult(undefined);
-        setSelectedThreadDump('');
+        setTarget((currentTarget) => {
+          if (currentTarget && !isSameTarget(currentTarget, t)) {
+            setAnalysisResult(undefined);
+            setSelectedThreadDump('');
+          }
+          return t;
+        });
       }),
     );
   }, [addSubscription, context.target, setTarget]);
@@ -577,7 +584,17 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
   );
 
   const queryThreadDumpAnalysis = React.useCallback(
-    (threadDump: string) => {
+    (threadDump: string, jvmId?: string) => {
+      const selectedJvmId = jvmId || threadDumps.find((t) => t.threadDumpId === threadDump)?.jvmId;
+      if (selectedJvmId) {
+        addSubscription(
+          context.api.analyzeThreadDump(selectedJvmId, threadDump).subscribe({
+            next: handleThreadDumpAnalysis,
+          }),
+        );
+        return;
+      }
+
       addSubscription(
         targetAsObs
           .pipe(
@@ -595,7 +612,7 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
           }),
       );
     },
-    [addSubscription, context.api, handleThreadDumpAnalysis, targetAsObs],
+    [addSubscription, context.api, handleThreadDumpAnalysis, targetAsObs, threadDumps],
   );
 
   React.useEffect(() => {
@@ -642,30 +659,40 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
   }, [addSubscription, context.notificationChannel]);
 
   const handleThreadDumpChange = React.useCallback(
-    (threadDump: string) => {
-      setSelectedThreadDump(threadDump);
-      queryThreadDumpAnalysis(threadDump);
+    (threadDump?: string) => {
+      setSelectedThreadDump(threadDump || '');
+      setAnalysisResult(undefined);
+      if (threadDump) {
+        queryThreadDumpAnalysis(threadDump);
+      }
     },
-    [setSelectedThreadDump, queryThreadDumpAnalysis],
+    [setSelectedThreadDump, setAnalysisResult, queryThreadDumpAnalysis],
   );
 
   React.useEffect(() => {
     const stateData = location.state as Record<string, unknown> | null;
     const reduxData = modalPrefill.route === location.pathname ? (modalPrefill.data as Record<string, unknown>) : null;
+    const params = new URLSearchParams(location.search);
 
-    const prefillJvmId = (stateData?.jvmId || reduxData?.jvmId) as string | undefined;
-    const prefillThreadDump = (stateData?.id || reduxData?.id) as string | undefined;
+    const prefillJvmId = (stateData?.jvmId || reduxData?.jvmId || params.get('jvmId')) as string | undefined;
+    const prefillThreadDump = (stateData?.id ||
+      stateData?.threadDumpId ||
+      reduxData?.id ||
+      reduxData?.threadDumpId ||
+      params.get('threadDumpId') ||
+      params.get('id')) as string | undefined;
 
-    var jvmId = prefillJvmId ? prefillJvmId : '';
-    var threadDumpId = prefillThreadDump ? prefillThreadDump : '';
-
-    setSelectedThreadDump(threadDumpId);
-    if (jvmId != '' && threadDumpId != '') {
-      context.api.analyzeThreadDump(jvmId, threadDumpId).subscribe({ next: handleThreadDumpAnalysis });
+    if (!prefillJvmId || !prefillThreadDump) {
+      return;
     }
+
+    setSelectedThreadDump(prefillThreadDump);
+    queryThreadDumpAnalysis(prefillThreadDump, prefillJvmId);
     dispatch(modalPrefillClearIntent());
+    if (location.state || location.search) {
+      navigate(`${location.pathname}${location.hash}`, { replace: true, state: null });
+    }
   }, [
-    context.api,
     location.state,
     location.search,
     location.hash,
@@ -673,7 +700,7 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
     modalPrefill,
     dispatch,
     navigate,
-    handleThreadDumpAnalysis,
+    queryThreadDumpAnalysis,
     setSelectedThreadDump,
   ]);
 

--- a/src/app/Diagnostics/Analysis/ThreadDumpSelector.tsx
+++ b/src/app/Diagnostics/Analysis/ThreadDumpSelector.tsx
@@ -25,22 +25,19 @@ export interface ThreadDumpSelectorProps {
 }
 
 export const ThreadDumpSelector: React.FC<ThreadDumpSelectorProps> = ({ selected, threadDumps, onSelect }) => {
-  const [selectedThreadDump, setSelectedThreadDump] = React.useState<string>(selected);
   const [isOpen, setIsOpen] = React.useState(false);
 
   const handleThreadDumpSelect = React.useCallback(
     (_, selected: string) => {
       if (!selected.length) {
         onSelect(undefined);
-        setSelectedThreadDump('');
         setIsOpen(false);
       } else {
         onSelect(selected);
-        setSelectedThreadDump(selected);
         setIsOpen(false);
       }
     },
-    [onSelect, setSelectedThreadDump],
+    [onSelect],
   );
 
   const onToggle = React.useCallback(() => setIsOpen((isOpen) => !isOpen), [setIsOpen]);
@@ -54,10 +51,10 @@ export const ThreadDumpSelector: React.FC<ThreadDumpSelectorProps> = ({ selected
         onClick={onToggle}
         isExpanded={isOpen}
       >
-        {selectedThreadDump == '' ? 'Select a Thread Dump' : selectedThreadDump}
+        {selected == '' ? 'Select a Thread Dump' : selected}
       </MenuToggle>
     ),
-    [onToggle, isOpen, selectedThreadDump],
+    [onToggle, isOpen, selected],
   );
 
   return (

--- a/src/app/Diagnostics/ThreadDumpsTable.tsx
+++ b/src/app/Diagnostics/ThreadDumpsTable.tsx
@@ -523,13 +523,16 @@ export const ThreadDumpAction: React.FC<ThreadDumpActionProps> = ({ threadDump, 
 
   const handleViewInAnalysis = React.useCallback(
     (jvmId) => {
-      var id = threadDump.threadDumpId;
+      const id = threadDump.threadDumpId;
+      const analysisPath = toPath('/analyze-thread-dumps');
+      const params = new URLSearchParams({ jvmId, threadDumpId: id });
       const state = {
         jvmId,
         id,
+        threadDumpId: id,
       };
-      store.dispatch(modalPrefillSetIntent(toPath('/analyze-thread-dumps'), state as Record<string, unknown>));
-      navigate(toPath('/analyze-thread-dumps'), { state });
+      store.dispatch(modalPrefillSetIntent(analysisPath, state as Record<string, unknown>));
+      navigate(`${analysisPath}?${params.toString()}`, { state });
     },
     [threadDump, navigate],
   );

--- a/src/test/Diagnostics/AnalyzeThreadDumps.test.tsx
+++ b/src/test/Diagnostics/AnalyzeThreadDumps.test.tsx
@@ -19,7 +19,7 @@ import { ThemeSetting } from '@app/Settings/types';
 import { RootState } from '@app/Shared/Redux/ReduxStore';
 import { Target, ThreadDump, ThreadDumpAnalysisResult } from '@app/Shared/Services/api.types';
 import { defaultServices } from '@app/Shared/Services/Services';
-import { cleanup, screen, within, act } from '@testing-library/react';
+import { cleanup, screen, within, act, waitFor } from '@testing-library/react';
 import { of } from 'rxjs';
 import { basePreloadedState, DEFAULT_DIMENSIONS, mockMediaQueryList, render, resize } from '../utils';
 
@@ -223,6 +223,67 @@ describe('<ThreadDumpAnalysis />', () => {
     });
 
     expect(screen.getByRole('heading', { name: 'Select a Thread Dump to Analyze' })).toBeInTheDocument();
+  });
+
+  it('prefills the selected thread dump from location state', async () => {
+    const analyzeSpy = jest.spyOn(defaultServices.api, 'analyzeThreadDump').mockReturnValue(of(mockThreadDumpAnalysis));
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/analyze-thread-dumps',
+            element: <ThreadDumpAnalysis />,
+          },
+        ],
+        options: {
+          initialEntries: [
+            {
+              pathname: '/analyze-thread-dumps',
+              state: { jvmId: mockTarget.jvmId, id: mockThreadDump.threadDumpId },
+            },
+          ],
+        },
+      },
+      preloadedState: preloadedState,
+    });
+
+    await waitFor(() => {
+      expect(analyzeSpy).toHaveBeenCalledWith(mockTarget.jvmId, mockThreadDump.threadDumpId);
+      expect(screen.getByRole('button', { name: 'thread dump selector toggle' })).toHaveTextContent(
+        mockThreadDump.threadDumpId,
+      );
+    });
+    expect(screen.getByText('JVM Information')).toBeInTheDocument();
+  });
+
+  it('prefills the selected thread dump from query params', async () => {
+    const analyzeSpy = jest.spyOn(defaultServices.api, 'analyzeThreadDump').mockReturnValue(of(mockThreadDumpAnalysis));
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/analyze-thread-dumps',
+            element: <ThreadDumpAnalysis />,
+          },
+        ],
+        options: {
+          initialEntries: [
+            `/analyze-thread-dumps?jvmId=${mockTarget.jvmId}&threadDumpId=${mockThreadDump.threadDumpId}`,
+          ],
+        },
+      },
+      preloadedState: preloadedState,
+    });
+
+    await waitFor(() => {
+      expect(analyzeSpy).toHaveBeenCalledWith(mockTarget.jvmId, mockThreadDump.threadDumpId);
+      expect(screen.getByRole('button', { name: 'thread dump selector toggle' })).toHaveTextContent(
+        mockThreadDump.threadDumpId,
+      );
+    });
+    expect(screen.getByText('JVM Information')).toBeInTheDocument();
   });
 
   it('should render the page correctly', async () => {

--- a/src/test/Diagnostics/ThreadDumpsTable.test.tsx
+++ b/src/test/Diagnostics/ThreadDumpsTable.test.tsx
@@ -326,4 +326,41 @@ describe('<ThreadDumpsTable />', () => {
     expect(downloadRequestSpy).toHaveBeenCalledTimes(1);
     expect(downloadRequestSpy).toHaveBeenCalledWith(mockThreadDump);
   });
+
+  it('navigates to analysis with the selected thread dump prefill data', async () => {
+    const { user, router } = render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/thread-dumps',
+            element: <ThreadDumpsTable target={of(mockTarget)} isNestedTable={false} />,
+          },
+          {
+            path: '/analyze-thread-dumps',
+            element: <>Analysis</>,
+          },
+        ],
+        options: {
+          initialEntries: ['/thread-dumps'],
+        },
+      },
+      preloadedState: preloadedState,
+    });
+
+    await tlr.act(async () => {
+      await user.click(screen.getByLabelText(testT('ThreadDumpActions.ARIA_LABELS.MENU_TOGGLE')));
+      await user.click(screen.getByText('Analyze Thread Dump'));
+    });
+
+    const state = {
+      jvmId: mockTarget.jvmId,
+      id: mockThreadDump.threadDumpId,
+      threadDumpId: mockThreadDump.threadDumpId,
+    };
+    expect(router.state.location.pathname).toEqual('/analyze-thread-dumps');
+    expect(router.state.location.search).toEqual(
+      `?jvmId=${mockTarget.jvmId}&threadDumpId=${mockThreadDump.threadDumpId}`,
+    );
+    expect(router.state.location.state).toEqual(state);
+  });
 });


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: cryostatio/cryostat-openshift-console-plugin#915

## Description of the change:
This change preserves and consumes the selected archived thread dump when navigating to the thread dump analysis page.

Changes:
- Add `jvmId` and `threadDumpId` query parameters when clicking **Analyze Thread Dump** from the thread dump table row action
- Keep the existing React Router `location.state` prefill path, and add query parameter fallback support for environments
where router state is not preserved
- Make `ThreadDumpSelector` reflect the selected dump from props instead of only using its initial local state
- Avoid clearing the selected dump/analysis result when the target service emits the same target during initial page load
- Add focused tests for location-state prefill, query-param prefill, and row-action navigation

## Motivation for the change:
In the OpenShift Console plugin, clicking **Analyze Thread Dump** from Thread Dump Archives navigates to the analysis page, but the selected dump is not pre-filled. Users then have to manually select the same dump again before analysis runs.

Passing the dump identifiers through the URL and making the analysis page consume them makes the flow work reliably in both standalone Cryostat Web and embedded OpenShift Console routing.

## How to manually test:
1. Start Cryostat with at least one discoverable target.
2. Create a thread dump for the target.
3. Navigate to **Thread Dumps**.
4. Open the row action menu for the archived thread dump and click **Analyze Thread Dump**.
5. Verify the app navigates to **Analyze Thread Dumps**.
6. Verify the thread dump selector is already populated with the selected dump ID.
7. Verify the analysis result loads automatically without manually selecting the dump.
8. In the OpenShift Console plugin, repeat the same flow from **Thread Dump Archives** and verify there is no 404 and no manual selection is required.