### PR TITLE
fix(diagnostics): prefill selected thread dump for analysis

### DIFF
--- a/src/app/Diagnostics/Analysis/ThreadDumpAnalysis.tsx
+++ b/src/app/Diagnostics/Analysis/ThreadDumpAnalysis.tsx
@@ -62,6 +62,9 @@ import { ThreadDumpSelector } from './ThreadDumpSelector';
 
 export interface ThreadDumpAnalysisProps {}
 
+const isSameTarget = (a: NullableTarget, b: NullableTarget): boolean =>
+  a?.connectUrl === b?.connectUrl && a?.jvmId === b?.jvmId;
+
 interface ThreadRowData {
   threadInfo: ThreadInfo;
   isExpanded: boolean;
@@ -247,9 +250,13 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
   React.useEffect(() => {
     addSubscription(
       context.target.target().subscribe((t) => {
-        setTarget(t);
-        setAnalysisResult(undefined);
-        setSelectedThreadDump('');
+        setTarget((currentTarget) => {
+          if (currentTarget && !isSameTarget(currentTarget, t)) {
+            setAnalysisResult(undefined);
+            setSelectedThreadDump('');
+          }
+          return t;
+        });
       }),
     );
   }, [addSubscription, context.target, setTarget]);
@@ -577,7 +584,17 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
   );
 
   const queryThreadDumpAnalysis = React.useCallback(
-    (threadDump: string) => {
+    (threadDump: string, jvmId?: string) => {
+      const selectedJvmId = jvmId || threadDumps.find((t) => t.threadDumpId === threadDump)?.jvmId;
+      if (selectedJvmId) {
+        addSubscription(
+          context.api.analyzeThreadDump(selectedJvmId, threadDump).subscribe({
+            next: handleThreadDumpAnalysis,
+          }),
+        );
+        return;
+      }
+
       addSubscription(
         targetAsObs
           .pipe(
@@ -595,7 +612,7 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
           }),
       );
     },
-    [addSubscription, context.api, handleThreadDumpAnalysis, targetAsObs],
+    [addSubscription, context.api, handleThreadDumpAnalysis, targetAsObs, threadDumps],
   );
 
   React.useEffect(() => {
@@ -642,30 +659,40 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
   }, [addSubscription, context.notificationChannel]);
 
   const handleThreadDumpChange = React.useCallback(
-    (threadDump: string) => {
-      setSelectedThreadDump(threadDump);
-      queryThreadDumpAnalysis(threadDump);
+    (threadDump?: string) => {
+      setSelectedThreadDump(threadDump || '');
+      setAnalysisResult(undefined);
+      if (threadDump) {
+        queryThreadDumpAnalysis(threadDump);
+      }
     },
-    [setSelectedThreadDump, queryThreadDumpAnalysis],
+    [setSelectedThreadDump, setAnalysisResult, queryThreadDumpAnalysis],
   );
 
   React.useEffect(() => {
     const stateData = location.state as Record<string, unknown> | null;
     const reduxData = modalPrefill.route === location.pathname ? (modalPrefill.data as Record<string, unknown>) : null;
+    const params = new URLSearchParams(location.search);
 
-    const prefillJvmId = (stateData?.jvmId || reduxData?.jvmId) as string | undefined;
-    const prefillThreadDump = (stateData?.id || reduxData?.id) as string | undefined;
+    const prefillJvmId = (stateData?.jvmId || reduxData?.jvmId || params.get('jvmId')) as string | undefined;
+    const prefillThreadDump = (stateData?.id ||
+      stateData?.threadDumpId ||
+      reduxData?.id ||
+      reduxData?.threadDumpId ||
+      params.get('threadDumpId') ||
+      params.get('id')) as string | undefined;
 
-    var jvmId = prefillJvmId ? prefillJvmId : '';
-    var threadDumpId = prefillThreadDump ? prefillThreadDump : '';
-
-    setSelectedThreadDump(threadDumpId);
-    if (jvmId != '' && threadDumpId != '') {
-      context.api.analyzeThreadDump(jvmId, threadDumpId).subscribe({ next: handleThreadDumpAnalysis });
+    if (!prefillJvmId || !prefillThreadDump) {
+      return;
     }
+
+    setSelectedThreadDump(prefillThreadDump);
+    queryThreadDumpAnalysis(prefillThreadDump, prefillJvmId);
     dispatch(modalPrefillClearIntent());
+    if (location.state || location.search) {
+      navigate(`${location.pathname}${location.hash}`, { replace: true, state: null });
+    }
   }, [
-    context.api,
     location.state,
     location.search,
     location.hash,
@@ -673,7 +700,7 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
     modalPrefill,
     dispatch,
     navigate,
-    handleThreadDumpAnalysis,
+    queryThreadDumpAnalysis,
     setSelectedThreadDump,
   ]);
 

--- a/src/app/Diagnostics/Analysis/ThreadDumpAnalysis.tsx
+++ b/src/app/Diagnostics/Analysis/ThreadDumpAnalysis.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { LoadingView } from '@app/Shared/Components/LoadingView';
 import { modalPrefillClearIntent, RootState } from '@app/Shared/Redux/ReduxStore';
 import {
   AnalysisFinding,
@@ -56,7 +57,7 @@ import {
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
-import { concatMap, first, of } from 'rxjs';
+import { EMPTY, concatMap, finalize, first, map, of } from 'rxjs';
 import { AggregateDataCard } from './AggregateDataCard.tsx';
 import { ThreadDumpSelector } from './ThreadDumpSelector';
 
@@ -64,6 +65,46 @@ export interface ThreadDumpAnalysisProps {}
 
 const isSameTarget = (a: NullableTarget, b: NullableTarget): boolean =>
   a?.connectUrl === b?.connectUrl && a?.jvmId === b?.jvmId;
+
+interface ThreadDumpPrefillLocation {
+  state: unknown;
+  search: string;
+  pathname: string;
+}
+
+interface ThreadDumpPrefillStore {
+  route: string | null;
+  data: unknown;
+}
+
+interface ThreadDumpPrefill {
+  jvmId?: string;
+  threadDumpId?: string;
+}
+
+const firstString = (...values: unknown[]): string | undefined =>
+  values.find((value): value is string => typeof value === 'string' && value.length > 0);
+
+const readThreadDumpPrefill = (
+  location: ThreadDumpPrefillLocation,
+  modalPrefill: ThreadDumpPrefillStore,
+): ThreadDumpPrefill => {
+  const stateData = location.state as Record<string, unknown> | null;
+  const reduxData = modalPrefill.route === location.pathname ? (modalPrefill.data as Record<string, unknown>) : null;
+  const params = new URLSearchParams(location.search);
+
+  return {
+    jvmId: firstString(stateData?.jvmId, reduxData?.jvmId, params.get('jvmId')),
+    threadDumpId: firstString(
+      stateData?.id,
+      stateData?.threadDumpId,
+      reduxData?.id,
+      reduxData?.threadDumpId,
+      params.get('threadDumpId'),
+      params.get('id'),
+    ),
+  };
+};
 
 interface ThreadRowData {
   threadInfo: ThreadInfo;
@@ -239,12 +280,27 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
 
   const [threadDumps, setThreadDumps] = React.useState<ThreadDump[]>([]);
   const [analysisResult, setAnalysisResult] = React.useState<ThreadDumpAnalysisResult>();
+  const [isAnalysisLoading, setIsAnalysisLoading] = React.useState(false);
   const [selectedThreadDump, setSelectedThreadDump] = React.useState('');
   const [target, setTarget] = React.useState(undefined as NullableTarget);
   const [openRows, setOpenRows] = React.useState<number[]>([]);
   const [openDeadlockRows, setOpenDeadlockRows] = React.useState<number[]>([]);
   const [sortBy, getSortParams] = useSort();
+  const selectedThreadDumpJvmIdRef = React.useRef<string>();
 
+  const prefill = React.useMemo(
+    () =>
+      readThreadDumpPrefill(
+        {
+          pathname: location.pathname,
+          search: location.search,
+          state: location.state,
+        },
+        modalPrefill,
+      ),
+    [location.pathname, location.search, location.state, modalPrefill],
+  );
+  const hasPendingPrefill = !!prefill.jvmId && !!prefill.threadDumpId;
   const targetAsObs = React.useMemo(() => of(target), [target]);
 
   React.useEffect(() => {
@@ -252,8 +308,12 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
       context.target.target().subscribe((t) => {
         setTarget((currentTarget) => {
           if (currentTarget && !isSameTarget(currentTarget, t)) {
-            setAnalysisResult(undefined);
-            setSelectedThreadDump('');
+            const selectedThreadDumpJvmId = selectedThreadDumpJvmIdRef.current;
+            if (!selectedThreadDumpJvmId || selectedThreadDumpJvmId !== t?.jvmId) {
+              selectedThreadDumpJvmIdRef.current = undefined;
+              setAnalysisResult(undefined);
+              setSelectedThreadDump('');
+            }
           }
           return t;
         });
@@ -586,11 +646,16 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
   const queryThreadDumpAnalysis = React.useCallback(
     (threadDump: string, jvmId?: string) => {
       const selectedJvmId = jvmId || threadDumps.find((t) => t.threadDumpId === threadDump)?.jvmId;
+      selectedThreadDumpJvmIdRef.current = selectedJvmId;
+      setIsAnalysisLoading(true);
       if (selectedJvmId) {
         addSubscription(
-          context.api.analyzeThreadDump(selectedJvmId, threadDump).subscribe({
-            next: handleThreadDumpAnalysis,
-          }),
+          context.api
+            .analyzeThreadDump(selectedJvmId, threadDump)
+            .pipe(finalize(() => setIsAnalysisLoading(false)))
+            .subscribe({
+              next: handleThreadDumpAnalysis,
+            }),
         );
         return;
       }
@@ -601,11 +666,12 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
             first(),
             concatMap((target: Target | undefined) => {
               if (target) {
+                selectedThreadDumpJvmIdRef.current = target.jvmId;
                 return context.api.analyzeThreadDump(target.jvmId ? target.jvmId : '', threadDump);
-              } else {
-                return of([]);
               }
+              return EMPTY;
             }),
+            finalize(() => setIsAnalysisLoading(false)),
           )
           .subscribe({
             next: handleThreadDumpAnalysis,
@@ -613,6 +679,24 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
       );
     },
     [addSubscription, context.api, handleThreadDumpAnalysis, targetAsObs, threadDumps],
+  );
+
+  const findTargetByJvmId = React.useCallback(
+    (jvmId: string) =>
+      context.targets.targets().pipe(
+        first(),
+        concatMap((targets) => {
+          const matchedTarget = targets.find((target) => target.jvmId === jvmId);
+          if (matchedTarget) {
+            return of(matchedTarget);
+          }
+          return context.targets.queryForTargets().pipe(
+            concatMap(() => context.targets.targets().pipe(first())),
+            map((targets) => targets.find((target) => target.jvmId === jvmId)),
+          );
+        }),
+      ),
+    [context.targets],
   );
 
   React.useEffect(() => {
@@ -644,14 +728,6 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
 
   React.useEffect(() => {
     addSubscription(
-      context.api.getThreadDumps().subscribe((dumps) => {
-        setThreadDumps(dumps);
-      }),
-    );
-  }, [addSubscription, context.api, setThreadDumps]);
-
-  React.useEffect(() => {
-    addSubscription(
       context.notificationChannel.messages(NotificationCategory.ThreadDumpSuccess).subscribe((msg) => {
         setThreadDumps((old) => old.filter((t) => t.threadDumpId !== msg.message.threadDump.threadDumpId));
       }),
@@ -662,45 +738,50 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
     (threadDump?: string) => {
       setSelectedThreadDump(threadDump || '');
       setAnalysisResult(undefined);
+      selectedThreadDumpJvmIdRef.current = threadDump
+        ? threadDumps.find((t) => t.threadDumpId === threadDump)?.jvmId || target?.jvmId
+        : undefined;
       if (threadDump) {
-        queryThreadDumpAnalysis(threadDump);
+        queryThreadDumpAnalysis(threadDump, selectedThreadDumpJvmIdRef.current);
       }
     },
-    [setSelectedThreadDump, setAnalysisResult, queryThreadDumpAnalysis],
+    [setSelectedThreadDump, setAnalysisResult, threadDumps, target, queryThreadDumpAnalysis],
   );
 
   React.useEffect(() => {
-    const stateData = location.state as Record<string, unknown> | null;
-    const reduxData = modalPrefill.route === location.pathname ? (modalPrefill.data as Record<string, unknown>) : null;
-    const params = new URLSearchParams(location.search);
-
-    const prefillJvmId = (stateData?.jvmId || reduxData?.jvmId || params.get('jvmId')) as string | undefined;
-    const prefillThreadDump = (stateData?.id ||
-      stateData?.threadDumpId ||
-      reduxData?.id ||
-      reduxData?.threadDumpId ||
-      params.get('threadDumpId') ||
-      params.get('id')) as string | undefined;
-
-    if (!prefillJvmId || !prefillThreadDump) {
+    if (!prefill.jvmId || !prefill.threadDumpId) {
       return;
     }
 
-    setSelectedThreadDump(prefillThreadDump);
-    queryThreadDumpAnalysis(prefillThreadDump, prefillJvmId);
-    dispatch(modalPrefillClearIntent());
-    if (location.state || location.search) {
-      navigate(`${location.pathname}${location.hash}`, { replace: true, state: null });
-    }
+    addSubscription(
+      findTargetByJvmId(prefill.jvmId).subscribe((target) => {
+        setAnalysisResult(undefined);
+        selectedThreadDumpJvmIdRef.current = prefill.jvmId;
+        setSelectedThreadDump(prefill.threadDumpId!);
+        if (target) {
+          context.target.setTarget(target);
+        }
+        queryThreadDumpAnalysis(prefill.threadDumpId!, prefill.jvmId);
+        dispatch(modalPrefillClearIntent());
+        if (location.state || location.search) {
+          navigate(`${location.pathname}${location.hash}`, { replace: true, state: null });
+        }
+      }),
+    );
   }, [
+    addSubscription,
+    context.target,
     location.state,
     location.search,
     location.hash,
     location.pathname,
-    modalPrefill,
+    prefill.jvmId,
+    prefill.threadDumpId,
     dispatch,
+    findTargetByJvmId,
     navigate,
     queryThreadDumpAnalysis,
+    setAnalysisResult,
     setSelectedThreadDump,
   ]);
 
@@ -711,7 +792,9 @@ export const ThreadDumpAnalysis: React.FC<ThreadDumpAnalysisProps> = ({ ...props
   }, [selectedThreadDump, threadDumps, handleThreadDumpChange]);
 
   var view;
-  if (analysisResult == null) {
+  if (isAnalysisLoading || (analysisResult == null && hasPendingPrefill)) {
+    view = <LoadingView />;
+  } else if (analysisResult == null) {
     view = <EmptyState titleText={'Select a Thread Dump to Analyze'} icon={SearchIcon} headingLevel="h4" />;
   } else {
     view = (

--- a/src/app/Diagnostics/Analysis/ThreadDumpSelector.tsx
+++ b/src/app/Diagnostics/Analysis/ThreadDumpSelector.tsx
@@ -25,22 +25,19 @@ export interface ThreadDumpSelectorProps {
 }
 
 export const ThreadDumpSelector: React.FC<ThreadDumpSelectorProps> = ({ selected, threadDumps, onSelect }) => {
-  const [selectedThreadDump, setSelectedThreadDump] = React.useState<string>(selected);
   const [isOpen, setIsOpen] = React.useState(false);
 
   const handleThreadDumpSelect = React.useCallback(
     (_, selected: string) => {
       if (!selected.length) {
         onSelect(undefined);
-        setSelectedThreadDump('');
         setIsOpen(false);
       } else {
         onSelect(selected);
-        setSelectedThreadDump(selected);
         setIsOpen(false);
       }
     },
-    [onSelect, setSelectedThreadDump],
+    [onSelect],
   );
 
   const onToggle = React.useCallback(() => setIsOpen((isOpen) => !isOpen), [setIsOpen]);
@@ -54,10 +51,10 @@ export const ThreadDumpSelector: React.FC<ThreadDumpSelectorProps> = ({ selected
         onClick={onToggle}
         isExpanded={isOpen}
       >
-        {selectedThreadDump == '' ? 'Select a Thread Dump' : selectedThreadDump}
+        {selected == '' ? 'Select a Thread Dump' : selected}
       </MenuToggle>
     ),
-    [onToggle, isOpen, selectedThreadDump],
+    [onToggle, isOpen, selected],
   );
 
   return (

--- a/src/app/Diagnostics/ThreadDumpsTable.tsx
+++ b/src/app/Diagnostics/ThreadDumpsTable.tsx
@@ -523,13 +523,16 @@ export const ThreadDumpAction: React.FC<ThreadDumpActionProps> = ({ threadDump, 
 
   const handleViewInAnalysis = React.useCallback(
     (jvmId) => {
-      var id = threadDump.threadDumpId;
+      const id = threadDump.threadDumpId;
+      const analysisPath = toPath('/analyze-thread-dumps');
+      const params = new URLSearchParams({ jvmId, threadDumpId: id });
       const state = {
         jvmId,
         id,
+        threadDumpId: id,
       };
-      store.dispatch(modalPrefillSetIntent(toPath('/analyze-thread-dumps'), state as Record<string, unknown>));
-      navigate(toPath('/analyze-thread-dumps'), { state });
+      store.dispatch(modalPrefillSetIntent(analysisPath, state as Record<string, unknown>));
+      navigate(`${analysisPath}?${params.toString()}`, { state });
     },
     [threadDump, navigate],
   );

--- a/src/test/Diagnostics/AnalyzeThreadDumps.test.tsx
+++ b/src/test/Diagnostics/AnalyzeThreadDumps.test.tsx
@@ -322,7 +322,7 @@ describe('<ThreadDumpAnalysis />', () => {
     setTargetSpy = jest.spyOn(defaultServices.target, 'setTarget').mockImplementation((target) => target$.next(target));
     jest.spyOn(defaultServices.targets, 'targets').mockReturnValue(of([mockTarget, mockOtherTarget]));
     jest.spyOn(defaultServices.api, 'getTargetThreadDumps').mockImplementation((target) => {
-      return of(target.jvmId === mockOtherTarget.jvmId ? [mockOtherThreadDump] : [mockThreadDump]);
+      return of(target.connectUrl === mockOtherTarget.connectUrl ? [mockOtherThreadDump] : [mockThreadDump]);
     });
 
     const { user } = render({

--- a/src/test/Diagnostics/AnalyzeThreadDumps.test.tsx
+++ b/src/test/Diagnostics/AnalyzeThreadDumps.test.tsx
@@ -20,7 +20,7 @@ import { RootState } from '@app/Shared/Redux/ReduxStore';
 import { Target, ThreadDump, ThreadDumpAnalysisResult } from '@app/Shared/Services/api.types';
 import { defaultServices } from '@app/Shared/Services/Services';
 import { cleanup, screen, within, act, waitFor } from '@testing-library/react';
-import { of } from 'rxjs';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 import { basePreloadedState, DEFAULT_DIMENSIONS, mockMediaQueryList, render, resize } from '../utils';
 
 const mockNewConnectUrl = 'service:jmx:rmi://someNewUrl';
@@ -37,12 +37,32 @@ const mockTarget: Target = {
   },
 };
 
+const mockOtherTarget: Target = {
+  agent: false,
+  jvmId: 'otherTarget',
+  connectUrl: 'service:jmx:rmi://someOtherUrl',
+  alias: 'other target',
+  labels: [],
+  annotations: {
+    cryostat: [],
+    platform: [],
+  },
+};
+
 const mockThreadDump: ThreadDump = {
   downloadUrl: 'someDownloadUrl',
   threadDumpId: 'someUuid',
   jvmId: mockTarget.jvmId,
   size: 1,
   metadata: { labels: [{ key: 'someLabel', value: 'someUpdatedValue' }] },
+};
+
+const mockOtherThreadDump: ThreadDump = {
+  downloadUrl: 'someOtherDownloadUrl',
+  threadDumpId: 'someOtherUuid',
+  jvmId: mockOtherTarget.jvmId,
+  size: 1,
+  metadata: { labels: [{ key: 'someLabel', value: 'someOtherValue' }] },
 };
 
 const mockThreadDumpAnalysis: ThreadDumpAnalysisResult = {
@@ -188,6 +208,7 @@ jest.spyOn(defaultServices.settings, 'media').mockReturnValue(of(mockMediaQueryL
 
 describe('<ThreadDumpAnalysis />', () => {
   let preloadedState: RootState;
+  let setTargetSpy: jest.SpyInstance | undefined;
 
   beforeAll(async () => {
     await act(async () => {
@@ -196,12 +217,20 @@ describe('<ThreadDumpAnalysis />', () => {
   });
 
   beforeEach(() => {
+    jest.spyOn(defaultServices.api, 'getTargetThreadDumps').mockReturnValue(of([mockThreadDump]));
+    jest.spyOn(defaultServices.api, 'getThreadDumps').mockReturnValue(of([mockThreadDump]));
+    jest.spyOn(defaultServices.target, 'target').mockReturnValue(of(mockTarget));
+    jest.spyOn(defaultServices.targets, 'targets').mockReturnValue(of([mockTarget]));
     preloadedState = {
       ...basePreloadedState,
     };
   });
 
-  afterEach(cleanup);
+  afterEach(() => {
+    setTargetSpy?.mockRestore();
+    setTargetSpy = undefined;
+    cleanup();
+  });
 
   afterAll(() => {
     resize(DEFAULT_DIMENSIONS[0], DEFAULT_DIMENSIONS[1]);
@@ -284,6 +313,87 @@ describe('<ThreadDumpAnalysis />', () => {
       );
     });
     expect(screen.getByText('JVM Information')).toBeInTheDocument();
+  });
+
+  it('updates the target context for a prefilled archived thread dump from another target', async () => {
+    const analyzeSpy = jest.spyOn(defaultServices.api, 'analyzeThreadDump').mockReturnValue(of(mockThreadDumpAnalysis));
+    const target$ = new BehaviorSubject<Target | undefined>(mockTarget);
+    jest.spyOn(defaultServices.target, 'target').mockReturnValue(target$);
+    setTargetSpy = jest.spyOn(defaultServices.target, 'setTarget').mockImplementation((target) => target$.next(target));
+    jest.spyOn(defaultServices.targets, 'targets').mockReturnValue(of([mockTarget, mockOtherTarget]));
+    jest.spyOn(defaultServices.api, 'getTargetThreadDumps').mockImplementation((target) => {
+      return of(target.jvmId === mockOtherTarget.jvmId ? [mockOtherThreadDump] : [mockThreadDump]);
+    });
+
+    const { user } = render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/analyze-thread-dumps',
+            element: <ThreadDumpAnalysis />,
+          },
+        ],
+        options: {
+          initialEntries: [
+            {
+              pathname: '/analyze-thread-dumps',
+              state: { jvmId: mockOtherTarget.jvmId, id: mockOtherThreadDump.threadDumpId },
+            },
+          ],
+        },
+      },
+      preloadedState: preloadedState,
+    });
+
+    await waitFor(() => {
+      expect(setTargetSpy).toHaveBeenCalledWith(mockOtherTarget);
+      expect(analyzeSpy).toHaveBeenCalledWith(mockOtherTarget.jvmId, mockOtherThreadDump.threadDumpId);
+      expect(screen.getByRole('button', { name: 'thread dump selector toggle' })).toHaveTextContent(
+        mockOtherThreadDump.threadDumpId,
+      );
+    });
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'thread dump selector toggle' }));
+    });
+    expect(within(await screen.findByRole('menu')).getByText(mockOtherThreadDump.threadDumpId)).toBeInTheDocument();
+  });
+
+  it('shows a loading state while prefilled thread dump analysis is pending', async () => {
+    const analysis$ = new Subject<ThreadDumpAnalysisResult>();
+    jest.spyOn(defaultServices.api, 'analyzeThreadDump').mockReturnValue(analysis$);
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/analyze-thread-dumps',
+            element: <ThreadDumpAnalysis />,
+          },
+        ],
+        options: {
+          initialEntries: [
+            {
+              pathname: '/analyze-thread-dumps',
+              state: { jvmId: mockTarget.jvmId, id: mockThreadDump.threadDumpId },
+            },
+          ],
+        },
+      },
+      preloadedState: preloadedState,
+    });
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Select a Thread Dump to Analyze' })).not.toBeInTheDocument();
+
+    await act(async () => {
+      analysis$.next(mockThreadDumpAnalysis);
+      analysis$.complete();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('JVM Information')).toBeInTheDocument();
+    });
   });
 
   it('should render the page correctly', async () => {

--- a/src/test/Diagnostics/AnalyzeThreadDumps.test.tsx
+++ b/src/test/Diagnostics/AnalyzeThreadDumps.test.tsx
@@ -19,7 +19,7 @@ import { ThemeSetting } from '@app/Settings/types';
 import { RootState } from '@app/Shared/Redux/ReduxStore';
 import { Target, ThreadDump, ThreadDumpAnalysisResult } from '@app/Shared/Services/api.types';
 import { defaultServices } from '@app/Shared/Services/Services';
-import { cleanup, screen, within, act } from '@testing-library/react';
+import { cleanup, screen, within, act, waitFor } from '@testing-library/react';
 import { of } from 'rxjs';
 import { basePreloadedState, DEFAULT_DIMENSIONS, mockMediaQueryList, render, resize } from '../utils';
 
@@ -223,6 +223,67 @@ describe('<ThreadDumpAnalysis />', () => {
     });
 
     expect(screen.getByRole('heading', { name: 'Select a Thread Dump to Analyze' })).toBeInTheDocument();
+  });
+
+  it('prefills the selected thread dump from location state', async () => {
+    const analyzeSpy = jest.spyOn(defaultServices.api, 'analyzeThreadDump').mockReturnValue(of(mockThreadDumpAnalysis));
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/analyze-thread-dumps',
+            element: <ThreadDumpAnalysis />,
+          },
+        ],
+        options: {
+          initialEntries: [
+            {
+              pathname: '/analyze-thread-dumps',
+              state: { jvmId: mockTarget.jvmId, id: mockThreadDump.threadDumpId },
+            },
+          ],
+        },
+      },
+      preloadedState: preloadedState,
+    });
+
+    await waitFor(() => {
+      expect(analyzeSpy).toHaveBeenCalledWith(mockTarget.jvmId, mockThreadDump.threadDumpId);
+      expect(screen.getByRole('button', { name: 'thread dump selector toggle' })).toHaveTextContent(
+        mockThreadDump.threadDumpId,
+      );
+    });
+    expect(screen.getByText('JVM Information')).toBeInTheDocument();
+  });
+
+  it('prefills the selected thread dump from query params', async () => {
+    const analyzeSpy = jest.spyOn(defaultServices.api, 'analyzeThreadDump').mockReturnValue(of(mockThreadDumpAnalysis));
+
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/analyze-thread-dumps',
+            element: <ThreadDumpAnalysis />,
+          },
+        ],
+        options: {
+          initialEntries: [
+            `/analyze-thread-dumps?jvmId=${mockTarget.jvmId}&threadDumpId=${mockThreadDump.threadDumpId}`,
+          ],
+        },
+      },
+      preloadedState: preloadedState,
+    });
+
+    await waitFor(() => {
+      expect(analyzeSpy).toHaveBeenCalledWith(mockTarget.jvmId, mockThreadDump.threadDumpId);
+      expect(screen.getByRole('button', { name: 'thread dump selector toggle' })).toHaveTextContent(
+        mockThreadDump.threadDumpId,
+      );
+    });
+    expect(screen.getByText('JVM Information')).toBeInTheDocument();
   });
 
   it('should render the page correctly', async () => {

--- a/src/test/Diagnostics/ThreadDumpsTable.test.tsx
+++ b/src/test/Diagnostics/ThreadDumpsTable.test.tsx
@@ -326,4 +326,41 @@ describe('<ThreadDumpsTable />', () => {
     expect(downloadRequestSpy).toHaveBeenCalledTimes(1);
     expect(downloadRequestSpy).toHaveBeenCalledWith(mockThreadDump);
   });
+
+  it('navigates to analysis with the selected thread dump prefill data', async () => {
+    const { user, router } = render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/thread-dumps',
+            element: <ThreadDumpsTable target={of(mockTarget)} isNestedTable={false} />,
+          },
+          {
+            path: '/analyze-thread-dumps',
+            element: <>Analysis</>,
+          },
+        ],
+        options: {
+          initialEntries: ['/thread-dumps'],
+        },
+      },
+      preloadedState: preloadedState,
+    });
+
+    await tlr.act(async () => {
+      await user.click(screen.getByLabelText(testT('ThreadDumpActions.ARIA_LABELS.MENU_TOGGLE')));
+      await user.click(screen.getByText('Analyze Thread Dump'));
+    });
+
+    const state = {
+      jvmId: mockTarget.jvmId,
+      id: mockThreadDump.threadDumpId,
+      threadDumpId: mockThreadDump.threadDumpId,
+    };
+    expect(router.state.location.pathname).toEqual('/analyze-thread-dumps');
+    expect(router.state.location.search).toEqual(
+      `?jvmId=${mockTarget.jvmId}&threadDumpId=${mockThreadDump.threadDumpId}`,
+    );
+    expect(router.state.location.state).toEqual(state);
+  });
 });


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: cryostatio/cryostat-openshift-console-plugin#915

## Description of the change:
This change preserves and consumes the selected archived thread dump when navigating to the thread dump analysis page.

Changes:
- Add `jvmId` and `threadDumpId` query parameters when clicking **Analyze Thread Dump** from the thread dump table row action
- Keep the existing React Router `location.state` prefill path, and add query parameter fallback support for environments
where router state is not preserved
- Make `ThreadDumpSelector` reflect the selected dump from props instead of only using its initial local state
- Avoid clearing the selected dump/analysis result when the target service emits the same target during initial page load
- Add focused tests for location-state prefill, query-param prefill, and row-action navigation

## Motivation for the change:
In the OpenShift Console plugin, clicking **Analyze Thread Dump** from Thread Dump Archives navigates to the analysis page, but the selected dump is not pre-filled. Users then have to manually select the same dump again before analysis runs.

Passing the dump identifiers through the URL and making the analysis page consume them makes the flow work reliably in both standalone Cryostat Web and embedded OpenShift Console routing.

## How to manually test:
1. Start Cryostat with at least one discoverable target.
2. Create a thread dump for the target.
3. Navigate to **Thread Dumps**.
4. Open the row action menu for the archived thread dump and click **Analyze Thread Dump**.
5. Verify the app navigates to **Analyze Thread Dumps**.
6. Verify the thread dump selector is already populated with the selected dump ID.
7. Verify the analysis result loads automatically without manually selecting the dump.
8. In the OpenShift Console plugin, repeat the same flow from **Thread Dump Archives** and verify there is no 404 and no manual selection is required.