### PR TITLE
fix(triggers): Fix typo in trigger creation modal

### DIFF
--- a/src/app/Triggers/SmartTriggers.tsx
+++ b/src/app/Triggers/SmartTriggers.tsx
@@ -708,8 +708,8 @@ export const CreateSmartTriggersModal: React.FC<CreateSmartTriggersModalProps> =
     { value: '>', label: 'Greater Than (>)' },
     { value: '>=', label: 'Greater Than/Equal To (>=)' },
     { value: '==', label: 'Equal To' },
-    { value: '<=', label: 'Less Than/Equal To (>)' },
-    { value: '<', label: 'Less Than (>)' },
+    { value: '<=', label: 'Less Than/Equal To (<=)' },
+    { value: '<', label: 'Less Than (<)' },
   ];
 
   const reset = React.useCallback(() => {


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [ ] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [ ] Linked a relevant issue which this PR resolves
* [ ] Linked any other relevant issues, PR's, or documentation, if any
* [ ] Resolved all conflicts, if any
* [ ] Rebased your branch PR on top of the latest upstream `main` branch
* [ ] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [ ] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

Fixes: [#2248](https://github.com/cryostatio/cryostat-web/issues/2248)

## Description of the change:

Fixes a typo in the Trigger Creation modal. The labels for Less Than/Equal To and Less Than had the wrong operator in brackets.

## Motivation for the change:

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
