### PR TITLE
feat(archives): improve rendering of startTime and duration labels

### DIFF
--- a/src/app/RecordingMetadata/ClickableLabel.tsx
+++ b/src/app/RecordingMetadata/ClickableLabel.tsx
@@ -14,10 +14,35 @@
  * limitations under the License.
  */
 
+import { DatetimeFormat } from '@i18n/datetime';
 import { KeyValue, keyValueToString } from '@app/Shared/Services/api.types';
-import { LABEL_TEXT_MAXWIDTH } from '@app/utils/utils';
+import useDayjs, { Dayjs } from '@app/utils/hooks/useDayjs';
+import { formatDuration, LABEL_TEXT_MAXWIDTH } from '@app/utils/utils';
 import { Label } from '@patternfly/react-core';
 import * as React from 'react';
+
+export const formatLabelValue = (label: KeyValue, dayjs: Dayjs, datetimeContext: DatetimeFormat): string => {
+  if (label.key === 'startTime') {
+    try {
+      const millis = Number(label.value);
+      if (!isNaN(millis)) {
+        return dayjs(millis).tz(datetimeContext.timeZone.full).format('L LTS z');
+      }
+    } catch (_e) {
+      // fall through
+    }
+  } else if (label.key === 'duration') {
+    try {
+      const millis = Number(label.value);
+      if (!isNaN(millis)) {
+        return formatDuration(millis, 1);
+      }
+    } catch (_e) {
+      // fall through
+    }
+  }
+  return label.value;
+};
 
 export interface ClickableLabelCellProps {
   label: KeyValue;
@@ -26,9 +51,15 @@ export interface ClickableLabelCellProps {
 }
 
 export const ClickableLabel: React.FC<ClickableLabelCellProps> = ({ label, isSelected, onLabelClick }) => {
+  const [dayjs, datetimeContext] = useDayjs();
   const labelColor = React.useMemo(() => (isSelected ? 'blue' : 'grey'), [isSelected]);
 
   const handleLabelClicked = React.useCallback(() => onLabelClick(label), [label, onLabelClick]);
+
+  const displayValue = React.useMemo(
+    () => formatLabelValue(label, dayjs, datetimeContext),
+    [label, dayjs, datetimeContext],
+  );
 
   return (
     <>
@@ -39,7 +70,7 @@ export const ClickableLabel: React.FC<ClickableLabelCellProps> = ({ label, isSel
         key={label.key}
         color={labelColor}
       >
-        {keyValueToString(label)}
+        {`${label.key}=${displayValue}`}
       </Label>
     </>
   );

--- a/src/app/RecordingMetadata/ClickableLabel.tsx
+++ b/src/app/RecordingMetadata/ClickableLabel.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { DatetimeFormat } from '@i18n/datetime';
 import { KeyValue, keyValueToString } from '@app/Shared/Services/api.types';
 import useDayjs, { Dayjs } from '@app/utils/hooks/useDayjs';
 import { formatDuration, LABEL_TEXT_MAXWIDTH } from '@app/utils/utils';
+import { DatetimeFormat } from '@i18n/datetime';
 import { Label } from '@patternfly/react-core';
 import * as React from 'react';
 

--- a/src/app/RecordingMetadata/LabelCell.tsx
+++ b/src/app/RecordingMetadata/LabelCell.tsx
@@ -17,9 +17,10 @@
 import { EmptyText } from '@app/Shared/Components/EmptyText';
 import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 import { KeyValue, keyValueToString } from '@app/Shared/Services/api.types';
+import useDayjs from '@app/utils/hooks/useDayjs';
 import { Label, LabelGroup } from '@patternfly/react-core';
 import * as React from 'react';
-import { ClickableLabel } from './ClickableLabel';
+import { ClickableLabel, formatLabelValue } from './ClickableLabel';
 
 export interface LabelCellProps {
   target: string;
@@ -32,6 +33,8 @@ export interface LabelCellProps {
 }
 
 export const LabelCell: React.FC<LabelCellProps> = ({ target, labels, clickableOptions }) => {
+  const [dayjs, datetimeContext] = useDayjs();
+
   const isLabelSelected = React.useCallback(
     (label: KeyValue) => {
       if (clickableOptions) {
@@ -75,7 +78,7 @@ export const LabelCell: React.FC<LabelCellProps> = ({ target, labels, clickableO
               />
             ) : (
               <Label aria-label={keyValueToString(label)} key={label.key} color={getLabelColor(label)}>
-                {keyValueToString(label)}
+                {`${label.key}=${formatLabelValue(label, dayjs, datetimeContext)}`}
               </Label>
             ),
           )}

--- a/src/test/RecordingMetadata/ClickableLabel.test.tsx
+++ b/src/test/RecordingMetadata/ClickableLabel.test.tsx
@@ -18,6 +18,7 @@ import '@testing-library/jest-dom';
 import { Palette } from '@app/Settings/types';
 import { KeyValue } from '@app/Shared/Services/api.types';
 import { defaultServices } from '@app/Shared/Services/Services';
+import dayjs, { defaultDatetimeFormat } from '@i18n/datetime';
 import { cleanup, screen } from '@testing-library/react';
 import { of } from 'rxjs';
 import { render } from '../utils';
@@ -34,6 +35,7 @@ const onLabelClick = jest.fn((_label: KeyValue) => {
 
 jest.spyOn(defaultServices.settings, 'palette').mockReturnValue(of(Palette.DEFAULT));
 jest.spyOn(defaultServices.settings, 'largeUi').mockReturnValue(of(false));
+jest.spyOn(defaultServices.settings, 'datetimeFormat').mockReturnValue(of(defaultDatetimeFormat));
 
 describe('<ClickableLabel />', () => {
   afterEach(cleanup);
@@ -110,5 +112,62 @@ describe('<ClickableLabel />', () => {
 
     expect(onLabelClick).toHaveBeenCalledTimes(1);
     expect(onLabelClick).toHaveBeenCalledWith(mockLabel);
+  });
+
+  it('should format startTime label as a human-readable datetime', async () => {
+    const startTimeMillis = 1782483737600;
+    const startTimeLabel: KeyValue = { key: 'startTime', value: String(startTimeMillis) };
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/recordings',
+            element: <ClickableLabel label={startTimeLabel} isSelected={false} onLabelClick={onLabelClick} />,
+          },
+        ],
+      },
+    });
+
+    const expectedText = `startTime=${dayjs(startTimeMillis).tz(defaultDatetimeFormat.timeZone.full).format('L LTS z')}`;
+    const displayedLabel = screen.getByText(expectedText);
+    expect(displayedLabel).toBeInTheDocument();
+    expect(displayedLabel).toBeVisible();
+  });
+
+  it('should format duration label as a humanized duration string', async () => {
+    const durationLabel: KeyValue = { key: 'duration', value: '90203' };
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/recordings',
+            element: <ClickableLabel label={durationLabel} isSelected={false} onLabelClick={onLabelClick} />,
+          },
+        ],
+      },
+    });
+
+    const displayedLabel = screen.getByText(/^duration=/);
+    expect(displayedLabel).toBeInTheDocument();
+    expect(displayedLabel).toBeVisible();
+    expect(displayedLabel.textContent).not.toBe('duration=90203');
+  });
+
+  it('should fall back to raw value for startTime label with non-numeric value', async () => {
+    const badLabel: KeyValue = { key: 'startTime', value: 'not-a-timestamp' };
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/recordings',
+            element: <ClickableLabel label={badLabel} isSelected={false} onLabelClick={onLabelClick} />,
+          },
+        ],
+      },
+    });
+
+    const displayedLabel = screen.getByText('startTime=not-a-timestamp');
+    expect(displayedLabel).toBeInTheDocument();
+    expect(displayedLabel).toBeVisible();
   });
 });

--- a/src/test/RecordingMetadata/LabelCell.test.tsx
+++ b/src/test/RecordingMetadata/LabelCell.test.tsx
@@ -17,10 +17,15 @@
 import { LabelCell } from '@app/RecordingMetadata/LabelCell';
 import { UpdateFilterOptions } from '@app/Shared/Redux/Filters/Common';
 import { KeyValue, Target } from '@app/Shared/Services/api.types';
+import { defaultServices } from '@app/Shared/Services/Services';
+import dayjs, { defaultDatetimeFormat } from '@i18n/datetime';
 import '@testing-library/jest-dom';
 import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { of } from 'rxjs';
 import { render } from '../utils';
+
+jest.spyOn(defaultServices.settings, 'datetimeFormat').mockReturnValue(of(defaultDatetimeFormat));
 
 const mockFooTarget: Target = {
   agent: false,
@@ -150,5 +155,62 @@ describe('<LabelCell />', () => {
     expect(placeHolder).toBeInTheDocument();
     expect(placeHolder).toBeVisible();
     expect(placeHolder.onclick).toBeNull();
+  });
+
+  it('should format startTime label as a human-readable datetime', async () => {
+    const startTimeMillis = 1782483737600;
+    const startTimeLabel: KeyValue = { key: 'startTime', value: String(startTimeMillis) };
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/recordings',
+            element: <LabelCell target={mockFooTarget.connectUrl} labels={[startTimeLabel]} />,
+          },
+        ],
+      },
+    });
+
+    const expectedText = `startTime=${dayjs(startTimeMillis).tz(defaultDatetimeFormat.timeZone.full).format('L LTS z')}`;
+    const displayedLabel = screen.getByText(expectedText);
+    expect(displayedLabel).toBeInTheDocument();
+    expect(displayedLabel).toBeVisible();
+  });
+
+  it('should format duration label as a humanized duration string', async () => {
+    const durationLabel: KeyValue = { key: 'duration', value: '90203' };
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/recordings',
+            element: <LabelCell target={mockFooTarget.connectUrl} labels={[durationLabel]} />,
+          },
+        ],
+      },
+    });
+
+    const displayedLabel = screen.getByText(/^duration=/);
+    expect(displayedLabel).toBeInTheDocument();
+    expect(displayedLabel).toBeVisible();
+    expect(displayedLabel.textContent).not.toBe('duration=90203');
+  });
+
+  it('should fall back to raw value for startTime label with non-numeric value', async () => {
+    const badLabel: KeyValue = { key: 'startTime', value: 'not-a-timestamp' };
+    render({
+      routerConfigs: {
+        routes: [
+          {
+            path: '/recordings',
+            element: <LabelCell target={mockFooTarget.connectUrl} labels={[badLabel]} />,
+          },
+        ],
+      },
+    });
+
+    const displayedLabel = screen.getByText('startTime=not-a-timestamp');
+    expect(displayedLabel).toBeInTheDocument();
+    expect(displayedLabel).toBeVisible();
   });
 });

--- a/src/test/Recordings/ArchivedRecordingsTable.test.tsx
+++ b/src/test/Recordings/ArchivedRecordingsTable.test.tsx
@@ -33,6 +33,7 @@ import {
 } from '@app/Shared/Services/api.types';
 import { FeatureLevel } from '@app/Shared/Services/service.types';
 import { defaultServices } from '@app/Shared/Services/Services';
+import { defaultDatetimeFormat } from '@i18n/datetime';
 import { Content } from '@patternfly/react-core';
 import '@testing-library/jest-dom';
 import * as tlr from '@testing-library/react';
@@ -182,6 +183,7 @@ jest
 
 jest.spyOn(defaultServices.settings, 'palette').mockReturnValue(of(Palette.DEFAULT));
 jest.spyOn(defaultServices.settings, 'largeUi').mockReturnValue(of(false));
+jest.spyOn(defaultServices.settings, 'datetimeFormat').mockReturnValue(of(defaultDatetimeFormat));
 jest.spyOn(defaultServices.settings, 'featureLevel').mockReturnValue(of(FeatureLevel.PRODUCTION));
 
 jest


### PR DESCRIPTION
# Welcome to Cryostat! 👋
## Before contributing, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/cryostatio/cryostat/blob/main/CONTRIBUTING.md)
* [x] Linked a relevant issue which this PR resolves
* [x] Linked any other relevant issues, PR's, or documentation, if any
* [x] Resolved all conflicts, if any
* [x] Rebased your branch PR on top of the latest upstream `main` branch
* [x] Attached at least one of the following labels to the PR: `[chore, ci, docs, feat, fix, test]`
* [x] [Signed all commits using a GPG signature](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)

**To recreate commits with GPG signature** `git fetch upstream && git rebase --force --gpg-sign upstream/main`
_______________________________________________

See cryostatio/cryostat#1669

## Description of the change:
*This change adds allows a match expression example to be copied to the clipboard...*

## Motivation for the change:
*This change is helpful because users may want to copy the example for easier use...*

## How to manually test:
1. *Run CRYOSTAT_IMAGE=quay.io... sh smoketest.sh...*
2. *...*
